### PR TITLE
Fix the issue that the timing of saving lastCreated is inappropriate

### DIFF
--- a/Covid19Radar/Covid19Radar/Services/ExposureNotificationHandler.cs
+++ b/Covid19Radar/Covid19Radar/Services/ExposureNotificationHandler.cs
@@ -199,7 +199,7 @@ namespace Covid19Radar.Services
             }
         }
 
-        private async Task<(int, long, List<string>)> DownloadBatchAsync(string region, long lastCreated, CancellationToken cancellationToken)
+        private async Task<(int, long, List<string>)> DownloadBatchAsync(string region, long startTimestamp, CancellationToken cancellationToken)
         {
             var loggerService = LoggerService;
             loggerService.StartMethod();
@@ -219,7 +219,7 @@ namespace Covid19Radar.Services
             {
                 loggerService.Exception("Failed to create directory", ex);
                 loggerService.EndMethod();
-                // catch error return batchnumber 0 / fileList 0
+                // catch error return batchnumber 0 / newCreated -1 /  fileList 0
                 return (batchNumber, -1, downloadedFiles);
             }
 
@@ -233,11 +233,11 @@ namespace Covid19Radar.Services
             }
             Debug.WriteLine("C19R Fetch Exposure Key");
 
-            var newCreated = lastCreated;
+            var newCreated = startTimestamp;
             foreach (var tekItem in tekList)
             {
                 loggerService.Info($"tekItem.Created: {tekItem.Created}");
-                if (tekItem.Created > newCreated || newCreated == 0)
+                if (tekItem.Created > startTimestamp || newCreated == 0)
                 {
                     var tmpFile = Path.Combine(tmpDir, Guid.NewGuid().ToString() + ".zip");
                     Debug.WriteLine(Utils.SerializeToJson(tekItem));


### PR DESCRIPTION
## Issue 番号 / Issue ID
- Close #17

## 目的 / Purpose
複数の診断キーのダウンロード途中でタイムアウトなどで失敗した場合、次回診断キーのダウンロード時にダウンロード対象に入らなくなることで接触チェックに漏れが発生する。

## 破壊的変更をもたらしますか / Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test
複数の診断キーをダウンロード途中にネットワークを切断するなどしてダウンロードを失敗させ、再び。
診断キーのダウンロードと接触確認がも漏れなく行われるか確認する。

### コードの入手 / Get the code

```
git clone https://github.com/keiji/cocoa
cd cocoa
git checkout fix_inappropriate_timing_of_saving_lastcreateddate
dotnet restore
```

## 確認事項 / What to check
接触確認が不要な戻値のパターンは「`batchNumber`が0の場合」「`newCreated`が-1の場合」「`downloadedFiles.Count`が0の場合」で問題ないか。