### PR TITLE
`IDateTimeUtility` をサービス化

### DIFF
--- a/Covid19Radar/Covid19Radar/App.xaml.cs
+++ b/Covid19Radar/Covid19Radar/App.xaml.cs
@@ -161,7 +161,6 @@ namespace Covid19Radar
         private static void RegisterCommonTypes(IContainer container)
         {
             // Services
-            container.Register<IDateTimeUtility, DateTimeUtility>(Reuse.Singleton);
             container.Register<ILoggerService, LoggerService>(Reuse.Singleton);
             container.Register<ILogFileService, LogFileService>(Reuse.Singleton);
             container.Register<ILogPathService, LogPathService>(Reuse.Singleton);
@@ -180,6 +179,9 @@ namespace Covid19Radar
             container.Register<IStorageService, StorageService>(Reuse.Singleton);
 #endif
             container.Register<ISecureStorageService, SecureStorageService>(Reuse.Singleton);
+
+            // Utilities
+            container.Register<IDateTimeUtility, DateTimeUtility>(Reuse.Singleton);
         }
 
         protected override void OnStart()

--- a/Covid19Radar/Covid19Radar/App.xaml.cs
+++ b/Covid19Radar/Covid19Radar/App.xaml.cs
@@ -1,4 +1,4 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
+﻿/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
@@ -161,6 +161,7 @@ namespace Covid19Radar
         private static void RegisterCommonTypes(IContainer container)
         {
             // Services
+            container.Register<IDateTimeUtility, DateTimeUtility>(Reuse.Singleton);
             container.Register<ILoggerService, LoggerService>(Reuse.Singleton);
             container.Register<ILogFileService, LogFileService>(Reuse.Singleton);
             container.Register<ILogPathService, LogPathService>(Reuse.Singleton);

--- a/Covid19Radar/Covid19Radar/Common/DateTimeUtility.cs
+++ b/Covid19Radar/Covid19Radar/Common/DateTimeUtility.cs
@@ -1,18 +1,18 @@
-﻿using System;
+﻿/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System;
+
 namespace Covid19Radar.Common
 {
     public interface IDateTimeUtility
     {
-        DateTime UtcNow { get; }
+        public DateTime UtcNow { get; }
     }
+
     public class DateTimeUtility : IDateTimeUtility
     {
-        public static IDateTimeUtility Instance = new DateTimeUtility();
-
-        public DateTimeUtility()
-        {
-        }
-
         public DateTime UtcNow => DateTime.UtcNow;
     }
 }

--- a/Covid19Radar/Covid19Radar/Services/ExposureNotificationService.cs
+++ b/Covid19Radar/Covid19Radar/Services/ExposureNotificationService.cs
@@ -53,17 +53,19 @@ namespace Covid19Radar.Services
         private readonly ISecureStorageService secureStorageService;
         private readonly IPreferencesService preferencesService;
         private readonly IApplicationPropertyService applicationPropertyService;
+        private readonly IDateTimeUtility dateTimeUtility;
 
         public string CurrentStatusMessage { get; set; } = "初期状態";
         public Status ExposureNotificationStatus { get; set; }
 
-        public ExposureNotificationService(ILoggerService loggerService, IHttpClientService httpClientService, ISecureStorageService secureStorageService, IPreferencesService preferencesService, IApplicationPropertyService applicationPropertyService)
+        public ExposureNotificationService(ILoggerService loggerService, IHttpClientService httpClientService, ISecureStorageService secureStorageService, IPreferencesService preferencesService, IApplicationPropertyService applicationPropertyService, IDateTimeUtility dateTimeUtility)
         {
             this.loggerService = loggerService;
             this.httpClientService = httpClientService;
             this.secureStorageService = secureStorageService;
             this.preferencesService = preferencesService;
             this.applicationPropertyService = applicationPropertyService;
+            this.dateTimeUtility = dateTimeUtility;
 
             _ = GetExposureNotificationConfig();
         }
@@ -246,7 +248,7 @@ namespace Covid19Radar.Services
         {
             loggerService.StartMethod();
             var list = GetExposureInformationList()?
-                .Where(x => x.Timestamp.CompareTo(DateTimeUtility.Instance.UtcNow.AddDays(AppConstants.DaysOfExposureInformationToDisplay)) >= 0)
+                .Where(x => x.Timestamp.CompareTo(dateTimeUtility.UtcNow.AddDays(AppConstants.DaysOfExposureInformationToDisplay)) >= 0)
                 .ToList();
             loggerService.EndMethod();
             return list;

--- a/Covid19Radar/Covid19Radar/Services/ExposureNotificationService.cs
+++ b/Covid19Radar/Covid19Radar/Services/ExposureNotificationService.cs
@@ -58,7 +58,13 @@ namespace Covid19Radar.Services
         public string CurrentStatusMessage { get; set; } = "初期状態";
         public Status ExposureNotificationStatus { get; set; }
 
-        public ExposureNotificationService(ILoggerService loggerService, IHttpClientService httpClientService, ISecureStorageService secureStorageService, IPreferencesService preferencesService, IApplicationPropertyService applicationPropertyService, IDateTimeUtility dateTimeUtility)
+        public ExposureNotificationService(
+            ILoggerService loggerService,
+            IHttpClientService httpClientService,
+            ISecureStorageService secureStorageService,
+            IPreferencesService preferencesService,
+            IApplicationPropertyService applicationPropertyService,
+            IDateTimeUtility dateTimeUtility)
         {
             this.loggerService = loggerService;
             this.httpClientService = httpClientService;

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/ExposureNotificationServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/ExposureNotificationServiceTests.cs
@@ -38,7 +38,6 @@ namespace Covid19Radar.UnitTests.Services
             mockPreferencesService = mockRepository.Create<IPreferencesService>();
             mockApplicationPropertyService = mockRepository.Create<IApplicationPropertyService>();
             mockDateTimeUtility = mockRepository.Create<IDateTimeUtility>();
-            DateTimeUtility.Instance = mockDateTimeUtility.Object;
         }
 
         private ExposureNotificationService CreateService()
@@ -48,7 +47,8 @@ namespace Covid19Radar.UnitTests.Services
                 mockHttpClientService.Object,
                 mockSecureStorageService.Object,
                 mockPreferencesService.Object,
-                mockApplicationPropertyService.Object);
+                mockApplicationPropertyService.Object,
+                mockDateTimeUtility.Object);
         }
 
         [Theory]


### PR DESCRIPTION
## Issue 番号 / Issue ID

<!--
  Issue 番号なき PR は受け付けません。
  PRs without the issue IDs are never accepted.
-->

- Close #223
- Close #229 (事実上)

## 目的 / Purpose

<!--
  その変更を提案する意図をご説明ください。どの問題が解決したり、機能的な追加がなされたりしますか。
  Describe the intention of the changes being proposed. What problem does it solve or functionality does it add?
-->

- `IDateTimeUtility` をサービス化し、外部からインスタンスの書き換えを行えなくしました。

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

<!--
  当てはまるもの 1 つに「x」とマークしてください。
  Mark one with an "x".
-->

```
[x] Yes
[ ] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone https://github.com/Takym/cocoa.git
cd cocoa
git checkout refactoring/dtutil
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```
```


## 確認事項 / What to check

- [ ] 以前と動作が変わらない。
- [ ] テストが正しく通る。

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->

- `IDateTimeUtility` と `IHttpClientService` は持っている機能が少なく似ているので統合しても良いかもしれませんね。
```cs
public interface IFactoryService
{
    public DateTime UtcNow { get; }
    public HttpClient CreateHttpClient();
}

public class FactoryService : IFactoryService
{
    public DateTime UtcNow => DateTime.UtcNow;

    public HttpClient Create()
    {
        return new HttpClient();
    }
}
```

----
Internal IDs:
- NFR 2900