### PR TITLE
Migrate IDeviceVerifier from DependencyService to ServiceLocator

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/MainApplication.cs
+++ b/Covid19Radar/Covid19Radar.Android/MainApplication.cs
@@ -39,6 +39,12 @@ namespace Covid19Radar.Droid
             container.Register<ISecureStorageDependencyService, SecureStorageServiceAndroid>(Reuse.Singleton);
             container.Register<IPreferencesService, PreferencesService>(Reuse.Singleton);
             container.Register<IApplicationPropertyService, ApplicationPropertyService>(Reuse.Singleton);
+
+#if USE_MOCK
+            container.Register<IDeviceVerifier, DeviceVerifierMock>(Reuse.Singleton);
+#else
+            container.Register<IDeviceVerifier, DeviceCheckService>(Reuse.Singleton);
+#endif
         }
     }
 }

--- a/Covid19Radar/Covid19Radar.Android/Services/DeviceCheckService.cs
+++ b/Covid19Radar/Covid19Radar.Android/Services/DeviceCheckService.cs
@@ -2,25 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Android.App;
-using Android.Content;
-using Android.OS;
-using Android.Runtime;
-using Android.Views;
-using Android.Widget;
 using Covid19Radar.Services;
-using Covid19Radar.Droid.Services;
-using Xamarin.Forms;
 using Covid19Radar.Model;
-using Covid19Radar.Common;
 using Android.Gms.SafetyNet;
 
-[assembly: Dependency(typeof(DeviceCheckService))]
 namespace Covid19Radar.Droid.Services
 {
     public class DeviceCheckService : IDeviceVerifier

--- a/Covid19Radar/Covid19Radar.iOS/AppDelegate.cs
+++ b/Covid19Radar/Covid19Radar.iOS/AppDelegate.cs
@@ -68,6 +68,12 @@ namespace Covid19Radar.iOS
             container.Register<ISecureStorageDependencyService, SecureStorageServiceIos>(Reuse.Singleton);
             container.Register<IPreferencesService, PreferencesService>(Reuse.Singleton);
             container.Register<IApplicationPropertyService, ApplicationPropertyService>(Reuse.Singleton);
+
+#if USE_MOCK
+            container.Register<IDeviceVerifier, DeviceVerifierMock>(Reuse.Singleton);
+#else
+            container.Register<IDeviceVerifier, DeviceCheckService>(Reuse.Singleton);
+#endif
         }
     }
 }

--- a/Covid19Radar/Covid19Radar.iOS/Services/DeviceCheckService.cs
+++ b/Covid19Radar/Covid19Radar.iOS/Services/DeviceCheckService.cs
@@ -5,11 +5,8 @@
 using System;
 using System.Threading.Tasks;
 using Covid19Radar.Services;
-using Covid19Radar.iOS.Services;
-using Xamarin.Forms;
 using Covid19Radar.Model;
 
-[assembly: Dependency(typeof(DeviceCheckService))]
 namespace Covid19Radar.iOS.Services
 {
     public class DeviceCheckService : IDeviceVerifier

--- a/Covid19Radar/Covid19Radar/Services/DeviceVerifierMock.cs
+++ b/Covid19Radar/Covid19Radar/Services/DeviceVerifierMock.cs
@@ -1,0 +1,15 @@
+﻿/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System.Threading.Tasks;
+using Covid19Radar.Model;
+
+namespace Covid19Radar.Services
+{
+    public class DeviceVerifierMock : IDeviceVerifier
+    {
+        public Task<string> VerifyAsync(DiagnosisSubmissionParameter submission)
+            => Task.Run(() =>　"DUMMY RESPONSE");
+    }
+}

--- a/Covid19Radar/Covid19Radar/Services/ExposureNotificationHandler.cs
+++ b/Covid19Radar/Covid19Radar/Services/ExposureNotificationHandler.cs
@@ -18,7 +18,6 @@ using Covid19Radar.Resources;
 using Covid19Radar.Services.Logs;
 using Xamarin.Essentials;
 using Xamarin.ExposureNotifications;
-using Xamarin.Forms;
 
 namespace Covid19Radar.Services
 {
@@ -29,6 +28,7 @@ namespace Covid19Radar.Services
         private IHttpDataService HttpDataService => ServiceLocator.Current.GetInstance<IHttpDataService>();
         private IExposureNotificationService ExposureNotificationService => ServiceLocator.Current.GetInstance<IExposureNotificationService>();
         private IUserDataService UserDataService => ServiceLocator.Current.GetInstance<IUserDataService>();
+        private readonly IDeviceVerifier DeviceVerifier = ServiceLocator.Current.GetInstance<IDeviceVerifier>();
 
         public ExposureNotificationHandler()
         {
@@ -386,11 +386,7 @@ namespace Covid19Radar.Services
                 Padding = padding
             };
 
-            // See if we can add the device verification
-            if (DependencyService.Get<IDeviceVerifier>() is IDeviceVerifier verifier)
-            {
-                submission.DeviceVerificationPayload = await verifier?.VerifyAsync(submission);
-            }
+            submission.DeviceVerificationPayload = await DeviceVerifier.VerifyAsync(submission);
 
             loggerService.Info($"DeviceVerificationPayload is {(string.IsNullOrEmpty(submission.DeviceVerificationPayload) ? "null or empty" : "set")}.");
             loggerService.Info($"VerificationPayload is {(string.IsNullOrEmpty(submission.VerificationPayload) ? "null or empty" : "set")}.");


### PR DESCRIPTION
## Issue 番号 / Issue ID

- Close #185

## 目的 / Purpose

DependencyServiceを廃止するためにIDeviceVerifierをServiceLocatorに移行する。

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[x] Yes
[ ] No
```

## Pull Request の種類 / Pull Request type

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

## 確認事項 / What to check

- Debug_Mock時にダミーの結果を返す（実際のDeviceCheckを使わない）
- Debug/Release時には実際のDeviceCheckを使用する

## その他 / Other information
`#if USE_MOCK`でモックを登録するところだけ`App`に置くか迷ったけど、結局Android, iOSのプラットフォーム固有処理の登録で`#if`ディレクティブ使うことになるので現在の形になりました。