### PR TITLE
GitHub Actionsのセットアップ（iOS）

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,16 +38,16 @@ jobs:
       run: |
         cd Covid19Radar
         msbuild ./Covid19Radar.Android/Covid19Radar.Android.csproj /t:Rebuild /p:Configuration=Release
-    #- name: iOS.Debug
-    #  run: |
-    #    cd Covid19Radar
-    #    msbuild ./Covid19Radar.iOS/Covid19Radar.iOS.csproj /t:Rebuild /p:Configuration=Debug /p:Platform=iPhoneSimulator
-    #- name: iOS.Debug_Mock
-    #  run: |
-    #    cd Covid19Radar
-    #    msbuild ./Covid19Radar.iOS/Covid19Radar.iOS.csproj /t:Rebuild /p:Configuration=Debug_Mock /p:Platform=iPhoneSimulator
-    #- name: iOS.Release
-    #  run: |
-    #    cd Covid19Radar
-    #    msbuild ./Covid19Radar.iOS/Covid19Radar.iOS.csproj /t:Rebuild /p:Configuration=Release /p:Platform=iPhoneSimulator
+    - name: iOS.Debug
+      run: |
+        cd Covid19Radar
+        msbuild ./Covid19Radar.iOS/Covid19Radar.iOS.csproj /t:Rebuild /p:Configuration=Debug /p:Platform=iPhoneSimulator
+    - name: iOS.Debug_Mock
+      run: |
+        cd Covid19Radar
+        msbuild ./Covid19Radar.iOS/Covid19Radar.iOS.csproj /t:Rebuild /p:Configuration=Debug_Mock /p:Platform=iPhoneSimulator
+    - name: iOS.Release
+      run: |
+        cd Covid19Radar
+        msbuild ./Covid19Radar.iOS/Covid19Radar.iOS.csproj /t:Rebuild /p:Configuration=Release /p:Platform=iPhoneSimulator
         

--- a/Covid19Radar/Covid19Radar.iOS/Covid19Radar.iOS.csproj
+++ b/Covid19Radar/Covid19Radar.iOS/Covid19Radar.iOS.csproj
@@ -28,7 +28,6 @@
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
     <CodesignKey>iPhone Developer</CodesignKey>
-    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <LangVersion>latest</LangVersion>
     <MtouchExtraArgs>--optimize=experimental-xforms-product-type --weak-framework=ExposureNotification</MtouchExtraArgs>
     <MtouchFastDev>true</MtouchFastDev>

--- a/Covid19Radar/Covid19Radar.iOS/Covid19Radar.iOS.csproj
+++ b/Covid19Radar/Covid19Radar.iOS/Covid19Radar.iOS.csproj
@@ -40,7 +40,7 @@
     <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <MtouchLink>None</MtouchLink>
+    <MtouchLink>SdkOnly</MtouchLink>
     <MtouchArch>x86_64</MtouchArch>
     <ConsolePause>false</ConsolePause>
     <CodesignKey>Apple Development: Kazumi Hirose (WG99EL99X6)</CodesignKey>


### PR DESCRIPTION
## Issue 番号 / Issue ID

- #75

## 目的 / Purpose

Pull Requestなどで、ファイルのアップロード漏れや特定のConfigurationでビルドできなくなるのを防ぐためにCIでビルドチェックを行いたい。

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

<!--
  当てはまるもの 1 つに「x」とマークしてください。
  Mark one with an "x".
-->

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 確認事項 / What to check

GitHub Actionsのビルドが成功するかを確認する。
https://github.com/cocoa-mhlw/cocoa/runs/2486259760

## その他 / Other information

Debug|iPhoneSimulatorに設定されていたCodesignEntitlementsは必要ないと言う結論に至った（iPhoneSimulatorでは実際のExposure Notificationを使う必要はない）。

また、iPhone実機で動かすケース（Debug|iPhone, Release|iPhone, Adhoc|iPhoneなど）は、ExposureNotificationを利用可能なプロビジョニングプロファイルを設定する必要がある。これらのプロファイルは非公開かつ開発チームは個別で設定しているのでオープンソースのビルドはiPhoneSimulatorを前提にするのが適切と考える。
