### PR TITLE
iOS の場合 ExposureInfo への保存がローカルタイム（ToLocaltime）となっている

### DIFF
--- a/Covid19Radar/Xamarin.ExposureNotification/ExposureNotification.ios.cs
+++ b/Covid19Radar/Xamarin.ExposureNotification/ExposureNotification.ios.cs
@@ -275,7 +275,7 @@ namespace Xamarin.ExposureNotifications
 						}
 
 						return new ExposureInfo(
-							((DateTime)i.Date).ToLocalTime(),
+							(DateTime)i.Date,
 							TimeSpan.FromMinutes(i.Duration),
 							i.AttenuationValue,
 							totalRisk,


### PR DESCRIPTION
## Purpose

* ExposureInfo への保存がローカルタイム（ToLocaltime）となっているため、Android と合わせるために UTC を使うように修正します。

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* 実機のみの動作のため、テストはしていません。

## What to Check

https://github.com/xamarin/XamarinComponents/blob/master/XPlat/ExposureNotification/source/Xamarin.ExposureNotification/ExposureNotification.ios.cs

ここの PR になります。

## Other Information
<!-- Add any other helpful information that may be needed here. -->