### PR TITLE
プロジェクト「`Xamarin.ExposureNotification`」から `LICENSE.md` を取り除く (#259)

### DIFF
--- a/Covid19Radar/Xamarin.ExposureNotification/Xamarin.ExposureNotification.csproj
+++ b/Covid19Radar/Xamarin.ExposureNotification/Xamarin.ExposureNotification.csproj
@@ -28,9 +28,6 @@
 	<ItemGroup>
 		<Compile Include="**\*.shared.cs" />
 		<Compile Include="**\*.shared.*.cs" />
-
-		<None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
-
 		<PackageReference Include="Xamarin.Essentials" Version="1.5.3.1" />
 	</ItemGroup>
 


### PR DESCRIPTION
## Issue 番号
- Close #259

## 目的
- `Xamarin.ExposureNotification` は MPL 2.0 ではなくMITライセンスの下で配布されていますので、 `LICENSE.md` を取り除きました。

## 破壊的変更をもたらしますか
```
[ ] Yes
[x] No
```

## Pull Request の種類
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## コードの入手
```
git clone https://github.com/Takym/cocoa.git
cd cocoa
git checkout refactoring/issue-259
dotnet restore
```

----
Internal IDs:
- NFR 2860