### PR TITLE
Disable "Override Force-dark (Dark mode)" setting.

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/Resources/values/styles.xml
+++ b/Covid19Radar/Covid19Radar.Android/Resources/values/styles.xml
@@ -40,6 +40,7 @@
     <item name="windowActionModeOverlay">true</item>
    
     <item name="android:datePickerDialogTheme">@style/AppCompatDialogStyle</item>
+    <item name="android:forceDarkAllowed">false</item>
   </style>
     <style name="AppCompatDialogStyle" parent="Theme.AppCompat.Light.Dialog">
       <item name="colorAccent">@color/colorAccent</item>


### PR DESCRIPTION
## Issue 番号 / Issue ID

- #135 

## 目的 / Purpose

開発者オプションで「Force-dark」を有効にした場合に表示が乱れる課題を解決する。

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
gh pr [PR ID]
dotnet restore
```

## 確認事項 / What to check

- 開発者向けオプションの「フォースダークのオーバーライド（Override Force-dark）」を有効にする
- 「設定」「ディスプレイ」「ダークテーマ」を有効にする
- COCOAを起動してホーム画面にダークテーマ（ダークモード）が適用されていないことを確認する

## その他 / Other information

本設定を無視する端末が存在する可能性がある。
本PRの取り込みで #135 はクローズせず、経過を観察する。
