### PR TITLE
ライセンス通知を追加するツールを作成

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{axml,cs,css,html,proto,storyboard,xaml,storyboard,proto}]
+[*.{axml,cs,csx,css,html,proto,storyboard,xaml,storyboard,proto}]
 indent_size = 4
 
 [*.cs]

--- a/Tools/AddLicenseHeader.bat
+++ b/Tools/AddLicenseHeader.bat
@@ -1,0 +1,7 @@
+@REM This Source Code Form is subject to the terms of the Mozilla Public
+@REM License, v. 2.0. If a copy of the MPL was not distributed with this
+@REM file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+@echo off
+call csi %~dp0\AddLicenseHeader.csx %~dp0\..\
+pause

--- a/Tools/AddLicenseHeader.csx
+++ b/Tools/AddLicenseHeader.csx
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#nullable enable
+
+const string LINE1 = "/* This Source Code Form is subject to the terms of the Mozilla Public";
+const string LINE2 = " * License, v. 2.0. If a copy of the MPL was not distributed with this";
+const string LINE3 = " * file, You can obtain one at https://mozilla.org/MPL/2.0/. */";
+
+if (Args.Count != 1) {
+    WriteLine("対象のディレクトリを指定してください。");
+    return;
+}
+
+string   dir   = Path.GetFullPath(Args[0]);
+string[] files = Directory.GetFiles(dir, "*.cs", SearchOption.AllDirectories);
+int      added = 0;
+
+WriteLine("対象のディレクトリ：" + dir);
+WriteLine();
+
+for (int i = 0; i < files.Length; ++i) {
+    string file = files[i];
+    WriteLine("\"{0}\" を確認しています . . .", file);
+    using (var fs = new FileStream(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+    using (var sr = new StreamReader(fs, true))
+    using (var sw = new StreamWriter(fs, Encoding.UTF8)) {
+        if ((sr.ReadLine() is not null and string line1) && line1 == LINE1 &&
+            (sr.ReadLine() is not null and string line2) && line2 == LINE2 &&
+            (sr.ReadLine() is not null and string line3) && line3 == LINE3) {
+            WriteLine("ライセンス通知は記述されています。");
+        } else {
+            fs.Seek(0, SeekOrigin.Begin);
+            sw.WriteLine(LINE1);
+            sw.WriteLine(LINE2);
+            sw.WriteLine(LINE3);
+            sw.WriteLine();
+            ++added;
+            WriteLine("ライセンス通知を追加しました。");
+        }
+    }
+}
+
+WriteLine();
+WriteLine("{0}個中{1}個のファイルにライセンス通知を追加しました。", files.Length, added);

--- a/Tools/AddLicenseHeader.csx
+++ b/Tools/AddLicenseHeader.csx
@@ -4,15 +4,15 @@
 
 #nullable enable
 
-const string LINE1 = "/* This Source Code Form is subject to the terms of the Mozilla Public";
-const string LINE2 = " * License, v. 2.0. If a copy of the MPL was not distributed with this";
-const string LINE3 = " * file, You can obtain one at https://mozilla.org/MPL/2.0/. */";
+const string HEADER_LF   = "/* This Source Code Form is subject to the terms of the Mozilla Public\n * License, v. 2.0. If a copy of the MPL was not distributed with this\n * file, You can obtain one at https://mozilla.org/MPL/2.0/. */\n";
+const string HEADER_CRLF = "/* This Source Code Form is subject to the terms of the Mozilla Public\r\n * License, v. 2.0. If a copy of the MPL was not distributed with this\r\n * file, You can obtain one at https://mozilla.org/MPL/2.0/. */\r\n";
 
 if (Args.Count != 1) {
     WriteLine("対象のディレクトリを指定してください。");
     return;
 }
 
+var      enc   = new UTF8Encoding(false);
 string   dir   = Path.GetFullPath(Args[0]);
 string[] files = Directory.GetFiles(dir, "*.cs", SearchOption.AllDirectories);
 int      added = 0;
@@ -23,24 +23,36 @@ WriteLine();
 for (int i = 0; i < files.Length; ++i) {
     string file = files[i];
     WriteLine("\"{0}\" を確認しています . . .", file);
-    using (var fs = new FileStream(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
-    using (var sr = new StreamReader(fs, true))
-    using (var sw = new StreamWriter(fs, Encoding.UTF8)) {
-        if ((sr.ReadLine() is not null and string line1) && line1 == LINE1 &&
-            (sr.ReadLine() is not null and string line2) && line2 == LINE2 &&
-            (sr.ReadLine() is not null and string line3) && line3 == LINE3) {
-            WriteLine("ライセンス通知は記述されています。");
-        } else {
-            fs.Seek(0, SeekOrigin.Begin);
-            sw.WriteLine(LINE1);
-            sw.WriteLine(LINE2);
-            sw.WriteLine(LINE3);
-            sw.WriteLine();
-            ++added;
-            WriteLine("ライセンス通知を追加しました。");
+    if (Ignore(file)) {
+        WriteLine("このファイルは無視されます。");
+    } else {
+        using (var fs = new FileStream(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+        using (var sr = new StreamReader(fs, true)) {
+            string data = sr.ReadToEnd();
+            if (data.StartsWith(HEADER_LF) || data.StartsWith(HEADER_CRLF)) {
+                WriteLine("ライセンス通知は記述されています。");
+            } else {
+                fs.SetLength(0);
+                using (var sw = new StreamWriter(fs, enc)) {
+                    sw.NewLine = "\n";
+                    sw.WriteLine(HEADER_LF);
+                    sw.Write(data);
+                }
+                ++added;
+                WriteLine("ライセンス通知を追加しました。");
+            }
         }
     }
+    WriteLine();
 }
 
 WriteLine();
 WriteLine("{0}個中{1}個のファイルにライセンス通知を追加しました。", files.Length, added);
+
+static bool Ignore(string file)
+{
+    return file.EndsWith(".designer.cs")
+        || file.EndsWith(".Designer.cs")
+        || file.EndsWith(".feature.cs")
+        || file.Contains("Xamarin.ExposureNotification");
+}


### PR DESCRIPTION
## Issue 番号
- #80
- #229

## 目的
- ライセンス通知をファイルの先頭に追加してくれるツールを作成しました。
- 現段階では C# ソースファイルにのみ対応しています。

## 破壊的変更をもたらしますか
```
[ ] Yes
[x] No
```

## Pull Request の種類
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法

### コードの入手
```
git clone https://github.com/Takym/cocoa.git
cd cocoa
git checkout tools/header
dotnet restore
```

### コードの検証
```
cd Tools
AddLicenseHeader
```

## 確認事項
- [ ] 予めC#インタラクティブ(csi.exe)へパスを通しておく必要があります。
- [ ] 現在は Windows でのみ実行できます。