### PR TITLE
Update Exposure Notification libs

### DIFF
--- a/Covid19Radar.sln
+++ b/Covid19Radar.sln
@@ -15,9 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{460BECFC
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Covid19Radar.UITest", "Covid19Radar\Tests\Covid19Radar.UITest\Covid19Radar.UITest.csproj", "{4223EE63-A661-4465-BBB0-08DD80DB2256}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.ExposureNotification", "Covid19Radar\Xamarin.ExposureNotification\Xamarin.ExposureNotification.csproj", "{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Covid19Radar.UnitTests", "Covid19Radar\Tests\Covid19Radar.UnitTests\Covid19Radar.UnitTests.csproj", "{464E6973-C26D-45DF-808D-D89F9F7BFCA7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Covid19Radar.UnitTests", "Covid19Radar\Tests\Covid19Radar.UnitTests\Covid19Radar.UnitTests.csproj", "{464E6973-C26D-45DF-808D-D89F9F7BFCA7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -169,36 +167,6 @@ Global
 		{4223EE63-A661-4465-BBB0-08DD80DB2256}.Release|iPhone.Build.0 = Release|Any CPU
 		{4223EE63-A661-4465-BBB0-08DD80DB2256}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{4223EE63-A661-4465-BBB0-08DD80DB2256}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Ad-Hoc|Any CPU.ActiveCfg = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Ad-Hoc|Any CPU.Build.0 = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Ad-Hoc|iPhone.ActiveCfg = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Ad-Hoc|iPhone.Build.0 = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Ad-Hoc|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Ad-Hoc|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.AppStore|Any CPU.Build.0 = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.AppStore|iPhone.ActiveCfg = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.AppStore|iPhone.Build.0 = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.AppStore|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.AppStore|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Debug_Mock|Any CPU.ActiveCfg = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Debug_Mock|Any CPU.Build.0 = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Debug_Mock|iPhone.ActiveCfg = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Debug_Mock|iPhone.Build.0 = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Debug_Mock|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Debug_Mock|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Release|iPhone.Build.0 = Release|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{83AF4C2E-22F8-4DAB-B993-BE6ABB3E56A1}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{464E6973-C26D-45DF-808D-D89F9F7BFCA7}.Ad-Hoc|Any CPU.ActiveCfg = Debug|Any CPU
 		{464E6973-C26D-45DF-808D-D89F9F7BFCA7}.Ad-Hoc|Any CPU.Build.0 = Debug|Any CPU
 		{464E6973-C26D-45DF-808D-D89F9F7BFCA7}.Ad-Hoc|iPhone.ActiveCfg = Debug|Any CPU

--- a/Covid19Radar/Covid19Radar.Android/Covid19Radar.Android.csproj
+++ b/Covid19Radar/Covid19Radar.Android/Covid19Radar.Android.csproj
@@ -176,7 +176,7 @@
       <Version>4.6.0.967</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.GooglePlayServices.Nearby.ExposureNotification">
-      <Version>18.0.2-eap.6</Version>
+      <Version>19.7.1-eap.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.GooglePlayServices.SafetyNet">
       <Version>117.0.0-preview03</Version>
@@ -218,56 +218,82 @@
       </Generator>
     </AndroidResource>
     <AndroidResource Include="Resources\xml\backup_settings.xml">
-      <SubType></SubType>
-      <Generator></Generator>
+      <SubType>
+      </SubType>
+      <Generator>
+      </Generator>
     </AndroidResource>
     <AndroidResource Include="Resources\drawable-en-xhdpi\privacypolicy_img01.png">
-      <SubType></SubType>
-      <Generator></Generator>
+      <SubType>
+      </SubType>
+      <Generator>
+      </Generator>
     </AndroidResource>
     <AndroidResource Include="Resources\drawable-en-xxhdpi\privacypolicy_img01.png">
-      <SubType></SubType>
-      <Generator></Generator>
+      <SubType>
+      </SubType>
+      <Generator>
+      </Generator>
     </AndroidResource>
     <AndroidResource Include="Resources\drawable-ja-xhdpi\privacypolicy_img01.png">
-      <SubType></SubType>
-      <Generator></Generator>
+      <SubType>
+      </SubType>
+      <Generator>
+      </Generator>
     </AndroidResource>
     <AndroidResource Include="Resources\drawable-ja-xxhdpi\privacypolicy_img01.png">
-      <SubType></SubType>
-      <Generator></Generator>
+      <SubType>
+      </SubType>
+      <Generator>
+      </Generator>
     </AndroidResource>
     <AndroidResource Include="Resources\drawable-xhdpi\privacypolicy_img01.png">
-      <SubType></SubType>
-      <Generator></Generator>
+      <SubType>
+      </SubType>
+      <Generator>
+      </Generator>
     </AndroidResource>
     <AndroidResource Include="Resources\drawable-xxhdpi\privacypolicy_img01.png">
-      <SubType></SubType>
-      <Generator></Generator>
+      <SubType>
+      </SubType>
+      <Generator>
+      </Generator>
     </AndroidResource>
     <AndroidResource Include="Resources\drawable-en-xxhdpi\arrow_icon.png">
-      <SubType></SubType>
-      <Generator></Generator>
+      <SubType>
+      </SubType>
+      <Generator>
+      </Generator>
     </AndroidResource>
     <AndroidResource Include="Resources\drawable-en-xhdpi\arrow_icon.png">
-      <SubType></SubType>
-      <Generator></Generator>
+      <SubType>
+      </SubType>
+      <Generator>
+      </Generator>
     </AndroidResource>
     <AndroidResource Include="Resources\drawable-ja-xhdpi\arrow_icon.png">
-      <SubType></SubType>
-      <Generator></Generator>
+      <SubType>
+      </SubType>
+      <Generator>
+      </Generator>
     </AndroidResource>
     <AndroidResource Include="Resources\drawable-ja-xxhdpi\arrow_icon.png">
-      <SubType></SubType>
-      <Generator></Generator>
+      <SubType>
+      </SubType>
+      <Generator>
+      </Generator>
     </AndroidResource>
     <AndroidResource Include="Resources\drawable-xhdpi\arrow_icon.png">
-      <SubType></SubType>
-      <Generator></Generator>
+      <SubType>
+      </SubType>
+      <Generator>
+      </Generator>
     </AndroidResource>
     <AndroidResource Include="Resources\drawable-xxhdpi\arrow_icon.png">
-      <SubType></SubType>
-      <Generator></Generator>
+      <SubType>
+      </SubType>
+      <Generator>
+      </Generator>
     </AndroidResource>
   </ItemGroup>
   <ItemGroup>
@@ -284,10 +310,6 @@
     <ProjectReference Include="..\Covid19Radar\Covid19Radar.csproj">
       <Project>{554EE1AB-B447-480C-90E5-C4F040891DE6}</Project>
       <Name>Covid19Radar</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Xamarin.ExposureNotification\Xamarin.ExposureNotification.csproj">
-      <Project>{83af4c2e-22f8-4dab-b993-be6abb3e56a1}</Project>
-      <Name>Xamarin.ExposureNotification</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
@@ -522,11 +544,7 @@
   <ItemGroup>
     <AndroidResource Include="Resources\drawable-xxhdpi\TutorialPage60.png" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Renderers\" />
-    <Folder Include="Resources\xml\" />
-    <Folder Include="Services\Logs\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <AndroidResource Include="Resources\drawable-ja-xhdpi\HeaderLogo.png" />
   </ItemGroup>

--- a/Covid19Radar/Covid19Radar.Android/Covid19Radar.Android.csproj
+++ b/Covid19Radar/Covid19Radar.Android/Covid19Radar.Android.csproj
@@ -127,37 +127,40 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Acr.UserDialogs">
-      <Version>7.1.0.442</Version>
+      <Version>7.1.0.475</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>12.0.3</Version>
     </PackageReference>
     <PackageReference Include="Prism.Core">
-      <Version>7.2.0.1422</Version>
+      <Version>8.0.0.1909</Version>
     </PackageReference>
     <PackageReference Include="Prism.DryIoc.Forms">
-      <Version>7.2.0.1422</Version>
+      <Version>8.0.0.1909</Version>
     </PackageReference>
     <PackageReference Include="Prism.Forms">
-      <Version>7.2.0.1422</Version>
+      <Version>8.0.0.1909</Version>
     </PackageReference>
     <PackageReference Include="Prism.Plugin.Logging.AppCenter">
-      <Version>7.2.0.1114</Version>
+      <Version>7.2.0.1421</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.AppCompat.AppCompatResources">
-      <Version>1.1.0.1</Version>
+      <Version>1.2.0.7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.AppCompat.Resources">
       <Version>1.1.0.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.MediaRouter">
-      <Version>1.1.0.1</Version>
+      <Version>1.2.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.AndroidX.Palette">
+      <Version>1.0.0.7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Work.Runtime">
-      <Version>2.3.4.1</Version>
+      <Version>2.5.0.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Essentials">
-      <Version>1.5.3.2</Version>
+      <Version>1.6.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.FFImageLoading">
       <Version>2.4.11.982</Version>
@@ -165,7 +168,7 @@
     <PackageReference Include="Xamarin.FFImageLoading.Forms">
       <Version>2.4.11.982</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="4.6.0.967" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
     <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.Design" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.3" />
@@ -173,13 +176,13 @@
     <PackageReference Include="Xamarin.Android.Support.v7.CardView" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Forms.Visual.Material">
-      <Version>4.6.0.967</Version>
+      <Version>5.0.0.2012</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.GooglePlayServices.Nearby.ExposureNotification">
       <Version>19.7.1-eap.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.GooglePlayServices.SafetyNet">
-      <Version>117.0.0-preview03</Version>
+      <Version>117.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Covid19Radar/Covid19Radar.Android/Resources/Resource.designer.cs
+++ b/Covid19Radar/Covid19Radar.Android/Resources/Resource.designer.cs
@@ -5181,6 +5181,305 @@ namespace Covid19Radar.Droid
 			global::Xamarin.Essentials.Resource.Styleable.GradientColor_android_tileMode = global::Covid19Radar.Droid.Resource.Styleable.GradientColor_android_tileMode;
 			global::Xamarin.Essentials.Resource.Styleable.GradientColor_android_type = global::Covid19Radar.Droid.Resource.Styleable.GradientColor_android_type;
 			global::Xamarin.Essentials.Resource.Xml.xamarin_essentials_fileprovider_file_paths = global::Covid19Radar.Droid.Resource.Xml.xamarin_essentials_fileprovider_file_paths;
+			global::Xamarin.ExposureNotification.Resource.Attribute.alpha = global::Covid19Radar.Droid.Resource.Attribute.alpha;
+			global::Xamarin.ExposureNotification.Resource.Attribute.buttonSize = global::Covid19Radar.Droid.Resource.Attribute.buttonSize;
+			global::Xamarin.ExposureNotification.Resource.Attribute.circleCrop = global::Covid19Radar.Droid.Resource.Attribute.circleCrop;
+			global::Xamarin.ExposureNotification.Resource.Attribute.colorScheme = global::Covid19Radar.Droid.Resource.Attribute.colorScheme;
+			global::Xamarin.ExposureNotification.Resource.Attribute.coordinatorLayoutStyle = global::Covid19Radar.Droid.Resource.Attribute.coordinatorLayoutStyle;
+			global::Xamarin.ExposureNotification.Resource.Attribute.font = global::Covid19Radar.Droid.Resource.Attribute.font;
+			global::Xamarin.ExposureNotification.Resource.Attribute.fontProviderAuthority = global::Covid19Radar.Droid.Resource.Attribute.fontProviderAuthority;
+			global::Xamarin.ExposureNotification.Resource.Attribute.fontProviderCerts = global::Covid19Radar.Droid.Resource.Attribute.fontProviderCerts;
+			global::Xamarin.ExposureNotification.Resource.Attribute.fontProviderFetchStrategy = global::Covid19Radar.Droid.Resource.Attribute.fontProviderFetchStrategy;
+			global::Xamarin.ExposureNotification.Resource.Attribute.fontProviderFetchTimeout = global::Covid19Radar.Droid.Resource.Attribute.fontProviderFetchTimeout;
+			global::Xamarin.ExposureNotification.Resource.Attribute.fontProviderPackage = global::Covid19Radar.Droid.Resource.Attribute.fontProviderPackage;
+			global::Xamarin.ExposureNotification.Resource.Attribute.fontProviderQuery = global::Covid19Radar.Droid.Resource.Attribute.fontProviderQuery;
+			global::Xamarin.ExposureNotification.Resource.Attribute.fontStyle = global::Covid19Radar.Droid.Resource.Attribute.fontStyle;
+			global::Xamarin.ExposureNotification.Resource.Attribute.fontVariationSettings = global::Covid19Radar.Droid.Resource.Attribute.fontVariationSettings;
+			global::Xamarin.ExposureNotification.Resource.Attribute.fontWeight = global::Covid19Radar.Droid.Resource.Attribute.fontWeight;
+			global::Xamarin.ExposureNotification.Resource.Attribute.imageAspectRatio = global::Covid19Radar.Droid.Resource.Attribute.imageAspectRatio;
+			global::Xamarin.ExposureNotification.Resource.Attribute.imageAspectRatioAdjust = global::Covid19Radar.Droid.Resource.Attribute.imageAspectRatioAdjust;
+			global::Xamarin.ExposureNotification.Resource.Attribute.keylines = global::Covid19Radar.Droid.Resource.Attribute.keylines;
+			global::Xamarin.ExposureNotification.Resource.Attribute.layout_anchor = global::Covid19Radar.Droid.Resource.Attribute.layout_anchor;
+			global::Xamarin.ExposureNotification.Resource.Attribute.layout_anchorGravity = global::Covid19Radar.Droid.Resource.Attribute.layout_anchorGravity;
+			global::Xamarin.ExposureNotification.Resource.Attribute.layout_behavior = global::Covid19Radar.Droid.Resource.Attribute.layout_behavior;
+			global::Xamarin.ExposureNotification.Resource.Attribute.layout_dodgeInsetEdges = global::Covid19Radar.Droid.Resource.Attribute.layout_dodgeInsetEdges;
+			global::Xamarin.ExposureNotification.Resource.Attribute.layout_insetEdge = global::Covid19Radar.Droid.Resource.Attribute.layout_insetEdge;
+			global::Xamarin.ExposureNotification.Resource.Attribute.layout_keyline = global::Covid19Radar.Droid.Resource.Attribute.layout_keyline;
+			global::Xamarin.ExposureNotification.Resource.Attribute.scopeUris = global::Covid19Radar.Droid.Resource.Attribute.scopeUris;
+			global::Xamarin.ExposureNotification.Resource.Attribute.statusBarBackground = global::Covid19Radar.Droid.Resource.Attribute.statusBarBackground;
+			global::Xamarin.ExposureNotification.Resource.Attribute.ttcIndex = global::Covid19Radar.Droid.Resource.Attribute.ttcIndex;
+			global::Xamarin.ExposureNotification.Resource.Boolean.enable_system_alarm_service_default = global::Covid19Radar.Droid.Resource.Boolean.enable_system_alarm_service_default;
+			global::Xamarin.ExposureNotification.Resource.Boolean.enable_system_foreground_service_default = global::Covid19Radar.Droid.Resource.Boolean.enable_system_foreground_service_default;
+			global::Xamarin.ExposureNotification.Resource.Boolean.enable_system_job_service_default = global::Covid19Radar.Droid.Resource.Boolean.enable_system_job_service_default;
+			global::Xamarin.ExposureNotification.Resource.Boolean.workmanager_test_configuration = global::Covid19Radar.Droid.Resource.Boolean.workmanager_test_configuration;
+			global::Xamarin.ExposureNotification.Resource.Color.browser_actions_bg_grey = global::Covid19Radar.Droid.Resource.Color.browser_actions_bg_grey;
+			global::Xamarin.ExposureNotification.Resource.Color.browser_actions_divider_color = global::Covid19Radar.Droid.Resource.Color.browser_actions_divider_color;
+			global::Xamarin.ExposureNotification.Resource.Color.browser_actions_text_color = global::Covid19Radar.Droid.Resource.Color.browser_actions_text_color;
+			global::Xamarin.ExposureNotification.Resource.Color.browser_actions_title_color = global::Covid19Radar.Droid.Resource.Color.browser_actions_title_color;
+			global::Xamarin.ExposureNotification.Resource.Color.common_google_signin_btn_text_dark = global::Covid19Radar.Droid.Resource.Color.common_google_signin_btn_text_dark;
+			global::Xamarin.ExposureNotification.Resource.Color.common_google_signin_btn_text_dark_default = global::Covid19Radar.Droid.Resource.Color.common_google_signin_btn_text_dark_default;
+			global::Xamarin.ExposureNotification.Resource.Color.common_google_signin_btn_text_dark_disabled = global::Covid19Radar.Droid.Resource.Color.common_google_signin_btn_text_dark_disabled;
+			global::Xamarin.ExposureNotification.Resource.Color.common_google_signin_btn_text_dark_focused = global::Covid19Radar.Droid.Resource.Color.common_google_signin_btn_text_dark_focused;
+			global::Xamarin.ExposureNotification.Resource.Color.common_google_signin_btn_text_dark_pressed = global::Covid19Radar.Droid.Resource.Color.common_google_signin_btn_text_dark_pressed;
+			global::Xamarin.ExposureNotification.Resource.Color.common_google_signin_btn_text_light = global::Covid19Radar.Droid.Resource.Color.common_google_signin_btn_text_light;
+			global::Xamarin.ExposureNotification.Resource.Color.common_google_signin_btn_text_light_default = global::Covid19Radar.Droid.Resource.Color.common_google_signin_btn_text_light_default;
+			global::Xamarin.ExposureNotification.Resource.Color.common_google_signin_btn_text_light_disabled = global::Covid19Radar.Droid.Resource.Color.common_google_signin_btn_text_light_disabled;
+			global::Xamarin.ExposureNotification.Resource.Color.common_google_signin_btn_text_light_focused = global::Covid19Radar.Droid.Resource.Color.common_google_signin_btn_text_light_focused;
+			global::Xamarin.ExposureNotification.Resource.Color.common_google_signin_btn_text_light_pressed = global::Covid19Radar.Droid.Resource.Color.common_google_signin_btn_text_light_pressed;
+			global::Xamarin.ExposureNotification.Resource.Color.common_google_signin_btn_tint = global::Covid19Radar.Droid.Resource.Color.common_google_signin_btn_tint;
+			global::Xamarin.ExposureNotification.Resource.Color.notification_action_color_filter = global::Covid19Radar.Droid.Resource.Color.notification_action_color_filter;
+			global::Xamarin.ExposureNotification.Resource.Color.notification_icon_bg_color = global::Covid19Radar.Droid.Resource.Color.notification_icon_bg_color;
+			global::Xamarin.ExposureNotification.Resource.Color.ripple_material_light = global::Covid19Radar.Droid.Resource.Color.ripple_material_light;
+			global::Xamarin.ExposureNotification.Resource.Color.secondary_text_default_material_light = global::Covid19Radar.Droid.Resource.Color.secondary_text_default_material_light;
+			global::Xamarin.ExposureNotification.Resource.Dimension.browser_actions_context_menu_max_width = global::Covid19Radar.Droid.Resource.Dimension.browser_actions_context_menu_max_width;
+			global::Xamarin.ExposureNotification.Resource.Dimension.browser_actions_context_menu_min_padding = global::Covid19Radar.Droid.Resource.Dimension.browser_actions_context_menu_min_padding;
+			global::Xamarin.ExposureNotification.Resource.Dimension.compat_button_inset_horizontal_material = global::Covid19Radar.Droid.Resource.Dimension.compat_button_inset_horizontal_material;
+			global::Xamarin.ExposureNotification.Resource.Dimension.compat_button_inset_vertical_material = global::Covid19Radar.Droid.Resource.Dimension.compat_button_inset_vertical_material;
+			global::Xamarin.ExposureNotification.Resource.Dimension.compat_button_padding_horizontal_material = global::Covid19Radar.Droid.Resource.Dimension.compat_button_padding_horizontal_material;
+			global::Xamarin.ExposureNotification.Resource.Dimension.compat_button_padding_vertical_material = global::Covid19Radar.Droid.Resource.Dimension.compat_button_padding_vertical_material;
+			global::Xamarin.ExposureNotification.Resource.Dimension.compat_control_corner_material = global::Covid19Radar.Droid.Resource.Dimension.compat_control_corner_material;
+			global::Xamarin.ExposureNotification.Resource.Dimension.compat_notification_large_icon_max_height = global::Covid19Radar.Droid.Resource.Dimension.compat_notification_large_icon_max_height;
+			global::Xamarin.ExposureNotification.Resource.Dimension.compat_notification_large_icon_max_width = global::Covid19Radar.Droid.Resource.Dimension.compat_notification_large_icon_max_width;
+			global::Xamarin.ExposureNotification.Resource.Dimension.notification_action_icon_size = global::Covid19Radar.Droid.Resource.Dimension.notification_action_icon_size;
+			global::Xamarin.ExposureNotification.Resource.Dimension.notification_action_text_size = global::Covid19Radar.Droid.Resource.Dimension.notification_action_text_size;
+			global::Xamarin.ExposureNotification.Resource.Dimension.notification_big_circle_margin = global::Covid19Radar.Droid.Resource.Dimension.notification_big_circle_margin;
+			global::Xamarin.ExposureNotification.Resource.Dimension.notification_content_margin_start = global::Covid19Radar.Droid.Resource.Dimension.notification_content_margin_start;
+			global::Xamarin.ExposureNotification.Resource.Dimension.notification_large_icon_height = global::Covid19Radar.Droid.Resource.Dimension.notification_large_icon_height;
+			global::Xamarin.ExposureNotification.Resource.Dimension.notification_large_icon_width = global::Covid19Radar.Droid.Resource.Dimension.notification_large_icon_width;
+			global::Xamarin.ExposureNotification.Resource.Dimension.notification_main_column_padding_top = global::Covid19Radar.Droid.Resource.Dimension.notification_main_column_padding_top;
+			global::Xamarin.ExposureNotification.Resource.Dimension.notification_media_narrow_margin = global::Covid19Radar.Droid.Resource.Dimension.notification_media_narrow_margin;
+			global::Xamarin.ExposureNotification.Resource.Dimension.notification_right_icon_size = global::Covid19Radar.Droid.Resource.Dimension.notification_right_icon_size;
+			global::Xamarin.ExposureNotification.Resource.Dimension.notification_right_side_padding_top = global::Covid19Radar.Droid.Resource.Dimension.notification_right_side_padding_top;
+			global::Xamarin.ExposureNotification.Resource.Dimension.notification_small_icon_background_padding = global::Covid19Radar.Droid.Resource.Dimension.notification_small_icon_background_padding;
+			global::Xamarin.ExposureNotification.Resource.Dimension.notification_small_icon_size_as_large = global::Covid19Radar.Droid.Resource.Dimension.notification_small_icon_size_as_large;
+			global::Xamarin.ExposureNotification.Resource.Dimension.notification_subtext_size = global::Covid19Radar.Droid.Resource.Dimension.notification_subtext_size;
+			global::Xamarin.ExposureNotification.Resource.Dimension.notification_top_pad = global::Covid19Radar.Droid.Resource.Dimension.notification_top_pad;
+			global::Xamarin.ExposureNotification.Resource.Dimension.notification_top_pad_large_text = global::Covid19Radar.Droid.Resource.Dimension.notification_top_pad_large_text;
+			global::Xamarin.ExposureNotification.Resource.Drawable.common_full_open_on_phone = global::Covid19Radar.Droid.Resource.Drawable.common_full_open_on_phone;
+			global::Xamarin.ExposureNotification.Resource.Drawable.common_google_signin_btn_icon_dark = global::Covid19Radar.Droid.Resource.Drawable.common_google_signin_btn_icon_dark;
+			global::Xamarin.ExposureNotification.Resource.Drawable.common_google_signin_btn_icon_dark_focused = global::Covid19Radar.Droid.Resource.Drawable.common_google_signin_btn_icon_dark_focused;
+			global::Xamarin.ExposureNotification.Resource.Drawable.common_google_signin_btn_icon_dark_normal = global::Covid19Radar.Droid.Resource.Drawable.common_google_signin_btn_icon_dark_normal;
+			global::Xamarin.ExposureNotification.Resource.Drawable.common_google_signin_btn_icon_dark_normal_background = global::Covid19Radar.Droid.Resource.Drawable.common_google_signin_btn_icon_dark_normal_background;
+			global::Xamarin.ExposureNotification.Resource.Drawable.common_google_signin_btn_icon_disabled = global::Covid19Radar.Droid.Resource.Drawable.common_google_signin_btn_icon_disabled;
+			global::Xamarin.ExposureNotification.Resource.Drawable.common_google_signin_btn_icon_light = global::Covid19Radar.Droid.Resource.Drawable.common_google_signin_btn_icon_light;
+			global::Xamarin.ExposureNotification.Resource.Drawable.common_google_signin_btn_icon_light_focused = global::Covid19Radar.Droid.Resource.Drawable.common_google_signin_btn_icon_light_focused;
+			global::Xamarin.ExposureNotification.Resource.Drawable.common_google_signin_btn_icon_light_normal = global::Covid19Radar.Droid.Resource.Drawable.common_google_signin_btn_icon_light_normal;
+			global::Xamarin.ExposureNotification.Resource.Drawable.common_google_signin_btn_icon_light_normal_background = global::Covid19Radar.Droid.Resource.Drawable.common_google_signin_btn_icon_light_normal_background;
+			global::Xamarin.ExposureNotification.Resource.Drawable.common_google_signin_btn_text_dark = global::Covid19Radar.Droid.Resource.Drawable.common_google_signin_btn_text_dark;
+			global::Xamarin.ExposureNotification.Resource.Drawable.common_google_signin_btn_text_dark_focused = global::Covid19Radar.Droid.Resource.Drawable.common_google_signin_btn_text_dark_focused;
+			global::Xamarin.ExposureNotification.Resource.Drawable.common_google_signin_btn_text_dark_normal = global::Covid19Radar.Droid.Resource.Drawable.common_google_signin_btn_text_dark_normal;
+			global::Xamarin.ExposureNotification.Resource.Drawable.common_google_signin_btn_text_dark_normal_background = global::Covid19Radar.Droid.Resource.Drawable.common_google_signin_btn_text_dark_normal_background;
+			global::Xamarin.ExposureNotification.Resource.Drawable.common_google_signin_btn_text_disabled = global::Covid19Radar.Droid.Resource.Drawable.common_google_signin_btn_text_disabled;
+			global::Xamarin.ExposureNotification.Resource.Drawable.common_google_signin_btn_text_light = global::Covid19Radar.Droid.Resource.Drawable.common_google_signin_btn_text_light;
+			global::Xamarin.ExposureNotification.Resource.Drawable.common_google_signin_btn_text_light_focused = global::Covid19Radar.Droid.Resource.Drawable.common_google_signin_btn_text_light_focused;
+			global::Xamarin.ExposureNotification.Resource.Drawable.common_google_signin_btn_text_light_normal = global::Covid19Radar.Droid.Resource.Drawable.common_google_signin_btn_text_light_normal;
+			global::Xamarin.ExposureNotification.Resource.Drawable.common_google_signin_btn_text_light_normal_background = global::Covid19Radar.Droid.Resource.Drawable.common_google_signin_btn_text_light_normal_background;
+			global::Xamarin.ExposureNotification.Resource.Drawable.googleg_disabled_color_18 = global::Covid19Radar.Droid.Resource.Drawable.googleg_disabled_color_18;
+			global::Xamarin.ExposureNotification.Resource.Drawable.googleg_standard_color_18 = global::Covid19Radar.Droid.Resource.Drawable.googleg_standard_color_18;
+			global::Xamarin.ExposureNotification.Resource.Drawable.notification_action_background = global::Covid19Radar.Droid.Resource.Drawable.notification_action_background;
+			global::Xamarin.ExposureNotification.Resource.Drawable.notification_bg = global::Covid19Radar.Droid.Resource.Drawable.notification_bg;
+			global::Xamarin.ExposureNotification.Resource.Drawable.notification_bg_low = global::Covid19Radar.Droid.Resource.Drawable.notification_bg_low;
+			global::Xamarin.ExposureNotification.Resource.Drawable.notification_bg_low_normal = global::Covid19Radar.Droid.Resource.Drawable.notification_bg_low_normal;
+			global::Xamarin.ExposureNotification.Resource.Drawable.notification_bg_low_pressed = global::Covid19Radar.Droid.Resource.Drawable.notification_bg_low_pressed;
+			global::Xamarin.ExposureNotification.Resource.Drawable.notification_bg_normal = global::Covid19Radar.Droid.Resource.Drawable.notification_bg_normal;
+			global::Xamarin.ExposureNotification.Resource.Drawable.notification_bg_normal_pressed = global::Covid19Radar.Droid.Resource.Drawable.notification_bg_normal_pressed;
+			global::Xamarin.ExposureNotification.Resource.Drawable.notification_icon_background = global::Covid19Radar.Droid.Resource.Drawable.notification_icon_background;
+			global::Xamarin.ExposureNotification.Resource.Drawable.notification_template_icon_bg = global::Covid19Radar.Droid.Resource.Drawable.notification_template_icon_bg;
+			global::Xamarin.ExposureNotification.Resource.Drawable.notification_template_icon_low_bg = global::Covid19Radar.Droid.Resource.Drawable.notification_template_icon_low_bg;
+			global::Xamarin.ExposureNotification.Resource.Drawable.notification_tile_bg = global::Covid19Radar.Droid.Resource.Drawable.notification_tile_bg;
+			global::Xamarin.ExposureNotification.Resource.Drawable.notify_panel_notification_icon_bg = global::Covid19Radar.Droid.Resource.Drawable.notify_panel_notification_icon_bg;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_action_clickable_span = global::Covid19Radar.Droid.Resource.Id.accessibility_action_clickable_span;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_0 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_0;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_1 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_1;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_10 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_10;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_11 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_11;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_12 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_12;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_13 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_13;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_14 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_14;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_15 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_15;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_16 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_16;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_17 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_17;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_18 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_18;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_19 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_19;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_2 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_2;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_20 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_20;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_21 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_21;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_22 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_22;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_23 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_23;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_24 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_24;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_25 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_25;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_26 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_26;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_27 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_27;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_28 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_28;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_29 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_29;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_3 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_3;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_30 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_30;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_31 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_31;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_4 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_4;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_5 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_5;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_6 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_6;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_7 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_7;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_8 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_8;
+			global::Xamarin.ExposureNotification.Resource.Id.accessibility_custom_action_9 = global::Covid19Radar.Droid.Resource.Id.accessibility_custom_action_9;
+			global::Xamarin.ExposureNotification.Resource.Id.actions = global::Covid19Radar.Droid.Resource.Id.actions;
+			global::Xamarin.ExposureNotification.Resource.Id.action_container = global::Covid19Radar.Droid.Resource.Id.action_container;
+			global::Xamarin.ExposureNotification.Resource.Id.action_divider = global::Covid19Radar.Droid.Resource.Id.action_divider;
+			global::Xamarin.ExposureNotification.Resource.Id.action_image = global::Covid19Radar.Droid.Resource.Id.action_image;
+			global::Xamarin.ExposureNotification.Resource.Id.action_text = global::Covid19Radar.Droid.Resource.Id.action_text;
+			global::Xamarin.ExposureNotification.Resource.Id.adjust_height = global::Covid19Radar.Droid.Resource.Id.adjust_height;
+			global::Xamarin.ExposureNotification.Resource.Id.adjust_width = global::Covid19Radar.Droid.Resource.Id.adjust_width;
+			global::Xamarin.ExposureNotification.Resource.Id.all = global::Covid19Radar.Droid.Resource.Id.all;
+			global::Xamarin.ExposureNotification.Resource.Id.async = global::Covid19Radar.Droid.Resource.Id.async;
+			global::Xamarin.ExposureNotification.Resource.Id.auto = global::Covid19Radar.Droid.Resource.Id.auto;
+			global::Xamarin.ExposureNotification.Resource.Id.blocking = global::Covid19Radar.Droid.Resource.Id.blocking;
+			global::Xamarin.ExposureNotification.Resource.Id.bottom = global::Covid19Radar.Droid.Resource.Id.bottom;
+			global::Xamarin.ExposureNotification.Resource.Id.browser_actions_header_text = global::Covid19Radar.Droid.Resource.Id.browser_actions_header_text;
+			global::Xamarin.ExposureNotification.Resource.Id.browser_actions_menu_items = global::Covid19Radar.Droid.Resource.Id.browser_actions_menu_items;
+			global::Xamarin.ExposureNotification.Resource.Id.browser_actions_menu_item_icon = global::Covid19Radar.Droid.Resource.Id.browser_actions_menu_item_icon;
+			global::Xamarin.ExposureNotification.Resource.Id.browser_actions_menu_item_text = global::Covid19Radar.Droid.Resource.Id.browser_actions_menu_item_text;
+			global::Xamarin.ExposureNotification.Resource.Id.browser_actions_menu_view = global::Covid19Radar.Droid.Resource.Id.browser_actions_menu_view;
+			global::Xamarin.ExposureNotification.Resource.Id.center = global::Covid19Radar.Droid.Resource.Id.center;
+			global::Xamarin.ExposureNotification.Resource.Id.center_horizontal = global::Covid19Radar.Droid.Resource.Id.center_horizontal;
+			global::Xamarin.ExposureNotification.Resource.Id.center_vertical = global::Covid19Radar.Droid.Resource.Id.center_vertical;
+			global::Xamarin.ExposureNotification.Resource.Id.chronometer = global::Covid19Radar.Droid.Resource.Id.chronometer;
+			global::Xamarin.ExposureNotification.Resource.Id.clip_horizontal = global::Covid19Radar.Droid.Resource.Id.clip_horizontal;
+			global::Xamarin.ExposureNotification.Resource.Id.clip_vertical = global::Covid19Radar.Droid.Resource.Id.clip_vertical;
+			global::Xamarin.ExposureNotification.Resource.Id.dark = global::Covid19Radar.Droid.Resource.Id.dark;
+			global::Xamarin.ExposureNotification.Resource.Id.dialog_button = global::Covid19Radar.Droid.Resource.Id.dialog_button;
+			global::Xamarin.ExposureNotification.Resource.Id.end = global::Covid19Radar.Droid.Resource.Id.end;
+			global::Xamarin.ExposureNotification.Resource.Id.fill = global::Covid19Radar.Droid.Resource.Id.fill;
+			global::Xamarin.ExposureNotification.Resource.Id.fill_horizontal = global::Covid19Radar.Droid.Resource.Id.fill_horizontal;
+			global::Xamarin.ExposureNotification.Resource.Id.fill_vertical = global::Covid19Radar.Droid.Resource.Id.fill_vertical;
+			global::Xamarin.ExposureNotification.Resource.Id.forever = global::Covid19Radar.Droid.Resource.Id.forever;
+			global::Xamarin.ExposureNotification.Resource.Id.icon = global::Covid19Radar.Droid.Resource.Id.icon;
+			global::Xamarin.ExposureNotification.Resource.Id.icon_group = global::Covid19Radar.Droid.Resource.Id.icon_group;
+			global::Xamarin.ExposureNotification.Resource.Id.icon_only = global::Covid19Radar.Droid.Resource.Id.icon_only;
+			global::Xamarin.ExposureNotification.Resource.Id.info = global::Covid19Radar.Droid.Resource.Id.info;
+			global::Xamarin.ExposureNotification.Resource.Id.italic = global::Covid19Radar.Droid.Resource.Id.italic;
+			global::Xamarin.ExposureNotification.Resource.Id.left = global::Covid19Radar.Droid.Resource.Id.left;
+			global::Xamarin.ExposureNotification.Resource.Id.light = global::Covid19Radar.Droid.Resource.Id.light;
+			global::Xamarin.ExposureNotification.Resource.Id.line1 = global::Covid19Radar.Droid.Resource.Id.line1;
+			global::Xamarin.ExposureNotification.Resource.Id.line3 = global::Covid19Radar.Droid.Resource.Id.line3;
+			global::Xamarin.ExposureNotification.Resource.Id.none = global::Covid19Radar.Droid.Resource.Id.none;
+			global::Xamarin.ExposureNotification.Resource.Id.normal = global::Covid19Radar.Droid.Resource.Id.normal;
+			global::Xamarin.ExposureNotification.Resource.Id.notification_background = global::Covid19Radar.Droid.Resource.Id.notification_background;
+			global::Xamarin.ExposureNotification.Resource.Id.notification_main_column = global::Covid19Radar.Droid.Resource.Id.notification_main_column;
+			global::Xamarin.ExposureNotification.Resource.Id.notification_main_column_container = global::Covid19Radar.Droid.Resource.Id.notification_main_column_container;
+			global::Xamarin.ExposureNotification.Resource.Id.right = global::Covid19Radar.Droid.Resource.Id.right;
+			global::Xamarin.ExposureNotification.Resource.Id.right_icon = global::Covid19Radar.Droid.Resource.Id.right_icon;
+			global::Xamarin.ExposureNotification.Resource.Id.right_side = global::Covid19Radar.Droid.Resource.Id.right_side;
+			global::Xamarin.ExposureNotification.Resource.Id.standard = global::Covid19Radar.Droid.Resource.Id.standard;
+			global::Xamarin.ExposureNotification.Resource.Id.start = global::Covid19Radar.Droid.Resource.Id.start;
+			global::Xamarin.ExposureNotification.Resource.Id.tag_accessibility_actions = global::Covid19Radar.Droid.Resource.Id.tag_accessibility_actions;
+			global::Xamarin.ExposureNotification.Resource.Id.tag_accessibility_clickable_spans = global::Covid19Radar.Droid.Resource.Id.tag_accessibility_clickable_spans;
+			global::Xamarin.ExposureNotification.Resource.Id.tag_accessibility_heading = global::Covid19Radar.Droid.Resource.Id.tag_accessibility_heading;
+			global::Xamarin.ExposureNotification.Resource.Id.tag_accessibility_pane_title = global::Covid19Radar.Droid.Resource.Id.tag_accessibility_pane_title;
+			global::Xamarin.ExposureNotification.Resource.Id.tag_screen_reader_focusable = global::Covid19Radar.Droid.Resource.Id.tag_screen_reader_focusable;
+			global::Xamarin.ExposureNotification.Resource.Id.tag_transition_group = global::Covid19Radar.Droid.Resource.Id.tag_transition_group;
+			global::Xamarin.ExposureNotification.Resource.Id.tag_unhandled_key_event_manager = global::Covid19Radar.Droid.Resource.Id.tag_unhandled_key_event_manager;
+			global::Xamarin.ExposureNotification.Resource.Id.tag_unhandled_key_listeners = global::Covid19Radar.Droid.Resource.Id.tag_unhandled_key_listeners;
+			global::Xamarin.ExposureNotification.Resource.Id.text = global::Covid19Radar.Droid.Resource.Id.text;
+			global::Xamarin.ExposureNotification.Resource.Id.text2 = global::Covid19Radar.Droid.Resource.Id.text2;
+			global::Xamarin.ExposureNotification.Resource.Id.time = global::Covid19Radar.Droid.Resource.Id.time;
+			global::Xamarin.ExposureNotification.Resource.Id.title = global::Covid19Radar.Droid.Resource.Id.title;
+			global::Xamarin.ExposureNotification.Resource.Id.top = global::Covid19Radar.Droid.Resource.Id.top;
+			global::Xamarin.ExposureNotification.Resource.Id.wide = global::Covid19Radar.Droid.Resource.Id.wide;
+			global::Xamarin.ExposureNotification.Resource.Integer.google_play_services_version = global::Covid19Radar.Droid.Resource.Integer.google_play_services_version;
+			global::Xamarin.ExposureNotification.Resource.Integer.status_bar_notification_info_maxnum = global::Covid19Radar.Droid.Resource.Integer.status_bar_notification_info_maxnum;
+			global::Xamarin.ExposureNotification.Resource.Layout.browser_actions_context_menu_page = global::Covid19Radar.Droid.Resource.Layout.browser_actions_context_menu_page;
+			global::Xamarin.ExposureNotification.Resource.Layout.browser_actions_context_menu_row = global::Covid19Radar.Droid.Resource.Layout.browser_actions_context_menu_row;
+			global::Xamarin.ExposureNotification.Resource.Layout.custom_dialog = global::Covid19Radar.Droid.Resource.Layout.custom_dialog;
+			global::Xamarin.ExposureNotification.Resource.Layout.notification_action = global::Covid19Radar.Droid.Resource.Layout.notification_action;
+			global::Xamarin.ExposureNotification.Resource.Layout.notification_action_tombstone = global::Covid19Radar.Droid.Resource.Layout.notification_action_tombstone;
+			global::Xamarin.ExposureNotification.Resource.Layout.notification_template_custom_big = global::Covid19Radar.Droid.Resource.Layout.notification_template_custom_big;
+			global::Xamarin.ExposureNotification.Resource.Layout.notification_template_icon_group = global::Covid19Radar.Droid.Resource.Layout.notification_template_icon_group;
+			global::Xamarin.ExposureNotification.Resource.Layout.notification_template_part_chronometer = global::Covid19Radar.Droid.Resource.Layout.notification_template_part_chronometer;
+			global::Xamarin.ExposureNotification.Resource.Layout.notification_template_part_time = global::Covid19Radar.Droid.Resource.Layout.notification_template_part_time;
+			global::Xamarin.ExposureNotification.Resource.String.common_google_play_services_enable_button = global::Covid19Radar.Droid.Resource.String.common_google_play_services_enable_button;
+			global::Xamarin.ExposureNotification.Resource.String.common_google_play_services_enable_text = global::Covid19Radar.Droid.Resource.String.common_google_play_services_enable_text;
+			global::Xamarin.ExposureNotification.Resource.String.common_google_play_services_enable_title = global::Covid19Radar.Droid.Resource.String.common_google_play_services_enable_title;
+			global::Xamarin.ExposureNotification.Resource.String.common_google_play_services_install_button = global::Covid19Radar.Droid.Resource.String.common_google_play_services_install_button;
+			global::Xamarin.ExposureNotification.Resource.String.common_google_play_services_install_text = global::Covid19Radar.Droid.Resource.String.common_google_play_services_install_text;
+			global::Xamarin.ExposureNotification.Resource.String.common_google_play_services_install_title = global::Covid19Radar.Droid.Resource.String.common_google_play_services_install_title;
+			global::Xamarin.ExposureNotification.Resource.String.common_google_play_services_notification_channel_name = global::Covid19Radar.Droid.Resource.String.common_google_play_services_notification_channel_name;
+			global::Xamarin.ExposureNotification.Resource.String.common_google_play_services_notification_ticker = global::Covid19Radar.Droid.Resource.String.common_google_play_services_notification_ticker;
+			global::Xamarin.ExposureNotification.Resource.String.common_google_play_services_unknown_issue = global::Covid19Radar.Droid.Resource.String.common_google_play_services_unknown_issue;
+			global::Xamarin.ExposureNotification.Resource.String.common_google_play_services_unsupported_text = global::Covid19Radar.Droid.Resource.String.common_google_play_services_unsupported_text;
+			global::Xamarin.ExposureNotification.Resource.String.common_google_play_services_update_button = global::Covid19Radar.Droid.Resource.String.common_google_play_services_update_button;
+			global::Xamarin.ExposureNotification.Resource.String.common_google_play_services_update_text = global::Covid19Radar.Droid.Resource.String.common_google_play_services_update_text;
+			global::Xamarin.ExposureNotification.Resource.String.common_google_play_services_update_title = global::Covid19Radar.Droid.Resource.String.common_google_play_services_update_title;
+			global::Xamarin.ExposureNotification.Resource.String.common_google_play_services_updating_text = global::Covid19Radar.Droid.Resource.String.common_google_play_services_updating_text;
+			global::Xamarin.ExposureNotification.Resource.String.common_google_play_services_wear_update_text = global::Covid19Radar.Droid.Resource.String.common_google_play_services_wear_update_text;
+			global::Xamarin.ExposureNotification.Resource.String.common_open_on_phone = global::Covid19Radar.Droid.Resource.String.common_open_on_phone;
+			global::Xamarin.ExposureNotification.Resource.String.common_signin_button_text = global::Covid19Radar.Droid.Resource.String.common_signin_button_text;
+			global::Xamarin.ExposureNotification.Resource.String.common_signin_button_text_long = global::Covid19Radar.Droid.Resource.String.common_signin_button_text_long;
+			global::Xamarin.ExposureNotification.Resource.String.status_bar_notification_info_overflow = global::Covid19Radar.Droid.Resource.String.status_bar_notification_info_overflow;
+			global::Xamarin.ExposureNotification.Resource.Style.TextAppearance_Compat_Notification = global::Covid19Radar.Droid.Resource.Style.TextAppearance_Compat_Notification;
+			global::Xamarin.ExposureNotification.Resource.Style.TextAppearance_Compat_Notification_Info = global::Covid19Radar.Droid.Resource.Style.TextAppearance_Compat_Notification_Info;
+			global::Xamarin.ExposureNotification.Resource.Style.TextAppearance_Compat_Notification_Line2 = global::Covid19Radar.Droid.Resource.Style.TextAppearance_Compat_Notification_Line2;
+			global::Xamarin.ExposureNotification.Resource.Style.TextAppearance_Compat_Notification_Time = global::Covid19Radar.Droid.Resource.Style.TextAppearance_Compat_Notification_Time;
+			global::Xamarin.ExposureNotification.Resource.Style.TextAppearance_Compat_Notification_Title = global::Covid19Radar.Droid.Resource.Style.TextAppearance_Compat_Notification_Title;
+			global::Xamarin.ExposureNotification.Resource.Style.Widget_Compat_NotificationActionContainer = global::Covid19Radar.Droid.Resource.Style.Widget_Compat_NotificationActionContainer;
+			global::Xamarin.ExposureNotification.Resource.Style.Widget_Compat_NotificationActionText = global::Covid19Radar.Droid.Resource.Style.Widget_Compat_NotificationActionText;
+			global::Xamarin.ExposureNotification.Resource.Style.Widget_Support_CoordinatorLayout = global::Covid19Radar.Droid.Resource.Style.Widget_Support_CoordinatorLayout;
+			global::Xamarin.ExposureNotification.Resource.Styleable.ColorStateListItem = global::Covid19Radar.Droid.Resource.Styleable.ColorStateListItem;
+			global::Xamarin.ExposureNotification.Resource.Styleable.ColorStateListItem_alpha = global::Covid19Radar.Droid.Resource.Styleable.ColorStateListItem_alpha;
+			global::Xamarin.ExposureNotification.Resource.Styleable.ColorStateListItem_android_alpha = global::Covid19Radar.Droid.Resource.Styleable.ColorStateListItem_android_alpha;
+			global::Xamarin.ExposureNotification.Resource.Styleable.ColorStateListItem_android_color = global::Covid19Radar.Droid.Resource.Styleable.ColorStateListItem_android_color;
+			global::Xamarin.ExposureNotification.Resource.Styleable.CoordinatorLayout = global::Covid19Radar.Droid.Resource.Styleable.CoordinatorLayout;
+			global::Xamarin.ExposureNotification.Resource.Styleable.CoordinatorLayout_keylines = global::Covid19Radar.Droid.Resource.Styleable.CoordinatorLayout_keylines;
+			global::Xamarin.ExposureNotification.Resource.Styleable.CoordinatorLayout_Layout = global::Covid19Radar.Droid.Resource.Styleable.CoordinatorLayout_Layout;
+			global::Xamarin.ExposureNotification.Resource.Styleable.CoordinatorLayout_Layout_android_layout_gravity = global::Covid19Radar.Droid.Resource.Styleable.CoordinatorLayout_Layout_android_layout_gravity;
+			global::Xamarin.ExposureNotification.Resource.Styleable.CoordinatorLayout_Layout_layout_anchor = global::Covid19Radar.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_anchor;
+			global::Xamarin.ExposureNotification.Resource.Styleable.CoordinatorLayout_Layout_layout_anchorGravity = global::Covid19Radar.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_anchorGravity;
+			global::Xamarin.ExposureNotification.Resource.Styleable.CoordinatorLayout_Layout_layout_behavior = global::Covid19Radar.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_behavior;
+			global::Xamarin.ExposureNotification.Resource.Styleable.CoordinatorLayout_Layout_layout_dodgeInsetEdges = global::Covid19Radar.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_dodgeInsetEdges;
+			global::Xamarin.ExposureNotification.Resource.Styleable.CoordinatorLayout_Layout_layout_insetEdge = global::Covid19Radar.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_insetEdge;
+			global::Xamarin.ExposureNotification.Resource.Styleable.CoordinatorLayout_Layout_layout_keyline = global::Covid19Radar.Droid.Resource.Styleable.CoordinatorLayout_Layout_layout_keyline;
+			global::Xamarin.ExposureNotification.Resource.Styleable.CoordinatorLayout_statusBarBackground = global::Covid19Radar.Droid.Resource.Styleable.CoordinatorLayout_statusBarBackground;
+			global::Xamarin.ExposureNotification.Resource.Styleable.FontFamily = global::Covid19Radar.Droid.Resource.Styleable.FontFamily;
+			global::Xamarin.ExposureNotification.Resource.Styleable.FontFamilyFont = global::Covid19Radar.Droid.Resource.Styleable.FontFamilyFont;
+			global::Xamarin.ExposureNotification.Resource.Styleable.FontFamilyFont_android_font = global::Covid19Radar.Droid.Resource.Styleable.FontFamilyFont_android_font;
+			global::Xamarin.ExposureNotification.Resource.Styleable.FontFamilyFont_android_fontStyle = global::Covid19Radar.Droid.Resource.Styleable.FontFamilyFont_android_fontStyle;
+			global::Xamarin.ExposureNotification.Resource.Styleable.FontFamilyFont_android_fontVariationSettings = global::Covid19Radar.Droid.Resource.Styleable.FontFamilyFont_android_fontVariationSettings;
+			global::Xamarin.ExposureNotification.Resource.Styleable.FontFamilyFont_android_fontWeight = global::Covid19Radar.Droid.Resource.Styleable.FontFamilyFont_android_fontWeight;
+			global::Xamarin.ExposureNotification.Resource.Styleable.FontFamilyFont_android_ttcIndex = global::Covid19Radar.Droid.Resource.Styleable.FontFamilyFont_android_ttcIndex;
+			global::Xamarin.ExposureNotification.Resource.Styleable.FontFamilyFont_font = global::Covid19Radar.Droid.Resource.Styleable.FontFamilyFont_font;
+			global::Xamarin.ExposureNotification.Resource.Styleable.FontFamilyFont_fontStyle = global::Covid19Radar.Droid.Resource.Styleable.FontFamilyFont_fontStyle;
+			global::Xamarin.ExposureNotification.Resource.Styleable.FontFamilyFont_fontVariationSettings = global::Covid19Radar.Droid.Resource.Styleable.FontFamilyFont_fontVariationSettings;
+			global::Xamarin.ExposureNotification.Resource.Styleable.FontFamilyFont_fontWeight = global::Covid19Radar.Droid.Resource.Styleable.FontFamilyFont_fontWeight;
+			global::Xamarin.ExposureNotification.Resource.Styleable.FontFamilyFont_ttcIndex = global::Covid19Radar.Droid.Resource.Styleable.FontFamilyFont_ttcIndex;
+			global::Xamarin.ExposureNotification.Resource.Styleable.FontFamily_fontProviderAuthority = global::Covid19Radar.Droid.Resource.Styleable.FontFamily_fontProviderAuthority;
+			global::Xamarin.ExposureNotification.Resource.Styleable.FontFamily_fontProviderCerts = global::Covid19Radar.Droid.Resource.Styleable.FontFamily_fontProviderCerts;
+			global::Xamarin.ExposureNotification.Resource.Styleable.FontFamily_fontProviderFetchStrategy = global::Covid19Radar.Droid.Resource.Styleable.FontFamily_fontProviderFetchStrategy;
+			global::Xamarin.ExposureNotification.Resource.Styleable.FontFamily_fontProviderFetchTimeout = global::Covid19Radar.Droid.Resource.Styleable.FontFamily_fontProviderFetchTimeout;
+			global::Xamarin.ExposureNotification.Resource.Styleable.FontFamily_fontProviderPackage = global::Covid19Radar.Droid.Resource.Styleable.FontFamily_fontProviderPackage;
+			global::Xamarin.ExposureNotification.Resource.Styleable.FontFamily_fontProviderQuery = global::Covid19Radar.Droid.Resource.Styleable.FontFamily_fontProviderQuery;
+			global::Xamarin.ExposureNotification.Resource.Styleable.GradientColor = global::Covid19Radar.Droid.Resource.Styleable.GradientColor;
+			global::Xamarin.ExposureNotification.Resource.Styleable.GradientColorItem = global::Covid19Radar.Droid.Resource.Styleable.GradientColorItem;
+			global::Xamarin.ExposureNotification.Resource.Styleable.GradientColorItem_android_color = global::Covid19Radar.Droid.Resource.Styleable.GradientColorItem_android_color;
+			global::Xamarin.ExposureNotification.Resource.Styleable.GradientColorItem_android_offset = global::Covid19Radar.Droid.Resource.Styleable.GradientColorItem_android_offset;
+			global::Xamarin.ExposureNotification.Resource.Styleable.GradientColor_android_centerColor = global::Covid19Radar.Droid.Resource.Styleable.GradientColor_android_centerColor;
+			global::Xamarin.ExposureNotification.Resource.Styleable.GradientColor_android_centerX = global::Covid19Radar.Droid.Resource.Styleable.GradientColor_android_centerX;
+			global::Xamarin.ExposureNotification.Resource.Styleable.GradientColor_android_centerY = global::Covid19Radar.Droid.Resource.Styleable.GradientColor_android_centerY;
+			global::Xamarin.ExposureNotification.Resource.Styleable.GradientColor_android_endColor = global::Covid19Radar.Droid.Resource.Styleable.GradientColor_android_endColor;
+			global::Xamarin.ExposureNotification.Resource.Styleable.GradientColor_android_endX = global::Covid19Radar.Droid.Resource.Styleable.GradientColor_android_endX;
+			global::Xamarin.ExposureNotification.Resource.Styleable.GradientColor_android_endY = global::Covid19Radar.Droid.Resource.Styleable.GradientColor_android_endY;
+			global::Xamarin.ExposureNotification.Resource.Styleable.GradientColor_android_gradientRadius = global::Covid19Radar.Droid.Resource.Styleable.GradientColor_android_gradientRadius;
+			global::Xamarin.ExposureNotification.Resource.Styleable.GradientColor_android_startColor = global::Covid19Radar.Droid.Resource.Styleable.GradientColor_android_startColor;
+			global::Xamarin.ExposureNotification.Resource.Styleable.GradientColor_android_startX = global::Covid19Radar.Droid.Resource.Styleable.GradientColor_android_startX;
+			global::Xamarin.ExposureNotification.Resource.Styleable.GradientColor_android_startY = global::Covid19Radar.Droid.Resource.Styleable.GradientColor_android_startY;
+			global::Xamarin.ExposureNotification.Resource.Styleable.GradientColor_android_tileMode = global::Covid19Radar.Droid.Resource.Styleable.GradientColor_android_tileMode;
+			global::Xamarin.ExposureNotification.Resource.Styleable.GradientColor_android_type = global::Covid19Radar.Droid.Resource.Styleable.GradientColor_android_type;
+			global::Xamarin.ExposureNotification.Resource.Styleable.LoadingImageView = global::Covid19Radar.Droid.Resource.Styleable.LoadingImageView;
+			global::Xamarin.ExposureNotification.Resource.Styleable.LoadingImageView_circleCrop = global::Covid19Radar.Droid.Resource.Styleable.LoadingImageView_circleCrop;
+			global::Xamarin.ExposureNotification.Resource.Styleable.LoadingImageView_imageAspectRatio = global::Covid19Radar.Droid.Resource.Styleable.LoadingImageView_imageAspectRatio;
+			global::Xamarin.ExposureNotification.Resource.Styleable.LoadingImageView_imageAspectRatioAdjust = global::Covid19Radar.Droid.Resource.Styleable.LoadingImageView_imageAspectRatioAdjust;
+			global::Xamarin.ExposureNotification.Resource.Styleable.SignInButton = global::Covid19Radar.Droid.Resource.Styleable.SignInButton;
+			global::Xamarin.ExposureNotification.Resource.Styleable.SignInButton_buttonSize = global::Covid19Radar.Droid.Resource.Styleable.SignInButton_buttonSize;
+			global::Xamarin.ExposureNotification.Resource.Styleable.SignInButton_colorScheme = global::Covid19Radar.Droid.Resource.Styleable.SignInButton_colorScheme;
+			global::Xamarin.ExposureNotification.Resource.Styleable.SignInButton_scopeUris = global::Covid19Radar.Droid.Resource.Styleable.SignInButton_scopeUris;
+			global::Xamarin.ExposureNotification.Resource.Xml.xamarin_essentials_fileprovider_file_paths = global::Covid19Radar.Droid.Resource.Xml.xamarin_essentials_fileprovider_file_paths;
 			global::Xamarin.Forms.Material.Android.Resource.Animation.abc_fade_in = global::Covid19Radar.Droid.Resource.Animation.abc_fade_in;
 			global::Xamarin.Forms.Material.Android.Resource.Animation.abc_fade_out = global::Covid19Radar.Droid.Resource.Animation.abc_fade_out;
 			global::Xamarin.Forms.Material.Android.Resource.Animation.abc_grow_fade_in_from_bottom = global::Covid19Radar.Droid.Resource.Animation.abc_grow_fade_in_from_bottom;
@@ -16535,910 +16834,916 @@ namespace Covid19Radar.Droid
 			public const int abc_vector_test = 2131165275;
 			
 			// aapt resource value: 0x7F07005C
-			public const int avd_hide_password = 2131165276;
+			public const int arrow_icon = 2131165276;
 			
 			// aapt resource value: 0x7F07005D
-			public const int avd_show_password = 2131165277;
+			public const int avd_hide_password = 2131165277;
 			
 			// aapt resource value: 0x7F07005E
-			public const int btn_checkbox_checked_mtrl = 2131165278;
+			public const int avd_show_password = 2131165278;
 			
 			// aapt resource value: 0x7F07005F
-			public const int btn_checkbox_checked_to_unchecked_mtrl_animation = 2131165279;
+			public const int btn_checkbox_checked_mtrl = 2131165279;
 			
 			// aapt resource value: 0x7F070060
-			public const int btn_checkbox_unchecked_mtrl = 2131165280;
+			public const int btn_checkbox_checked_to_unchecked_mtrl_animation = 2131165280;
 			
 			// aapt resource value: 0x7F070061
-			public const int btn_checkbox_unchecked_to_checked_mtrl_animation = 2131165281;
+			public const int btn_checkbox_unchecked_mtrl = 2131165281;
 			
 			// aapt resource value: 0x7F070062
-			public const int btn_radio_off_mtrl = 2131165282;
+			public const int btn_checkbox_unchecked_to_checked_mtrl_animation = 2131165282;
 			
 			// aapt resource value: 0x7F070063
-			public const int btn_radio_off_to_on_mtrl_animation = 2131165283;
+			public const int btn_radio_off_mtrl = 2131165283;
 			
 			// aapt resource value: 0x7F070064
-			public const int btn_radio_on_mtrl = 2131165284;
+			public const int btn_radio_off_to_on_mtrl_animation = 2131165284;
 			
 			// aapt resource value: 0x7F070065
-			public const int btn_radio_on_to_off_mtrl_animation = 2131165285;
+			public const int btn_radio_on_mtrl = 2131165285;
 			
 			// aapt resource value: 0x7F070066
-			public const int common_full_open_on_phone = 2131165286;
+			public const int btn_radio_on_to_off_mtrl_animation = 2131165286;
 			
 			// aapt resource value: 0x7F070067
-			public const int common_google_signin_btn_icon_dark = 2131165287;
+			public const int common_full_open_on_phone = 2131165287;
 			
 			// aapt resource value: 0x7F070068
-			public const int common_google_signin_btn_icon_dark_focused = 2131165288;
+			public const int common_google_signin_btn_icon_dark = 2131165288;
 			
 			// aapt resource value: 0x7F070069
-			public const int common_google_signin_btn_icon_dark_normal = 2131165289;
+			public const int common_google_signin_btn_icon_dark_focused = 2131165289;
 			
 			// aapt resource value: 0x7F07006A
-			public const int common_google_signin_btn_icon_dark_normal_background = 2131165290;
+			public const int common_google_signin_btn_icon_dark_normal = 2131165290;
 			
 			// aapt resource value: 0x7F07006B
-			public const int common_google_signin_btn_icon_disabled = 2131165291;
+			public const int common_google_signin_btn_icon_dark_normal_background = 2131165291;
 			
 			// aapt resource value: 0x7F07006C
-			public const int common_google_signin_btn_icon_light = 2131165292;
+			public const int common_google_signin_btn_icon_disabled = 2131165292;
 			
 			// aapt resource value: 0x7F07006D
-			public const int common_google_signin_btn_icon_light_focused = 2131165293;
+			public const int common_google_signin_btn_icon_light = 2131165293;
 			
 			// aapt resource value: 0x7F07006E
-			public const int common_google_signin_btn_icon_light_normal = 2131165294;
+			public const int common_google_signin_btn_icon_light_focused = 2131165294;
 			
 			// aapt resource value: 0x7F07006F
-			public const int common_google_signin_btn_icon_light_normal_background = 2131165295;
+			public const int common_google_signin_btn_icon_light_normal = 2131165295;
 			
 			// aapt resource value: 0x7F070070
-			public const int common_google_signin_btn_text_dark = 2131165296;
+			public const int common_google_signin_btn_icon_light_normal_background = 2131165296;
 			
 			// aapt resource value: 0x7F070071
-			public const int common_google_signin_btn_text_dark_focused = 2131165297;
+			public const int common_google_signin_btn_text_dark = 2131165297;
 			
 			// aapt resource value: 0x7F070072
-			public const int common_google_signin_btn_text_dark_normal = 2131165298;
+			public const int common_google_signin_btn_text_dark_focused = 2131165298;
 			
 			// aapt resource value: 0x7F070073
-			public const int common_google_signin_btn_text_dark_normal_background = 2131165299;
+			public const int common_google_signin_btn_text_dark_normal = 2131165299;
 			
 			// aapt resource value: 0x7F070074
-			public const int common_google_signin_btn_text_disabled = 2131165300;
+			public const int common_google_signin_btn_text_dark_normal_background = 2131165300;
 			
 			// aapt resource value: 0x7F070075
-			public const int common_google_signin_btn_text_light = 2131165301;
+			public const int common_google_signin_btn_text_disabled = 2131165301;
 			
 			// aapt resource value: 0x7F070076
-			public const int common_google_signin_btn_text_light_focused = 2131165302;
+			public const int common_google_signin_btn_text_light = 2131165302;
 			
 			// aapt resource value: 0x7F070077
-			public const int common_google_signin_btn_text_light_normal = 2131165303;
+			public const int common_google_signin_btn_text_light_focused = 2131165303;
 			
 			// aapt resource value: 0x7F070078
-			public const int common_google_signin_btn_text_light_normal_background = 2131165304;
+			public const int common_google_signin_btn_text_light_normal = 2131165304;
 			
 			// aapt resource value: 0x7F070079
-			public const int design_bottom_navigation_item_background = 2131165305;
+			public const int common_google_signin_btn_text_light_normal_background = 2131165305;
 			
 			// aapt resource value: 0x7F07007A
-			public const int design_fab_background = 2131165306;
+			public const int design_bottom_navigation_item_background = 2131165306;
 			
 			// aapt resource value: 0x7F07007B
-			public const int design_ic_visibility = 2131165307;
+			public const int design_fab_background = 2131165307;
 			
 			// aapt resource value: 0x7F07007C
-			public const int design_ic_visibility_off = 2131165308;
+			public const int design_ic_visibility = 2131165308;
 			
 			// aapt resource value: 0x7F07007D
-			public const int design_password_eye = 2131165309;
+			public const int design_ic_visibility_off = 2131165309;
 			
 			// aapt resource value: 0x7F07007E
-			public const int design_snackbar_background = 2131165310;
+			public const int design_password_eye = 2131165310;
 			
 			// aapt resource value: 0x7F07007F
-			public const int googleg_disabled_color_18 = 2131165311;
+			public const int design_snackbar_background = 2131165311;
 			
 			// aapt resource value: 0x7F070080
-			public const int googleg_standard_color_18 = 2131165312;
+			public const int googleg_disabled_color_18 = 2131165312;
 			
 			// aapt resource value: 0x7F070081
-			public const int HeaderLogo = 2131165313;
+			public const int googleg_standard_color_18 = 2131165313;
 			
 			// aapt resource value: 0x7F070082
-			public const int HelpPage20 = 2131165314;
+			public const int HeaderLogo = 2131165314;
 			
 			// aapt resource value: 0x7F070083
-			public const int HelpPage21 = 2131165315;
+			public const int HelpPage20 = 2131165315;
 			
 			// aapt resource value: 0x7F070084
-			public const int HelpPage22 = 2131165316;
+			public const int HelpPage21 = 2131165316;
 			
 			// aapt resource value: 0x7F070085
-			public const int HelpPage30 = 2131165317;
+			public const int HelpPage22 = 2131165317;
 			
 			// aapt resource value: 0x7F070086
-			public const int HelpPage31 = 2131165318;
+			public const int HelpPage30 = 2131165318;
 			
 			// aapt resource value: 0x7F070087
-			public const int HelpPage32 = 2131165319;
+			public const int HelpPage31 = 2131165319;
 			
 			// aapt resource value: 0x7F070088
-			public const int HelpPage40 = 2131165320;
+			public const int HelpPage32 = 2131165320;
 			
 			// aapt resource value: 0x7F070089
-			public const int HelpPage41 = 2131165321;
+			public const int HelpPage40 = 2131165321;
 			
 			// aapt resource value: 0x7F07008A
-			public const int HelpPage42 = 2131165322;
+			public const int HelpPage41 = 2131165322;
 			
 			// aapt resource value: 0x7F07008B
-			public const int HelpPage44 = 2131165323;
+			public const int HelpPage42 = 2131165323;
 			
 			// aapt resource value: 0x7F07008C
-			public const int HelpPage45 = 2131165324;
+			public const int HelpPage44 = 2131165324;
 			
 			// aapt resource value: 0x7F07008D
-			public const int HelpPage50 = 2131165325;
+			public const int HelpPage45 = 2131165325;
 			
 			// aapt resource value: 0x7F07008E
-			public const int HOMEPage10 = 2131165326;
+			public const int HelpPage50 = 2131165326;
 			
 			// aapt resource value: 0x7F07008F
-			public const int HOMEPage11 = 2131165327;
+			public const int HOMEPage10 = 2131165327;
 			
 			// aapt resource value: 0x7F070090
-			public const int ic_audiotrack_dark = 2131165328;
+			public const int HOMEPage11 = 2131165328;
 			
 			// aapt resource value: 0x7F070091
-			public const int ic_audiotrack_light = 2131165329;
+			public const int ic_audiotrack_dark = 2131165329;
 			
 			// aapt resource value: 0x7F070092
-			public const int ic_checked_checkbox = 2131165330;
+			public const int ic_audiotrack_light = 2131165330;
 			
 			// aapt resource value: 0x7F070093
-			public const int ic_dialog_close_dark = 2131165331;
+			public const int ic_checked_checkbox = 2131165331;
 			
 			// aapt resource value: 0x7F070094
-			public const int ic_dialog_close_light = 2131165332;
+			public const int ic_dialog_close_dark = 2131165332;
 			
 			// aapt resource value: 0x7F070095
-			public const int ic_errorstatus = 2131165333;
+			public const int ic_dialog_close_light = 2131165333;
 			
 			// aapt resource value: 0x7F070096
-			public const int ic_group_collapse_00 = 2131165334;
+			public const int ic_errorstatus = 2131165334;
 			
 			// aapt resource value: 0x7F070097
-			public const int ic_group_collapse_01 = 2131165335;
+			public const int ic_group_collapse_00 = 2131165335;
 			
 			// aapt resource value: 0x7F070098
-			public const int ic_group_collapse_02 = 2131165336;
+			public const int ic_group_collapse_01 = 2131165336;
 			
 			// aapt resource value: 0x7F070099
-			public const int ic_group_collapse_03 = 2131165337;
+			public const int ic_group_collapse_02 = 2131165337;
 			
 			// aapt resource value: 0x7F07009A
-			public const int ic_group_collapse_04 = 2131165338;
+			public const int ic_group_collapse_03 = 2131165338;
 			
 			// aapt resource value: 0x7F07009B
-			public const int ic_group_collapse_05 = 2131165339;
+			public const int ic_group_collapse_04 = 2131165339;
 			
 			// aapt resource value: 0x7F07009C
-			public const int ic_group_collapse_06 = 2131165340;
+			public const int ic_group_collapse_05 = 2131165340;
 			
 			// aapt resource value: 0x7F07009D
-			public const int ic_group_collapse_07 = 2131165341;
+			public const int ic_group_collapse_06 = 2131165341;
 			
 			// aapt resource value: 0x7F07009E
-			public const int ic_group_collapse_08 = 2131165342;
+			public const int ic_group_collapse_07 = 2131165342;
 			
 			// aapt resource value: 0x7F07009F
-			public const int ic_group_collapse_09 = 2131165343;
+			public const int ic_group_collapse_08 = 2131165343;
 			
 			// aapt resource value: 0x7F0700A0
-			public const int ic_group_collapse_10 = 2131165344;
+			public const int ic_group_collapse_09 = 2131165344;
 			
 			// aapt resource value: 0x7F0700A1
-			public const int ic_group_collapse_11 = 2131165345;
+			public const int ic_group_collapse_10 = 2131165345;
 			
 			// aapt resource value: 0x7F0700A2
-			public const int ic_group_collapse_12 = 2131165346;
+			public const int ic_group_collapse_11 = 2131165346;
 			
 			// aapt resource value: 0x7F0700A3
-			public const int ic_group_collapse_13 = 2131165347;
+			public const int ic_group_collapse_12 = 2131165347;
 			
 			// aapt resource value: 0x7F0700A4
-			public const int ic_group_collapse_14 = 2131165348;
+			public const int ic_group_collapse_13 = 2131165348;
 			
 			// aapt resource value: 0x7F0700A5
-			public const int ic_group_collapse_15 = 2131165349;
+			public const int ic_group_collapse_14 = 2131165349;
 			
 			// aapt resource value: 0x7F0700A6
-			public const int ic_group_expand_00 = 2131165350;
+			public const int ic_group_collapse_15 = 2131165350;
 			
 			// aapt resource value: 0x7F0700A7
-			public const int ic_group_expand_01 = 2131165351;
+			public const int ic_group_expand_00 = 2131165351;
 			
 			// aapt resource value: 0x7F0700A8
-			public const int ic_group_expand_02 = 2131165352;
+			public const int ic_group_expand_01 = 2131165352;
 			
 			// aapt resource value: 0x7F0700A9
-			public const int ic_group_expand_03 = 2131165353;
+			public const int ic_group_expand_02 = 2131165353;
 			
 			// aapt resource value: 0x7F0700AA
-			public const int ic_group_expand_04 = 2131165354;
+			public const int ic_group_expand_03 = 2131165354;
 			
 			// aapt resource value: 0x7F0700AB
-			public const int ic_group_expand_05 = 2131165355;
+			public const int ic_group_expand_04 = 2131165355;
 			
 			// aapt resource value: 0x7F0700AC
-			public const int ic_group_expand_06 = 2131165356;
+			public const int ic_group_expand_05 = 2131165356;
 			
 			// aapt resource value: 0x7F0700AD
-			public const int ic_group_expand_07 = 2131165357;
+			public const int ic_group_expand_06 = 2131165357;
 			
 			// aapt resource value: 0x7F0700AE
-			public const int ic_group_expand_08 = 2131165358;
+			public const int ic_group_expand_07 = 2131165358;
 			
 			// aapt resource value: 0x7F0700AF
-			public const int ic_group_expand_09 = 2131165359;
+			public const int ic_group_expand_08 = 2131165359;
 			
 			// aapt resource value: 0x7F0700B0
-			public const int ic_group_expand_10 = 2131165360;
+			public const int ic_group_expand_09 = 2131165360;
 			
 			// aapt resource value: 0x7F0700B1
-			public const int ic_group_expand_11 = 2131165361;
+			public const int ic_group_expand_10 = 2131165361;
 			
 			// aapt resource value: 0x7F0700B2
-			public const int ic_group_expand_12 = 2131165362;
+			public const int ic_group_expand_11 = 2131165362;
 			
 			// aapt resource value: 0x7F0700B3
-			public const int ic_group_expand_13 = 2131165363;
+			public const int ic_group_expand_12 = 2131165363;
 			
 			// aapt resource value: 0x7F0700B4
-			public const int ic_group_expand_14 = 2131165364;
+			public const int ic_group_expand_13 = 2131165364;
 			
 			// aapt resource value: 0x7F0700B5
-			public const int ic_group_expand_15 = 2131165365;
+			public const int ic_group_expand_14 = 2131165365;
 			
 			// aapt resource value: 0x7F0700B6
-			public const int ic_hamburger = 2131165366;
+			public const int ic_group_expand_15 = 2131165366;
 			
 			// aapt resource value: 0x7F0700B7
-			public const int ic_media_pause_dark = 2131165367;
+			public const int ic_hamburger = 2131165367;
 			
 			// aapt resource value: 0x7F0700B8
-			public const int ic_media_pause_light = 2131165368;
+			public const int ic_media_pause_dark = 2131165368;
 			
 			// aapt resource value: 0x7F0700B9
-			public const int ic_media_play_dark = 2131165369;
+			public const int ic_media_pause_light = 2131165369;
 			
 			// aapt resource value: 0x7F0700BA
-			public const int ic_media_play_light = 2131165370;
+			public const int ic_media_play_dark = 2131165370;
 			
 			// aapt resource value: 0x7F0700BB
-			public const int ic_media_stop_dark = 2131165371;
+			public const int ic_media_play_light = 2131165371;
 			
 			// aapt resource value: 0x7F0700BC
-			public const int ic_media_stop_light = 2131165372;
+			public const int ic_media_stop_dark = 2131165372;
 			
 			// aapt resource value: 0x7F0700BD
-			public const int ic_mr_button_connected_00_dark = 2131165373;
+			public const int ic_media_stop_light = 2131165373;
 			
 			// aapt resource value: 0x7F0700BE
-			public const int ic_mr_button_connected_00_light = 2131165374;
+			public const int ic_mr_button_connected_00_dark = 2131165374;
 			
 			// aapt resource value: 0x7F0700BF
-			public const int ic_mr_button_connected_01_dark = 2131165375;
+			public const int ic_mr_button_connected_00_light = 2131165375;
 			
 			// aapt resource value: 0x7F0700C0
-			public const int ic_mr_button_connected_01_light = 2131165376;
+			public const int ic_mr_button_connected_01_dark = 2131165376;
 			
 			// aapt resource value: 0x7F0700C1
-			public const int ic_mr_button_connected_02_dark = 2131165377;
+			public const int ic_mr_button_connected_01_light = 2131165377;
 			
 			// aapt resource value: 0x7F0700C2
-			public const int ic_mr_button_connected_02_light = 2131165378;
+			public const int ic_mr_button_connected_02_dark = 2131165378;
 			
 			// aapt resource value: 0x7F0700C3
-			public const int ic_mr_button_connected_03_dark = 2131165379;
+			public const int ic_mr_button_connected_02_light = 2131165379;
 			
 			// aapt resource value: 0x7F0700C4
-			public const int ic_mr_button_connected_03_light = 2131165380;
+			public const int ic_mr_button_connected_03_dark = 2131165380;
 			
 			// aapt resource value: 0x7F0700C5
-			public const int ic_mr_button_connected_04_dark = 2131165381;
+			public const int ic_mr_button_connected_03_light = 2131165381;
 			
 			// aapt resource value: 0x7F0700C6
-			public const int ic_mr_button_connected_04_light = 2131165382;
+			public const int ic_mr_button_connected_04_dark = 2131165382;
 			
 			// aapt resource value: 0x7F0700C7
-			public const int ic_mr_button_connected_05_dark = 2131165383;
+			public const int ic_mr_button_connected_04_light = 2131165383;
 			
 			// aapt resource value: 0x7F0700C8
-			public const int ic_mr_button_connected_05_light = 2131165384;
+			public const int ic_mr_button_connected_05_dark = 2131165384;
 			
 			// aapt resource value: 0x7F0700C9
-			public const int ic_mr_button_connected_06_dark = 2131165385;
+			public const int ic_mr_button_connected_05_light = 2131165385;
 			
 			// aapt resource value: 0x7F0700CA
-			public const int ic_mr_button_connected_06_light = 2131165386;
+			public const int ic_mr_button_connected_06_dark = 2131165386;
 			
 			// aapt resource value: 0x7F0700CB
-			public const int ic_mr_button_connected_07_dark = 2131165387;
+			public const int ic_mr_button_connected_06_light = 2131165387;
 			
 			// aapt resource value: 0x7F0700CC
-			public const int ic_mr_button_connected_07_light = 2131165388;
+			public const int ic_mr_button_connected_07_dark = 2131165388;
 			
 			// aapt resource value: 0x7F0700CD
-			public const int ic_mr_button_connected_08_dark = 2131165389;
+			public const int ic_mr_button_connected_07_light = 2131165389;
 			
 			// aapt resource value: 0x7F0700CE
-			public const int ic_mr_button_connected_08_light = 2131165390;
+			public const int ic_mr_button_connected_08_dark = 2131165390;
 			
 			// aapt resource value: 0x7F0700CF
-			public const int ic_mr_button_connected_09_dark = 2131165391;
+			public const int ic_mr_button_connected_08_light = 2131165391;
 			
 			// aapt resource value: 0x7F0700D0
-			public const int ic_mr_button_connected_09_light = 2131165392;
+			public const int ic_mr_button_connected_09_dark = 2131165392;
 			
 			// aapt resource value: 0x7F0700D1
-			public const int ic_mr_button_connected_10_dark = 2131165393;
+			public const int ic_mr_button_connected_09_light = 2131165393;
 			
 			// aapt resource value: 0x7F0700D2
-			public const int ic_mr_button_connected_10_light = 2131165394;
+			public const int ic_mr_button_connected_10_dark = 2131165394;
 			
 			// aapt resource value: 0x7F0700D3
-			public const int ic_mr_button_connected_11_dark = 2131165395;
+			public const int ic_mr_button_connected_10_light = 2131165395;
 			
 			// aapt resource value: 0x7F0700D4
-			public const int ic_mr_button_connected_11_light = 2131165396;
+			public const int ic_mr_button_connected_11_dark = 2131165396;
 			
 			// aapt resource value: 0x7F0700D5
-			public const int ic_mr_button_connected_12_dark = 2131165397;
+			public const int ic_mr_button_connected_11_light = 2131165397;
 			
 			// aapt resource value: 0x7F0700D6
-			public const int ic_mr_button_connected_12_light = 2131165398;
+			public const int ic_mr_button_connected_12_dark = 2131165398;
 			
 			// aapt resource value: 0x7F0700D7
-			public const int ic_mr_button_connected_13_dark = 2131165399;
+			public const int ic_mr_button_connected_12_light = 2131165399;
 			
 			// aapt resource value: 0x7F0700D8
-			public const int ic_mr_button_connected_13_light = 2131165400;
+			public const int ic_mr_button_connected_13_dark = 2131165400;
 			
 			// aapt resource value: 0x7F0700D9
-			public const int ic_mr_button_connected_14_dark = 2131165401;
+			public const int ic_mr_button_connected_13_light = 2131165401;
 			
 			// aapt resource value: 0x7F0700DA
-			public const int ic_mr_button_connected_14_light = 2131165402;
+			public const int ic_mr_button_connected_14_dark = 2131165402;
 			
 			// aapt resource value: 0x7F0700DB
-			public const int ic_mr_button_connected_15_dark = 2131165403;
+			public const int ic_mr_button_connected_14_light = 2131165403;
 			
 			// aapt resource value: 0x7F0700DC
-			public const int ic_mr_button_connected_15_light = 2131165404;
+			public const int ic_mr_button_connected_15_dark = 2131165404;
 			
 			// aapt resource value: 0x7F0700DD
-			public const int ic_mr_button_connected_16_dark = 2131165405;
+			public const int ic_mr_button_connected_15_light = 2131165405;
 			
 			// aapt resource value: 0x7F0700DE
-			public const int ic_mr_button_connected_16_light = 2131165406;
+			public const int ic_mr_button_connected_16_dark = 2131165406;
 			
 			// aapt resource value: 0x7F0700DF
-			public const int ic_mr_button_connected_17_dark = 2131165407;
+			public const int ic_mr_button_connected_16_light = 2131165407;
 			
 			// aapt resource value: 0x7F0700E0
-			public const int ic_mr_button_connected_17_light = 2131165408;
+			public const int ic_mr_button_connected_17_dark = 2131165408;
 			
 			// aapt resource value: 0x7F0700E1
-			public const int ic_mr_button_connected_18_dark = 2131165409;
+			public const int ic_mr_button_connected_17_light = 2131165409;
 			
 			// aapt resource value: 0x7F0700E2
-			public const int ic_mr_button_connected_18_light = 2131165410;
+			public const int ic_mr_button_connected_18_dark = 2131165410;
 			
 			// aapt resource value: 0x7F0700E3
-			public const int ic_mr_button_connected_19_dark = 2131165411;
+			public const int ic_mr_button_connected_18_light = 2131165411;
 			
 			// aapt resource value: 0x7F0700E4
-			public const int ic_mr_button_connected_19_light = 2131165412;
+			public const int ic_mr_button_connected_19_dark = 2131165412;
 			
 			// aapt resource value: 0x7F0700E5
-			public const int ic_mr_button_connected_20_dark = 2131165413;
+			public const int ic_mr_button_connected_19_light = 2131165413;
 			
 			// aapt resource value: 0x7F0700E6
-			public const int ic_mr_button_connected_20_light = 2131165414;
+			public const int ic_mr_button_connected_20_dark = 2131165414;
 			
 			// aapt resource value: 0x7F0700E7
-			public const int ic_mr_button_connected_21_dark = 2131165415;
+			public const int ic_mr_button_connected_20_light = 2131165415;
 			
 			// aapt resource value: 0x7F0700E8
-			public const int ic_mr_button_connected_21_light = 2131165416;
+			public const int ic_mr_button_connected_21_dark = 2131165416;
 			
 			// aapt resource value: 0x7F0700E9
-			public const int ic_mr_button_connected_22_dark = 2131165417;
+			public const int ic_mr_button_connected_21_light = 2131165417;
 			
 			// aapt resource value: 0x7F0700EA
-			public const int ic_mr_button_connected_22_light = 2131165418;
+			public const int ic_mr_button_connected_22_dark = 2131165418;
 			
 			// aapt resource value: 0x7F0700EB
-			public const int ic_mr_button_connected_23_dark = 2131165419;
+			public const int ic_mr_button_connected_22_light = 2131165419;
 			
 			// aapt resource value: 0x7F0700EC
-			public const int ic_mr_button_connected_23_light = 2131165420;
+			public const int ic_mr_button_connected_23_dark = 2131165420;
 			
 			// aapt resource value: 0x7F0700ED
-			public const int ic_mr_button_connected_24_dark = 2131165421;
+			public const int ic_mr_button_connected_23_light = 2131165421;
 			
 			// aapt resource value: 0x7F0700EE
-			public const int ic_mr_button_connected_24_light = 2131165422;
+			public const int ic_mr_button_connected_24_dark = 2131165422;
 			
 			// aapt resource value: 0x7F0700EF
-			public const int ic_mr_button_connected_25_dark = 2131165423;
+			public const int ic_mr_button_connected_24_light = 2131165423;
 			
 			// aapt resource value: 0x7F0700F0
-			public const int ic_mr_button_connected_25_light = 2131165424;
+			public const int ic_mr_button_connected_25_dark = 2131165424;
 			
 			// aapt resource value: 0x7F0700F1
-			public const int ic_mr_button_connected_26_dark = 2131165425;
+			public const int ic_mr_button_connected_25_light = 2131165425;
 			
 			// aapt resource value: 0x7F0700F2
-			public const int ic_mr_button_connected_26_light = 2131165426;
+			public const int ic_mr_button_connected_26_dark = 2131165426;
 			
 			// aapt resource value: 0x7F0700F3
-			public const int ic_mr_button_connected_27_dark = 2131165427;
+			public const int ic_mr_button_connected_26_light = 2131165427;
 			
 			// aapt resource value: 0x7F0700F4
-			public const int ic_mr_button_connected_27_light = 2131165428;
+			public const int ic_mr_button_connected_27_dark = 2131165428;
 			
 			// aapt resource value: 0x7F0700F5
-			public const int ic_mr_button_connected_28_dark = 2131165429;
+			public const int ic_mr_button_connected_27_light = 2131165429;
 			
 			// aapt resource value: 0x7F0700F6
-			public const int ic_mr_button_connected_28_light = 2131165430;
+			public const int ic_mr_button_connected_28_dark = 2131165430;
 			
 			// aapt resource value: 0x7F0700F7
-			public const int ic_mr_button_connected_29_dark = 2131165431;
+			public const int ic_mr_button_connected_28_light = 2131165431;
 			
 			// aapt resource value: 0x7F0700F8
-			public const int ic_mr_button_connected_29_light = 2131165432;
+			public const int ic_mr_button_connected_29_dark = 2131165432;
 			
 			// aapt resource value: 0x7F0700F9
-			public const int ic_mr_button_connected_30_dark = 2131165433;
+			public const int ic_mr_button_connected_29_light = 2131165433;
 			
 			// aapt resource value: 0x7F0700FA
-			public const int ic_mr_button_connected_30_light = 2131165434;
+			public const int ic_mr_button_connected_30_dark = 2131165434;
 			
 			// aapt resource value: 0x7F0700FB
-			public const int ic_mr_button_connecting_00_dark = 2131165435;
+			public const int ic_mr_button_connected_30_light = 2131165435;
 			
 			// aapt resource value: 0x7F0700FC
-			public const int ic_mr_button_connecting_00_light = 2131165436;
+			public const int ic_mr_button_connecting_00_dark = 2131165436;
 			
 			// aapt resource value: 0x7F0700FD
-			public const int ic_mr_button_connecting_01_dark = 2131165437;
+			public const int ic_mr_button_connecting_00_light = 2131165437;
 			
 			// aapt resource value: 0x7F0700FE
-			public const int ic_mr_button_connecting_01_light = 2131165438;
+			public const int ic_mr_button_connecting_01_dark = 2131165438;
 			
 			// aapt resource value: 0x7F0700FF
-			public const int ic_mr_button_connecting_02_dark = 2131165439;
+			public const int ic_mr_button_connecting_01_light = 2131165439;
 			
 			// aapt resource value: 0x7F070100
-			public const int ic_mr_button_connecting_02_light = 2131165440;
+			public const int ic_mr_button_connecting_02_dark = 2131165440;
 			
 			// aapt resource value: 0x7F070101
-			public const int ic_mr_button_connecting_03_dark = 2131165441;
+			public const int ic_mr_button_connecting_02_light = 2131165441;
 			
 			// aapt resource value: 0x7F070102
-			public const int ic_mr_button_connecting_03_light = 2131165442;
+			public const int ic_mr_button_connecting_03_dark = 2131165442;
 			
 			// aapt resource value: 0x7F070103
-			public const int ic_mr_button_connecting_04_dark = 2131165443;
+			public const int ic_mr_button_connecting_03_light = 2131165443;
 			
 			// aapt resource value: 0x7F070104
-			public const int ic_mr_button_connecting_04_light = 2131165444;
+			public const int ic_mr_button_connecting_04_dark = 2131165444;
 			
 			// aapt resource value: 0x7F070105
-			public const int ic_mr_button_connecting_05_dark = 2131165445;
+			public const int ic_mr_button_connecting_04_light = 2131165445;
 			
 			// aapt resource value: 0x7F070106
-			public const int ic_mr_button_connecting_05_light = 2131165446;
+			public const int ic_mr_button_connecting_05_dark = 2131165446;
 			
 			// aapt resource value: 0x7F070107
-			public const int ic_mr_button_connecting_06_dark = 2131165447;
+			public const int ic_mr_button_connecting_05_light = 2131165447;
 			
 			// aapt resource value: 0x7F070108
-			public const int ic_mr_button_connecting_06_light = 2131165448;
+			public const int ic_mr_button_connecting_06_dark = 2131165448;
 			
 			// aapt resource value: 0x7F070109
-			public const int ic_mr_button_connecting_07_dark = 2131165449;
+			public const int ic_mr_button_connecting_06_light = 2131165449;
 			
 			// aapt resource value: 0x7F07010A
-			public const int ic_mr_button_connecting_07_light = 2131165450;
+			public const int ic_mr_button_connecting_07_dark = 2131165450;
 			
 			// aapt resource value: 0x7F07010B
-			public const int ic_mr_button_connecting_08_dark = 2131165451;
+			public const int ic_mr_button_connecting_07_light = 2131165451;
 			
 			// aapt resource value: 0x7F07010C
-			public const int ic_mr_button_connecting_08_light = 2131165452;
+			public const int ic_mr_button_connecting_08_dark = 2131165452;
 			
 			// aapt resource value: 0x7F07010D
-			public const int ic_mr_button_connecting_09_dark = 2131165453;
+			public const int ic_mr_button_connecting_08_light = 2131165453;
 			
 			// aapt resource value: 0x7F07010E
-			public const int ic_mr_button_connecting_09_light = 2131165454;
+			public const int ic_mr_button_connecting_09_dark = 2131165454;
 			
 			// aapt resource value: 0x7F07010F
-			public const int ic_mr_button_connecting_10_dark = 2131165455;
+			public const int ic_mr_button_connecting_09_light = 2131165455;
 			
 			// aapt resource value: 0x7F070110
-			public const int ic_mr_button_connecting_10_light = 2131165456;
+			public const int ic_mr_button_connecting_10_dark = 2131165456;
 			
 			// aapt resource value: 0x7F070111
-			public const int ic_mr_button_connecting_11_dark = 2131165457;
+			public const int ic_mr_button_connecting_10_light = 2131165457;
 			
 			// aapt resource value: 0x7F070112
-			public const int ic_mr_button_connecting_11_light = 2131165458;
+			public const int ic_mr_button_connecting_11_dark = 2131165458;
 			
 			// aapt resource value: 0x7F070113
-			public const int ic_mr_button_connecting_12_dark = 2131165459;
+			public const int ic_mr_button_connecting_11_light = 2131165459;
 			
 			// aapt resource value: 0x7F070114
-			public const int ic_mr_button_connecting_12_light = 2131165460;
+			public const int ic_mr_button_connecting_12_dark = 2131165460;
 			
 			// aapt resource value: 0x7F070115
-			public const int ic_mr_button_connecting_13_dark = 2131165461;
+			public const int ic_mr_button_connecting_12_light = 2131165461;
 			
 			// aapt resource value: 0x7F070116
-			public const int ic_mr_button_connecting_13_light = 2131165462;
+			public const int ic_mr_button_connecting_13_dark = 2131165462;
 			
 			// aapt resource value: 0x7F070117
-			public const int ic_mr_button_connecting_14_dark = 2131165463;
+			public const int ic_mr_button_connecting_13_light = 2131165463;
 			
 			// aapt resource value: 0x7F070118
-			public const int ic_mr_button_connecting_14_light = 2131165464;
+			public const int ic_mr_button_connecting_14_dark = 2131165464;
 			
 			// aapt resource value: 0x7F070119
-			public const int ic_mr_button_connecting_15_dark = 2131165465;
+			public const int ic_mr_button_connecting_14_light = 2131165465;
 			
 			// aapt resource value: 0x7F07011A
-			public const int ic_mr_button_connecting_15_light = 2131165466;
+			public const int ic_mr_button_connecting_15_dark = 2131165466;
 			
 			// aapt resource value: 0x7F07011B
-			public const int ic_mr_button_connecting_16_dark = 2131165467;
+			public const int ic_mr_button_connecting_15_light = 2131165467;
 			
 			// aapt resource value: 0x7F07011C
-			public const int ic_mr_button_connecting_16_light = 2131165468;
+			public const int ic_mr_button_connecting_16_dark = 2131165468;
 			
 			// aapt resource value: 0x7F07011D
-			public const int ic_mr_button_connecting_17_dark = 2131165469;
+			public const int ic_mr_button_connecting_16_light = 2131165469;
 			
 			// aapt resource value: 0x7F07011E
-			public const int ic_mr_button_connecting_17_light = 2131165470;
+			public const int ic_mr_button_connecting_17_dark = 2131165470;
 			
 			// aapt resource value: 0x7F07011F
-			public const int ic_mr_button_connecting_18_dark = 2131165471;
+			public const int ic_mr_button_connecting_17_light = 2131165471;
 			
 			// aapt resource value: 0x7F070120
-			public const int ic_mr_button_connecting_18_light = 2131165472;
+			public const int ic_mr_button_connecting_18_dark = 2131165472;
 			
 			// aapt resource value: 0x7F070121
-			public const int ic_mr_button_connecting_19_dark = 2131165473;
+			public const int ic_mr_button_connecting_18_light = 2131165473;
 			
 			// aapt resource value: 0x7F070122
-			public const int ic_mr_button_connecting_19_light = 2131165474;
+			public const int ic_mr_button_connecting_19_dark = 2131165474;
 			
 			// aapt resource value: 0x7F070123
-			public const int ic_mr_button_connecting_20_dark = 2131165475;
+			public const int ic_mr_button_connecting_19_light = 2131165475;
 			
 			// aapt resource value: 0x7F070124
-			public const int ic_mr_button_connecting_20_light = 2131165476;
+			public const int ic_mr_button_connecting_20_dark = 2131165476;
 			
 			// aapt resource value: 0x7F070125
-			public const int ic_mr_button_connecting_21_dark = 2131165477;
+			public const int ic_mr_button_connecting_20_light = 2131165477;
 			
 			// aapt resource value: 0x7F070126
-			public const int ic_mr_button_connecting_21_light = 2131165478;
+			public const int ic_mr_button_connecting_21_dark = 2131165478;
 			
 			// aapt resource value: 0x7F070127
-			public const int ic_mr_button_connecting_22_dark = 2131165479;
+			public const int ic_mr_button_connecting_21_light = 2131165479;
 			
 			// aapt resource value: 0x7F070128
-			public const int ic_mr_button_connecting_22_light = 2131165480;
+			public const int ic_mr_button_connecting_22_dark = 2131165480;
 			
 			// aapt resource value: 0x7F070129
-			public const int ic_mr_button_connecting_23_dark = 2131165481;
+			public const int ic_mr_button_connecting_22_light = 2131165481;
 			
 			// aapt resource value: 0x7F07012A
-			public const int ic_mr_button_connecting_23_light = 2131165482;
+			public const int ic_mr_button_connecting_23_dark = 2131165482;
 			
 			// aapt resource value: 0x7F07012B
-			public const int ic_mr_button_connecting_24_dark = 2131165483;
+			public const int ic_mr_button_connecting_23_light = 2131165483;
 			
 			// aapt resource value: 0x7F07012C
-			public const int ic_mr_button_connecting_24_light = 2131165484;
+			public const int ic_mr_button_connecting_24_dark = 2131165484;
 			
 			// aapt resource value: 0x7F07012D
-			public const int ic_mr_button_connecting_25_dark = 2131165485;
+			public const int ic_mr_button_connecting_24_light = 2131165485;
 			
 			// aapt resource value: 0x7F07012E
-			public const int ic_mr_button_connecting_25_light = 2131165486;
+			public const int ic_mr_button_connecting_25_dark = 2131165486;
 			
 			// aapt resource value: 0x7F07012F
-			public const int ic_mr_button_connecting_26_dark = 2131165487;
+			public const int ic_mr_button_connecting_25_light = 2131165487;
 			
 			// aapt resource value: 0x7F070130
-			public const int ic_mr_button_connecting_26_light = 2131165488;
+			public const int ic_mr_button_connecting_26_dark = 2131165488;
 			
 			// aapt resource value: 0x7F070131
-			public const int ic_mr_button_connecting_27_dark = 2131165489;
+			public const int ic_mr_button_connecting_26_light = 2131165489;
 			
 			// aapt resource value: 0x7F070132
-			public const int ic_mr_button_connecting_27_light = 2131165490;
+			public const int ic_mr_button_connecting_27_dark = 2131165490;
 			
 			// aapt resource value: 0x7F070133
-			public const int ic_mr_button_connecting_28_dark = 2131165491;
+			public const int ic_mr_button_connecting_27_light = 2131165491;
 			
 			// aapt resource value: 0x7F070134
-			public const int ic_mr_button_connecting_28_light = 2131165492;
+			public const int ic_mr_button_connecting_28_dark = 2131165492;
 			
 			// aapt resource value: 0x7F070135
-			public const int ic_mr_button_connecting_29_dark = 2131165493;
+			public const int ic_mr_button_connecting_28_light = 2131165493;
 			
 			// aapt resource value: 0x7F070136
-			public const int ic_mr_button_connecting_29_light = 2131165494;
+			public const int ic_mr_button_connecting_29_dark = 2131165494;
 			
 			// aapt resource value: 0x7F070137
-			public const int ic_mr_button_connecting_30_dark = 2131165495;
+			public const int ic_mr_button_connecting_29_light = 2131165495;
 			
 			// aapt resource value: 0x7F070138
-			public const int ic_mr_button_connecting_30_light = 2131165496;
+			public const int ic_mr_button_connecting_30_dark = 2131165496;
 			
 			// aapt resource value: 0x7F070139
-			public const int ic_mr_button_disabled_dark = 2131165497;
+			public const int ic_mr_button_connecting_30_light = 2131165497;
 			
 			// aapt resource value: 0x7F07013A
-			public const int ic_mr_button_disabled_light = 2131165498;
+			public const int ic_mr_button_disabled_dark = 2131165498;
 			
 			// aapt resource value: 0x7F07013B
-			public const int ic_mr_button_disconnected_dark = 2131165499;
+			public const int ic_mr_button_disabled_light = 2131165499;
 			
 			// aapt resource value: 0x7F07013C
-			public const int ic_mr_button_disconnected_light = 2131165500;
+			public const int ic_mr_button_disconnected_dark = 2131165500;
 			
 			// aapt resource value: 0x7F07013D
-			public const int ic_mr_button_grey = 2131165501;
+			public const int ic_mr_button_disconnected_light = 2131165501;
 			
 			// aapt resource value: 0x7F07013E
-			public const int ic_mtrl_chip_checked_black = 2131165502;
+			public const int ic_mr_button_grey = 2131165502;
 			
 			// aapt resource value: 0x7F07013F
-			public const int ic_mtrl_chip_checked_circle = 2131165503;
+			public const int ic_mtrl_chip_checked_black = 2131165503;
 			
 			// aapt resource value: 0x7F070140
-			public const int ic_mtrl_chip_close_circle = 2131165504;
+			public const int ic_mtrl_chip_checked_circle = 2131165504;
 			
 			// aapt resource value: 0x7F070141
-			public const int ic_successstatus = 2131165505;
+			public const int ic_mtrl_chip_close_circle = 2131165505;
 			
 			// aapt resource value: 0x7F070142
-			public const int ic_unchecked_checkbox = 2131165506;
+			public const int ic_successstatus = 2131165506;
 			
 			// aapt resource value: 0x7F070143
-			public const int ic_vol_mute = 2131165507;
+			public const int ic_unchecked_checkbox = 2131165507;
 			
 			// aapt resource value: 0x7F070144
-			public const int ic_vol_type_speaker_dark = 2131165508;
+			public const int ic_vol_mute = 2131165508;
 			
 			// aapt resource value: 0x7F070145
-			public const int ic_vol_type_speaker_group_dark = 2131165509;
+			public const int ic_vol_type_speaker_dark = 2131165509;
 			
 			// aapt resource value: 0x7F070146
-			public const int ic_vol_type_speaker_group_light = 2131165510;
+			public const int ic_vol_type_speaker_group_dark = 2131165510;
 			
 			// aapt resource value: 0x7F070147
-			public const int ic_vol_type_speaker_light = 2131165511;
+			public const int ic_vol_type_speaker_group_light = 2131165511;
 			
 			// aapt resource value: 0x7F070148
-			public const int ic_vol_type_tv_dark = 2131165512;
+			public const int ic_vol_type_speaker_light = 2131165512;
 			
 			// aapt resource value: 0x7F070149
-			public const int ic_vol_type_tv_light = 2131165513;
+			public const int ic_vol_type_tv_dark = 2131165513;
 			
 			// aapt resource value: 0x7F07014A
-			public const int ic_vol_unmute = 2131165514;
+			public const int ic_vol_type_tv_light = 2131165514;
 			
 			// aapt resource value: 0x7F07014B
-			public const int InfoMark = 2131165515;
+			public const int ic_vol_unmute = 2131165515;
 			
 			// aapt resource value: 0x7F07014C
-			public const int Logo = 2131165516;
+			public const int InfoMark = 2131165516;
 			
 			// aapt resource value: 0x7F07014D
-			public const int MaterialActivityIndicatorBackground = 2131165517;
+			public const int Logo = 2131165517;
 			
 			// aapt resource value: 0x7F07014E
-			public const int MaterialProgressBar = 2131165518;
+			public const int MaterialActivityIndicatorBackground = 2131165518;
 			
 			// aapt resource value: 0x7F07014F
-			public const int mr_button_connected_dark = 2131165519;
+			public const int MaterialProgressBar = 2131165519;
 			
 			// aapt resource value: 0x7F070150
-			public const int mr_button_connected_light = 2131165520;
+			public const int mr_button_connected_dark = 2131165520;
 			
 			// aapt resource value: 0x7F070151
-			public const int mr_button_connecting_dark = 2131165521;
+			public const int mr_button_connected_light = 2131165521;
 			
 			// aapt resource value: 0x7F070152
-			public const int mr_button_connecting_light = 2131165522;
+			public const int mr_button_connecting_dark = 2131165522;
 			
 			// aapt resource value: 0x7F070153
-			public const int mr_button_dark = 2131165523;
+			public const int mr_button_connecting_light = 2131165523;
 			
 			// aapt resource value: 0x7F070154
-			public const int mr_button_dark_static = 2131165524;
+			public const int mr_button_dark = 2131165524;
 			
 			// aapt resource value: 0x7F070155
-			public const int mr_button_light = 2131165525;
+			public const int mr_button_dark_static = 2131165525;
 			
 			// aapt resource value: 0x7F070156
-			public const int mr_button_light_static = 2131165526;
+			public const int mr_button_light = 2131165526;
 			
 			// aapt resource value: 0x7F070157
-			public const int mr_cast_checkbox = 2131165527;
+			public const int mr_button_light_static = 2131165527;
 			
 			// aapt resource value: 0x7F070158
-			public const int mr_cast_group_seekbar_track = 2131165528;
+			public const int mr_cast_checkbox = 2131165528;
 			
 			// aapt resource value: 0x7F070159
-			public const int mr_cast_mute_button = 2131165529;
+			public const int mr_cast_group_seekbar_track = 2131165529;
 			
 			// aapt resource value: 0x7F07015A
-			public const int mr_cast_route_seekbar_track = 2131165530;
+			public const int mr_cast_mute_button = 2131165530;
 			
 			// aapt resource value: 0x7F07015B
-			public const int mr_cast_stop = 2131165531;
+			public const int mr_cast_route_seekbar_track = 2131165531;
 			
 			// aapt resource value: 0x7F07015C
-			public const int mr_cast_thumb = 2131165532;
+			public const int mr_cast_stop = 2131165532;
 			
 			// aapt resource value: 0x7F07015D
-			public const int mr_dialog_close_dark = 2131165533;
+			public const int mr_cast_thumb = 2131165533;
 			
 			// aapt resource value: 0x7F07015E
-			public const int mr_dialog_close_light = 2131165534;
+			public const int mr_dialog_close_dark = 2131165534;
 			
 			// aapt resource value: 0x7F07015F
-			public const int mr_dialog_material_background_dark = 2131165535;
+			public const int mr_dialog_close_light = 2131165535;
 			
 			// aapt resource value: 0x7F070160
-			public const int mr_dialog_material_background_light = 2131165536;
+			public const int mr_dialog_material_background_dark = 2131165536;
 			
 			// aapt resource value: 0x7F070161
-			public const int mr_group_collapse = 2131165537;
+			public const int mr_dialog_material_background_light = 2131165537;
 			
 			// aapt resource value: 0x7F070162
-			public const int mr_group_expand = 2131165538;
+			public const int mr_group_collapse = 2131165538;
 			
 			// aapt resource value: 0x7F070163
-			public const int mr_media_pause_dark = 2131165539;
+			public const int mr_group_expand = 2131165539;
 			
 			// aapt resource value: 0x7F070164
-			public const int mr_media_pause_light = 2131165540;
+			public const int mr_media_pause_dark = 2131165540;
 			
 			// aapt resource value: 0x7F070165
-			public const int mr_media_play_dark = 2131165541;
+			public const int mr_media_pause_light = 2131165541;
 			
 			// aapt resource value: 0x7F070166
-			public const int mr_media_play_light = 2131165542;
+			public const int mr_media_play_dark = 2131165542;
 			
 			// aapt resource value: 0x7F070167
-			public const int mr_media_stop_dark = 2131165543;
+			public const int mr_media_play_light = 2131165543;
 			
 			// aapt resource value: 0x7F070168
-			public const int mr_media_stop_light = 2131165544;
+			public const int mr_media_stop_dark = 2131165544;
 			
 			// aapt resource value: 0x7F070169
-			public const int mr_vol_type_audiotrack_dark = 2131165545;
+			public const int mr_media_stop_light = 2131165545;
 			
 			// aapt resource value: 0x7F07016A
-			public const int mr_vol_type_audiotrack_light = 2131165546;
+			public const int mr_vol_type_audiotrack_dark = 2131165546;
 			
 			// aapt resource value: 0x7F07016B
-			public const int mtrl_snackbar_background = 2131165547;
+			public const int mr_vol_type_audiotrack_light = 2131165547;
 			
 			// aapt resource value: 0x7F07016C
-			public const int mtrl_tabs_default_indicator = 2131165548;
+			public const int mtrl_snackbar_background = 2131165548;
 			
 			// aapt resource value: 0x7F07016D
-			public const int navigation_empty_icon = 2131165549;
+			public const int mtrl_tabs_default_indicator = 2131165549;
 			
 			// aapt resource value: 0x7F07016E
-			public const int Nocontact10 = 2131165550;
+			public const int navigation_empty_icon = 2131165550;
 			
 			// aapt resource value: 0x7F07016F
-			public const int notification_action_background = 2131165551;
+			public const int Nocontact10 = 2131165551;
 			
 			// aapt resource value: 0x7F070170
-			public const int notification_bg = 2131165552;
+			public const int notification_action_background = 2131165552;
 			
 			// aapt resource value: 0x7F070171
-			public const int notification_bg_low = 2131165553;
+			public const int notification_bg = 2131165553;
 			
 			// aapt resource value: 0x7F070172
-			public const int notification_bg_low_normal = 2131165554;
+			public const int notification_bg_low = 2131165554;
 			
 			// aapt resource value: 0x7F070173
-			public const int notification_bg_low_pressed = 2131165555;
+			public const int notification_bg_low_normal = 2131165555;
 			
 			// aapt resource value: 0x7F070174
-			public const int notification_bg_normal = 2131165556;
+			public const int notification_bg_low_pressed = 2131165556;
 			
 			// aapt resource value: 0x7F070175
-			public const int notification_bg_normal_pressed = 2131165557;
+			public const int notification_bg_normal = 2131165557;
 			
 			// aapt resource value: 0x7F070176
-			public const int notification_icon_background = 2131165558;
+			public const int notification_bg_normal_pressed = 2131165558;
 			
 			// aapt resource value: 0x7F070177
-			public const int notification_template_icon_bg = 2131165559;
+			public const int notification_icon_background = 2131165559;
 			
 			// aapt resource value: 0x7F070178
-			public const int notification_template_icon_low_bg = 2131165560;
+			public const int notification_template_icon_bg = 2131165560;
 			
 			// aapt resource value: 0x7F070179
-			public const int notification_tile_bg = 2131165561;
+			public const int notification_template_icon_low_bg = 2131165561;
 			
 			// aapt resource value: 0x7F07017A
-			public const int notify_panel_notification_icon_bg = 2131165562;
+			public const int notification_tile_bg = 2131165562;
 			
 			// aapt resource value: 0x7F07017B
-			public const int roundedbg = 2131165563;
+			public const int notify_panel_notification_icon_bg = 2131165563;
 			
 			// aapt resource value: 0x7F07017C
-			public const int roundedbgdark = 2131165564;
-			
-			// aapt resource value: 0x7F07017E
-			public const int SplashImg = 2131165566;
-			
-			// aapt resource value: 0x7F07017F
-			public const int SplashPage10 = 2131165567;
-			
-			// aapt resource value: 0x7F070180
-			public const int SplashPage11 = 2131165568;
+			public const int privacypolicy_img01 = 2131165564;
 			
 			// aapt resource value: 0x7F07017D
-			public const int splash_screen = 2131165565;
+			public const int roundedbg = 2131165565;
+			
+			// aapt resource value: 0x7F07017E
+			public const int roundedbgdark = 2131165566;
+			
+			// aapt resource value: 0x7F070180
+			public const int SplashImg = 2131165568;
 			
 			// aapt resource value: 0x7F070181
-			public const int tooltip_frame_dark = 2131165569;
+			public const int SplashPage10 = 2131165569;
 			
 			// aapt resource value: 0x7F070182
-			public const int tooltip_frame_light = 2131165570;
+			public const int SplashPage11 = 2131165570;
+			
+			// aapt resource value: 0x7F07017F
+			public const int splash_screen = 2131165567;
 			
 			// aapt resource value: 0x7F070183
-			public const int TutorialPage10 = 2131165571;
+			public const int tooltip_frame_dark = 2131165571;
 			
 			// aapt resource value: 0x7F070184
-			public const int TutorialPage11 = 2131165572;
+			public const int tooltip_frame_light = 2131165572;
 			
 			// aapt resource value: 0x7F070185
-			public const int TutorialPage12 = 2131165573;
+			public const int TutorialPage10 = 2131165573;
 			
 			// aapt resource value: 0x7F070186
-			public const int TutorialPage20 = 2131165574;
+			public const int TutorialPage11 = 2131165574;
 			
 			// aapt resource value: 0x7F070187
-			public const int TutorialPage40 = 2131165575;
+			public const int TutorialPage12 = 2131165575;
 			
 			// aapt resource value: 0x7F070188
-			public const int TutorialPage50 = 2131165576;
+			public const int TutorialPage20 = 2131165576;
 			
 			// aapt resource value: 0x7F070189
-			public const int TutorialPage60 = 2131165577;
+			public const int TutorialPage40 = 2131165577;
+			
+			// aapt resource value: 0x7F07018A
+			public const int TutorialPage50 = 2131165578;
+			
+			// aapt resource value: 0x7F07018B
+			public const int TutorialPage60 = 2131165579;
 			
 			static Drawable()
 			{
@@ -23869,7 +24174,10 @@ namespace Covid19Radar.Droid
 		{
 			
 			// aapt resource value: 0x7F100000
-			public const int xamarin_essentials_fileprovider_file_paths = 2131755008;
+			public const int backup_settings = 2131755008;
+			
+			// aapt resource value: 0x7F100001
+			public const int xamarin_essentials_fileprovider_file_paths = 2131755009;
 			
 			static Xml()
 			{

--- a/Covid19Radar/Covid19Radar.iOS/Covid19Radar.iOS.csproj
+++ b/Covid19Radar/Covid19Radar.iOS/Covid19Radar.iOS.csproj
@@ -537,7 +537,7 @@
       <Version>4.6.0.967</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.iOS.ExposureNotification">
-      <Version>1.1.0-beta1</Version>
+      <Version>1.2.2-preview1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.iOS.MaterialComponents">
       <Version>92.0.0</Version>
@@ -547,10 +547,6 @@
     <ProjectReference Include="..\Covid19Radar\Covid19Radar.csproj">
       <Project>{554EE1AB-B447-480C-90E5-C4F040891DE6}</Project>
       <Name>Covid19Radar</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Xamarin.ExposureNotification\Xamarin.ExposureNotification.csproj">
-      <Project>{83af4c2e-22f8-4dab-b993-be6abb3e56a1}</Project>
-      <Name>Xamarin.ExposureNotification</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
@@ -1347,10 +1343,7 @@
     <EmbeddedResource Include="NotoSansCJKjp-Regular.otf" />
     <EmbeddedResource Include="Roboto-Regular.ttf" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Services\Logs\" />
-    <Folder Include="Renderers\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>

--- a/Covid19Radar/Covid19Radar.iOS/Covid19Radar.iOS.csproj
+++ b/Covid19Radar/Covid19Radar.iOS/Covid19Radar.iOS.csproj
@@ -506,25 +506,22 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Acr.UserDialogs">
-      <Version>7.1.0.442</Version>
+      <Version>7.1.0.475</Version>
     </PackageReference>
     <PackageReference Include="Google.Protobuf">
-      <Version>3.12.3</Version>
-    </PackageReference>
-    <PackageReference Include="Prism.Autofac.Forms">
-      <Version>7.1.0.431</Version>
+      <Version>3.15.2</Version>
     </PackageReference>
     <PackageReference Include="Prism.Core">
-      <Version>7.2.0.1422</Version>
+      <Version>8.0.0.1909</Version>
     </PackageReference>
     <PackageReference Include="Prism.DryIoc.Forms">
-      <Version>7.2.0.1422</Version>
+      <Version>8.0.0.1909</Version>
     </PackageReference>
     <PackageReference Include="Prism.Forms">
-      <Version>7.2.0.1422</Version>
+      <Version>8.0.0.1909</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Essentials">
-      <Version>1.5.3.2</Version>
+      <Version>1.6.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.FFImageLoading">
       <Version>2.4.11.982</Version>
@@ -532,9 +529,9 @@
     <PackageReference Include="Xamarin.FFImageLoading.Forms">
       <Version>2.4.11.982</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="4.6.0.967" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
     <PackageReference Include="Xamarin.Forms.Visual.Material">
-      <Version>4.6.0.967</Version>
+      <Version>5.0.0.2012</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.iOS.ExposureNotification">
       <Version>1.2.2-preview1</Version>

--- a/Covid19Radar/Covid19Radar/Covid19Radar.csproj
+++ b/Covid19Radar/Covid19Radar/Covid19Radar.csproj
@@ -104,19 +104,20 @@
     <EmbeddedResource Include="Resources\Fonts\Roboto-Regular.ttf" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Acr.UserDialogs" Version="7.1.0.442" />
+    <PackageReference Include="Acr.UserDialogs" Version="7.1.0.475" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Prism.DryIoc.Forms" Version="7.2.0.1422" />
-    <PackageReference Include="Prism.Forms" Version="7.2.0.1422" />
-    <PackageReference Include="Prism.Plugin.Logging.AppCenter" Version="7.2.0.1114" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
+    <PackageReference Include="Prism.DryIoc.Forms" Version="8.0.0.1909" />
+    <PackageReference Include="Prism.Forms" Version="8.0.0.1909" />
+    <PackageReference Include="Prism.Plugin.Logging.Abstractions" Version="8.0.11-beta" />
+    <PackageReference Include="Prism.Plugin.Logging.AppCenter" Version="8.0.11-beta" />
+    <PackageReference Include="Prism.Plugin.Logging.Common" Version="8.0.11-beta" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
     <PackageReference Include="Xamarin.ExposureNotification" Version="0.15.0-preview" />
     <PackageReference Include="Xamarin.FFImageLoading" Version="2.4.11.982" />
     <PackageReference Include="Xamarin.FFImageLoading.Forms" Version="2.4.11.982" />
-    <PackageReference Include="Xamarin.Forms" Version="4.6.0.967" />
-    <PackageReference Include="Xamarin.Forms.BehaviorValidationPack" Version="1.1.0" />
-    <PackageReference Include="Xamarin.Forms.Visual.Material" Version="4.6.0.967" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
+    <PackageReference Include="Xamarin.Forms.Visual.Material" Version="5.0.0.2012" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.8.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Controls\CustomDatePicker.cs" />

--- a/Covid19Radar/Covid19Radar/Covid19Radar.csproj
+++ b/Covid19Radar/Covid19Radar/Covid19Radar.csproj
@@ -110,6 +110,7 @@
     <PackageReference Include="Prism.Forms" Version="7.2.0.1422" />
     <PackageReference Include="Prism.Plugin.Logging.AppCenter" Version="7.2.0.1114" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
+    <PackageReference Include="Xamarin.ExposureNotification" Version="0.15.0-preview" />
     <PackageReference Include="Xamarin.FFImageLoading" Version="2.4.11.982" />
     <PackageReference Include="Xamarin.FFImageLoading.Forms" Version="2.4.11.982" />
     <PackageReference Include="Xamarin.Forms" Version="4.6.0.967" />
@@ -195,9 +196,6 @@
     <Folder Include="Image\" />
     <Folder Include="Services\Logs\" />
     <Folder Include="Controls\" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Xamarin.ExposureNotification\Xamarin.ExposureNotification.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Image\ic_hamburger.png">

--- a/Covid19Radar/Covid19Radar/Services/DebugLogger.cs
+++ b/Covid19Radar/Covid19Radar/Services/DebugLogger.cs
@@ -1,11 +1,12 @@
 ﻿using FFImageLoading.Helpers;
 using Prism.Logging;
 using System;
+using System.Collections.Generic;
 using static System.Diagnostics.Debug;
 
 namespace Covid19Radar.Services
 {
-    public class DebugLogger : ILoggerFacade, IMiniLogger
+    public class DebugLogger : ConsoleLoggingService , IMiniLogger
     {
         public void Debug(string message) =>
             WriteLine($"Debug: {message}");
@@ -16,7 +17,13 @@ namespace Covid19Radar.Services
         public void Error(string errorMessage, Exception ex) =>
             WriteLine($"Error: {errorMessage}\n{ex.GetType().Name}: {ex}");
 
+        // Prism 8
+        // BREAKING Removed ILoggerFacade and entire Prism.Logging namespace - recommended migration use Prism.Plugin.Logging or other 3rd party logging frameworks
+        // Recoomend solutoin Prism.Plugin.Logging
+        // https://github.com/dansiegel/Prism.Plugin.Logging/blob/d54217be59973f1ea7021c16014ca9aed265ae77/src/Prism.Plugin.Logging.Abstractions/ConsoleLoggingService.cs
+        /*
         public void Log(string message, Category category, Priority priority) =>
             WriteLine($"{category} - {priority}: {message}");
+        */
     }
 }

--- a/Covid19Radar/Covid19Radar/Views/HomePage/NotifyOtherPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/NotifyOtherPage.xaml
@@ -3,11 +3,11 @@
     x:Class="Covid19Radar.Views.NotifyOtherPage"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:common="clr-namespace:Covid19Radar.Common"
+    xmlns:controls="clr-namespace:Covid19Radar.Controls"
     xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
     xmlns:prism="http://prismlibrary.com"
     xmlns:resources="clr-namespace:Covid19Radar.Resources"
-    xmlns:common="clr-namespace:Covid19Radar.Common"
-    xmlns:controls="clr-namespace:Covid19Radar.Controls"
     Title="{x:Static resources:AppResources.NotifyOtherPageTitle}"
     ios:Page.UseSafeArea="true"
     prism:ViewModelLocator.AutowireViewModel="True"
@@ -20,79 +20,85 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <StackLayout Grid.Row="0">
-                <Label Margin="0, 0, 0, 10"
-                       Style="{StaticResource DefaultLabel}"
-                       Text="{x:Static resources:AppResources.NotifyOtherPageDescription1}" />
-                <Label Margin="0, 0, 0, 10"
-                       Style="{StaticResource DefaultLabelSmall}"
-                       Text="{x:Static resources:AppResources.NotifyOtherPageDescription2}" />
+                <Label
+                    Margin="0,0,0,10"
+                    Style="{StaticResource DefaultLabel}"
+                    Text="{x:Static resources:AppResources.NotifyOtherPageDescription1}" />
+                <Label
+                    Margin="0,0,0,10"
+                    Style="{StaticResource DefaultLabelSmall}"
+                    Text="{x:Static resources:AppResources.NotifyOtherPageDescription2}" />
                 <StackLayout Orientation="Horizontal" Spacing="30">
-                    <RadioButton TextColor="Black"
-                                 FontSize="Medium"
-                                 CheckedChanged="OnRadioButtonCheckedChanged"
-                                 Text="{x:Static resources:AppResources.NotifyOtherPageRadioButtonYes}"
-                                 GroupName="CheckSymptoms" />
-                    <RadioButton TextColor="Black"
-                                 FontSize="Medium"
-                                 CheckedChanged="OnRadioButtonCheckedChanged"
-                                 Text="{x:Static resources:AppResources.NotifyOtherPageRadioButtonNo}"
-                                 GroupName="CheckSymptoms" />
+                    <RadioButton
+                        CheckedChanged="OnRadioButtonCheckedChanged"
+                        Content="{x:Static resources:AppResources.NotifyOtherPageRadioButtonYes}"
+                        FontSize="Medium"
+                        GroupName="CheckSymptoms"
+                        TextColor="Black" />
+                    <RadioButton
+                        CheckedChanged="OnRadioButtonCheckedChanged"
+                        Content="{x:Static resources:AppResources.NotifyOtherPageRadioButtonNo}"
+                        FontSize="Medium"
+                        GroupName="CheckSymptoms"
+                        TextColor="Black" />
                 </StackLayout>
-                <StackLayout Margin="0, 15, 0, 0"
-                             IsVisible="{Binding IsVisibleWithSymptomsLayout}">
-                    <Label Style="{StaticResource DefaultLabel}"
-                           Text="{x:Static resources:AppResources.NotifyOtherPageWithSymptomsDescription1}" />
-                    <StackLayout Spacing="0"
-                                 Margin="0, 5, 0, 10">
-                        <Frame Padding="0"
-                               BackgroundColor="#CECECE"
-                               CornerRadius="7"
-                               HasShadow="False"
-                               HorizontalOptions="FillAndExpand">
-                            <Frame Margin="3"
-                                   Padding="0"
-                                   BackgroundColor="White"
-                                   CornerRadius="5"
-                                   HasShadow="False">
-                                <controls:CustomDatePicker MaximumDate="{x:Static x:DateTime.Now}"
-                                                           BackgroundColor="White"
-                                                           Format="d"
-                                                           Date="{Binding DiagnosisDate}"/>
+                <StackLayout Margin="0,15,0,0" IsVisible="{Binding IsVisibleWithSymptomsLayout}">
+                    <Label Style="{StaticResource DefaultLabel}" Text="{x:Static resources:AppResources.NotifyOtherPageWithSymptomsDescription1}" />
+                    <StackLayout Margin="0,5,0,10" Spacing="0">
+                        <Frame
+                            Padding="0"
+                            BackgroundColor="#CECECE"
+                            CornerRadius="7"
+                            HasShadow="False"
+                            HorizontalOptions="FillAndExpand">
+                            <Frame
+                                Margin="3"
+                                Padding="0"
+                                BackgroundColor="White"
+                                CornerRadius="5"
+                                HasShadow="False">
+                                <controls:CustomDatePicker
+                                    BackgroundColor="White"
+                                    Date="{Binding DiagnosisDate}"
+                                    Format="d"
+                                    MaximumDate="{x:Static x:DateTime.Now}" />
                             </Frame>
                         </Frame>
                     </StackLayout>
                 </StackLayout>
-                <StackLayout Margin="0, 15, 0, 0"
-                             IsVisible="{Binding IsVisibleNoSymptomsLayout}">
-                    <Label Style="{StaticResource DefaultLabel}"
-                           Text="{x:Static resources:AppResources.NotifyOtherPageNoSymptomsDescription1}" />
-                    <StackLayout Spacing="0"
-                                 Margin="0, 5, 0, 10">
-                        <Frame Padding="0"
-                               BackgroundColor="#CECECE"
-                               CornerRadius="7"
-                               HasShadow="False"
-                               HorizontalOptions="FillAndExpand">
-                            <Frame Margin="3"
-                                   Padding="0"
-                                   BackgroundColor="White"
-                                   CornerRadius="5"
-                                   HasShadow="False">
-                                <controls:CustomDatePicker MaximumDate="{x:Static x:DateTime.Now}"
-                                                           BackgroundColor="White"
-                                                           Format="d"
-                                                           Date="{Binding DiagnosisDate}"/>
+                <StackLayout Margin="0,15,0,0" IsVisible="{Binding IsVisibleNoSymptomsLayout}">
+                    <Label Style="{StaticResource DefaultLabel}" Text="{x:Static resources:AppResources.NotifyOtherPageNoSymptomsDescription1}" />
+                    <StackLayout Margin="0,5,0,10" Spacing="0">
+                        <Frame
+                            Padding="0"
+                            BackgroundColor="#CECECE"
+                            CornerRadius="7"
+                            HasShadow="False"
+                            HorizontalOptions="FillAndExpand">
+                            <Frame
+                                Margin="3"
+                                Padding="0"
+                                BackgroundColor="White"
+                                CornerRadius="5"
+                                HasShadow="False">
+                                <controls:CustomDatePicker
+                                    BackgroundColor="White"
+                                    Date="{Binding DiagnosisDate}"
+                                    Format="d"
+                                    MaximumDate="{x:Static x:DateTime.Now}" />
                             </Frame>
                         </Frame>
                     </StackLayout>
                 </StackLayout>
-                <Label Margin="0, 15, 0, 0"
-                       Style="{StaticResource DefaultLabel}"
-                       Text="{x:Static resources:AppResources.NotifyOtherPageDescription3}" />
-                <Label Margin="0, 0, 0, 5"
-                       HorizontalOptions="Start"
-                       Style="{StaticResource DefaultLabelColor}"
-                       Text="{x:Static resources:AppResources.NotifyOtherPageLabel}">
+                <Label
+                    Margin="0,15,0,0"
+                    Style="{StaticResource DefaultLabel}"
+                    Text="{x:Static resources:AppResources.NotifyOtherPageDescription3}" />
+                <Label
+                    Margin="0,0,0,5"
+                    HorizontalOptions="Start"
+                    Style="{StaticResource DefaultLabelColor}"
+                    Text="{x:Static resources:AppResources.NotifyOtherPageLabel}">
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer Command="{prism:NavigateTo 'HelpPage3'}" />
                     </Label.GestureRecognizers>
@@ -126,13 +132,13 @@
                         BackgroundColor="#FFF3DD"
                         CornerRadius="10">
                         <StackLayout Spacing="10">
-                            <Label FontSize="Medium"
-                                   FontAttributes="Bold"
-                                   TextColor="Black"
-                                   Text="{x:Static resources:AppResources.NotifyOtherPageDescription4}"/>
+                            <Label
+                                FontAttributes="Bold"
+                                FontSize="Medium"
+                                Text="{x:Static resources:AppResources.NotifyOtherPageDescription4}"
+                                TextColor="Black" />
                             <Label Style="{StaticResource DefaultLabel}" Text="{x:Static resources:AppResources.NotifyOtherPageDescription5}" />
-                            <Label Style="{StaticResource DefaultLabelSmall}"
-                                   Text="{x:Static resources:AppResources.NotifyOtherPageDescription6}" />
+                            <Label Style="{StaticResource DefaultLabelSmall}" Text="{x:Static resources:AppResources.NotifyOtherPageDescription6}" />
                         </StackLayout>
                     </Frame>
                 </StackLayout>

--- a/Covid19Radar/Covid19Radar/Views/HomePage/NotifyOtherPage.xaml.cs
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/NotifyOtherPage.xaml.cs
@@ -17,7 +17,8 @@ namespace Covid19Radar.Views
             var button = (RadioButton)sender;
             if (button.IsChecked)
             {
-                (BindingContext as NotifyOtherPageViewModel).OnClickRadioButtonIsTrueCommand(button.Text);
+                // Xamarin Forms 5 change Text to Content Prop
+                (BindingContext as NotifyOtherPageViewModel).OnClickRadioButtonIsTrueCommand(button.Content.ToString());
             }
         }
     }

--- a/Covid19Radar/Tests/Covid19Radar.UITest/Covid19Radar.UITest.csproj
+++ b/Covid19Radar/Tests/Covid19Radar.UITest/Covid19Radar.UITest.csproj
@@ -52,21 +52,21 @@
       <Version>12.0.3</Version>
     </PackageReference>
     <PackageReference Include="Shouldly">
-      <Version>3.0.2</Version>
+      <Version>4.0.3</Version>
     </PackageReference>
     <PackageReference Include="SpecFlow.NUnit">
-      <Version>3.1.97</Version>
+      <Version>3.7.13</Version>
     </PackageReference>
     <PackageReference Include="SpecFlow.Tools.MsBuild.Generation">
-      <Version>3.1.97</Version>
+      <Version>3.7.13</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.UITest" Version="3.0.7" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+    <PackageReference Include="Xamarin.UITest" Version="3.0.14" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Xamariners.EndToEnd.Xamarin">
-      <Version>0.0.8</Version>
+      <Version>0.0.9</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Covid19Radar.UnitTests.csproj
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Covid19Radar.UnitTests.csproj
@@ -7,17 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="coverlet.collector" Version="3.0.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
-    <PackageReference Include="Moq" Version="4.15.1" />
-    <PackageReference Include="Microsoft.CodeCoverage" Version="16.8.0" />
-    <PackageReference Include="Xamarin.Forms.Mocks" Version="4.6.0.1" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Microsoft.CodeCoverage" Version="16.9.1" />
+    <PackageReference Include="Xamarin.Forms.Mocks" Version="4.7.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Purpose
Exposure Notificationライブラリと各OSのネイティブバインディングのアップデートをご検討ください。
EN v2対応なども枯れています。

なお、Denmark/NorwayのXamarin EN実装(Smittestopp)を見る限り、最新版のバインディングをテスト中と思われます。
https://github.com/folkehelseinstituttet/Fhi.Smittestopp.App

## Does this introduce a breaking change?
ライブラリのみで、v1 APIの場合、インターフェイスなどは変更がありませんが十分にテストされる事をお勧めします。
```
[X] Yes
[] No
```
## Pull Request Type
ライブラリBugのPatch対応の為、プロジェクトとして取り込まれていた古いライブラリ参照の削除
Xamarin.Forms / Android / iOSそれぞれでのnugetでの最新ライブラリの参照

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
ビルドまでは確認していますが、実機動作までは証明書や環境変数などの都合によりテストができておりません。

* Test the code
試験的にマージして、ビルドしてみてください。

## Other Information
Denmark Fhi.Smittestopp.App
https://github.com/folkehelseinstituttet/Fhi.Smittestopp.App
Xplat Lib https://github.com/xamarin/XamarinComponents/tree/master/XPlat/ExposureNotification
Android Native Binding https://github.com/xamarin/XamarinComponents/tree/master/Android/ExposureNotification
iOS Native Binding https://github.com/xamarin/XamarinComponents/tree/master/iOS/ExposureNotification
