### PR TITLE
Update Google ExposureNotification library version to 19.7.1-eap.1

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/Covid19Radar.Android.csproj
+++ b/Covid19Radar/Covid19Radar.Android/Covid19Radar.Android.csproj
@@ -176,7 +176,7 @@
       <Version>4.6.0.967</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.GooglePlayServices.Nearby.ExposureNotification">
-      <Version>18.0.2-eap.6</Version>
+      <Version>19.7.1-eap.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.GooglePlayServices.SafetyNet">
       <Version>117.0.0-preview03</Version>

--- a/Covid19Radar/Xamarin.ExposureNotification/Xamarin.ExposureNotification.csproj
+++ b/Covid19Radar/Xamarin.ExposureNotification/Xamarin.ExposureNotification.csproj
@@ -45,7 +45,7 @@
 
 		<PackageReference Include="Xamarin.GooglePlayServices.Basement" Version="117.2.1-preview01" />
 		<PackageReference Include="Xamarin.GooglePlayServices.Tasks" Version="117.0.2-preview01" />
-		<PackageReference Include="Xamarin.GooglePlayServices.Nearby.ExposureNotification" Version="18.0.2-eap.6" />
+		<PackageReference Include="Xamarin.GooglePlayServices.Nearby.ExposureNotification" Version="19.7.1-eap.1" />
 		<PackageReference Include="Xamarin.AndroidX.Core" Version="1.2.0" />
 		<PackageReference Include="Xamarin.AndroidX.Work.Runtime" Version="2.3.4.1" />
 	</ItemGroup>


### PR DESCRIPTION
## Issue 番号 / Issue ID

- Close #136

## 目的 / Purpose

一部端末のシステムによりCOCOAが強制停止されてバックグラウンドタスクが起動しない状態になることを防ぐためForce-stop Handlingを有効にする必要がある。

ExposureNotification SDKのバージョンをv1.5以降にアップデートすることで Force-stop Handlingが有効化される。

本PRは、`Xamarin.GooglePlayServices.Nearby.ExposureNotification`のバージョンを更新する。
バージョン`19.7.1-eap.1`は、SDKのバージョン `1.7.1-eap`にリンクしている。

v1.7, September 2020
https://developers.google.com/android/exposure-notifications/release-notes#v17_september_2020

October 2020にバグフィックス版のv1.7.2がリリースされているが、コードが指し示しているaarファイルは1.7.1のもの。

v1.7.2, October 2020
https://developers.google.com/android/exposure-notifications/release-notes#v172_october_2020

https://github.com/xamarin/XamarinComponents/blob/f39add7ad854c3a8d8ad6a9284220a3d1073e055/Android/ExposureNotification/build.cake#L3-L4

v1.7.1に修正は反映されていないか、リリースノートの1.7.2が実は1.7.1のことを指し示している可能性がある。

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
gh pr [pr-id]
dotnet restore
```

### コードの検証 / Test the code

PackageReferneceに指定している`Xamarin.GooglePlayServices.Nearby.ExposureNotification`のバージョンを更新するに留めている。

## 確認事項 / What to check

 1. COCOAをインストールして利用を開始する
 2. `adb shell dumpsys jobscheduler` でJobSchedulerの登録状態を確認する
 3. `adb shell am force-stop [APP_PACKAGE_NAME]` でアプリを強制停止する
 4. `adb shell dumpsys jobscheduler` でJobSchedulerの登録状態を確認して、アプリのJobがない（消えている）ことを確認する 
 5. 6時間程度待つ（Force-stop handlingでアプリの再有効化）
 6. `adb shell dumpsys jobscheduler` でJobSchedulerの登録状態を確認して、アプリのJobがある（復帰している）ことを確認する

アプリの詳細画面から「強制停止」を選択した場合、JobSchedulerの復帰は確認できなかった。

**Exposure Notification機能の根幹となるライブラリを更新しているため、陽性登録と接触確認についてリグレッションテストが必要。**

## その他 / Other information

別途、さらに新しい `1.8.3-eap` を使うPull Requestも提出する予定。