### PR TITLE
Fix issue that background task doesn't work in Android.

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/MainApplication.cs
+++ b/Covid19Radar/Covid19Radar.Android/MainApplication.cs
@@ -24,5 +24,17 @@ namespace Covid19Radar.Droid
         public MainApplication(IntPtr handle, JniHandleOwnership transfer) : base(handle, transfer)
         {
         }
+
+        public override void OnCreate()
+        {
+            base.OnCreate();
+
+            Xamarin.ExposureNotifications.ExposureNotification.ConfigureBackgroundWorkRequest(TimeSpan.FromHours(6), b =>
+                b.SetConstraints(new AndroidX.Work.Constraints.Builder()
+                    .SetRequiresBatteryNotLow(true)
+                    .SetRequiredNetworkType(AndroidX.Work.NetworkType.Connected)
+                    .Build())
+                );
+        }
     }
 }


### PR DESCRIPTION
I confirmed that worker tasks do not start if constraints `RequiresDeviceIdle` are set true.

## Purpose
Fix issue #25

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
https://gist.github.com/keiji/4b41890377ab342a48432b38943a0cd3

 1. Launch an application
 2. On console(terminal), type adb command `adb shell dumpsys jobscheduler`
 3. Confirm job status "Minimum latency" and "Required constraints" correct.

```
  JOB #u0a91/104: 3d7af17 APP_PACKAGE_NAME.APP_PACKAGE_NAME/androidx.work.impl.background.systemjob.SystemJobService
    u0a91 tag=*job*/APP_PACKAGE_NAME.APP_PACKAGE_NAME/androidx.work.impl.background.systemjob.SystemJobService
    Source: uid=u0a91 user=0 pkg=APP_PACKAGE_NAME.APP_PACKAGE_NAME
    JobInfo:
      Service: APP_PACKAGE_NAME.APP_PACKAGE_NAME/androidx.work.impl.background.systemjob.SystemJobService
      Requires: charging=false batteryNotLow=true deviceIdle=false
      Extras: mParcelledData.dataSize=180
      Network type: NetworkRequest [ NONE id=0, [ Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED&VALIDATED Unwanted:  Uid: 10091] ]
      Minimum latency: +5h59m59s992ms
      Backoff: policy=1 initial=+30s0ms
      Has early constraint
    Required constraints: BATTERY_NOT_LOW TIMING_DELAY CONNECTIVITY [0x90000002]
    Satisfied constraints: BATTERY_NOT_LOW CONNECTIVITY DEVICE_NOT_DOZING BACKGROUND_NOT_RESTRICTED [0x12400002]
    Unsatisfied constraints: TIMING_DELAY [0x80000000]
    Uid: active
    Tracking: BATTERY CONNECTIVITY TIME
    Network: 100
    Standby bucket: ACTIVE
    Enqueue time: -147ms
    Run time: earliest=+5h59m59s845ms, latest=none
    Last run heartbeat: 18
    Ready: false (job=false user=true !pending=true !active=true !backingup=true comp=true)
```

----

Android版で診断キーサーバーとの通信タスクが定期実行されない問題について調査し、原因の一つらしき箇所が見つかったためサジェスチョンとしてのPRとなります。

手元で最小限のコードを作成して実験したところ`WorkManager`の`WorkRequest`に制約（Constraints）として、要待機状態（requiresDeviceIdle）を設定すると、Workerが実行されない現象が確認されました。

今回`requiresDeviceIdle`を設定した場合に定期実行されない現象については原因は解明できていませんが、現象に対応するため、`requiresDeviceIdle`を設定しない（デフォルトでfalse）変更をしています。

Googleの公開しているリファレンス実装「exposure-notification-android」の当該部分には`requiresDeviceIdle`がついていません。EN APIの挙動としては当該制約はなくても問題はないという認識です。

https://github.com/google/exposure-notifications-android/blob/4b7b461282b2ede6fb2a93488c6d628440052c8d/app/src/main/java/com/google/android/apps/exposurenotification/nearby/ProvideDiagnosisKeysWorker.java#L216-L219

この変更によってバックグラウンドタスクの定期実行が正常に動作するか（https://github.com/cocoa-mhlw/cocoa/issues/25#issuecomment-786668197 と合わせて複合的な要因である可能性もあります）。
あとはアイドル時以外でも実行されることが、アプリとしてのCOCOAの要件を満たすかと言う話になってくると考えます。


## 検証方法
検証のため、COCOAのコードからWorkManagerに関連した部分を確認して、最小限で動作する検証コードを作成しました。
結果、ぼくの手元の端末では`requiresDeviceIdle`を`true`に設定した場合にWorkerが実行されない現象が確認されました。

検証用のコードをGistに置いておきます(コードはXamarinのものですが、Androidネイティブで同様のものを作成して実験することもできます)。

https://gist.github.com/keiji/4b41890377ab342a48432b38943a0cd3

WorkManagerは、Androidのバックグラウンドジョブを実行するライブラリで、その実体はJobScheduler(API Level 23以上の場合)です。

JobSchedulerでは`setRequiresDeviceIdle`の注意事項として「端末そのもののIDLEや省電力（DOZE）モードとは関係がなく、直接使われていない場合にジョブの実行を許可する」とあり、IDLEの定義は明確になっていません。

https://developer.android.com/reference/android/app/job/JobInfo.Builder#setRequiresDeviceIdle(boolean)

WorkManagerのデバッグ方法はAndroidの公式サイトで紹介されています。

https://developer.android.com/topic/libraries/architecture/workmanager/how-to/debugging?hl=ja

そこで、Android（API Level 28）のエミュレーターに検証用のアプリをインストールして、`requiresDeviceIdle`を`true`のパターンでコマンド `adb shell dumpsys jobscheduler` を実行したところ「IDLE制約を満たしていない」ため実行されない（Unsatisfied constraints: IDLE [0x4]）という結果が得られました。

```
 JOB #u0a89/0: 4a47b44 dev.keiji.test4/androidx.work.impl.background.systemjob.SystemJobService
    u0a89 tag=*job*/dev.keiji.test4/androidx.work.impl.background.systemjob.SystemJobService
    Source: uid=u0a89 user=0 pkg=dev.keiji.test4
    JobInfo:
      Service: dev.keiji.test4/androidx.work.impl.background.systemjob.SystemJobService
      Requires: charging=false batteryNotLow=false deviceIdle=true
      Extras: mParcelledData.dataSize=180
      Backoff: policy=1 initial=+30s0ms
      Has early constraint
    Required constraints: TIMING_DELAY IDLE [0x80000004]
    Satisfied constraints: TIMING_DELAY DEVICE_NOT_DOZING BACKGROUND_NOT_RESTRICTED [0x82400000]
    Unsatisfied constraints: IDLE [0x4]
    Uid: active
    Tracking: IDLE
    Standby bucket: ACTIVE
    Enqueue time: -5s683ms
    Run time: earliest=-5s683ms, latest=none
    Last run heartbeat: -130
    Ready: false (job=false user=true !pending=true !active=true !backingup=true comp=true)
```

どのような状態がIDLEかは明確でないため、エミュレーターの電源ボタンを押して表示を消したり、 `adb shell dumpsys deviceidle force-idle`を用いてエミュレーターを強制的にIDLE状態に設定したりしましたが、IDLE制約を満たしてWorkerが実行されることはありませんでした。


## 参考
他にも`setRequiresDeviceIdle`について触れられているIssueが見つかっているので参考までに。

 * https://stackoverflow.com/questions/50307553/android-jobscheduler-setrequiresdeviceidle-job-not-firing
 * https://github.com/evernote/android-job/issues/116
