### PR TITLE
Remove build Api.External for preparing remove unused APIs

### DIFF
--- a/.github/workflows/CIserver.yml
+++ b/.github/workflows/CIserver.yml
@@ -36,19 +36,6 @@ jobs:
       uses: microsoft/setup-msbuild@v1
     - name: Build
       run: msbuild ${{ github.workspace }}/src/Covid19Radar.Api.Common/Covid19Radar.Api.Common.csproj /restore /t:Build /p:Configuration=${{ matrix.Configuration }}
-  build_serverapi_external:
-    name: Build-ServerApi-External
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        Configuration: [Debug, Release]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1
-    - name: Build
-      run: msbuild ${{ github.workspace }}/src/Covid19Radar.Api.External/Covid19Radar.Api.External.csproj /restore /t:Build /p:Configuration=${{ matrix.Configuration }}
   build_serverapi_background:
     name: Build-ServerApi-Background
     runs-on: windows-latest
@@ -65,7 +52,7 @@ jobs:
   test:
     name: Test-ServerApi
     runs-on: ubuntu-latest
-    needs: [build_serverapi, build_serverapi_common, build_serverapi_external, build_serverapi_background]
+    needs: [build_serverapi, build_serverapi_common, build_serverapi_background]
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
## Issue 番号 / Issue ID

- #264
- #263

## 目的 / Purpose

#263 でCovid19Radar.Api.Externalを削除するのでGitHub Actionsを調整する。

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: CI
```

## 確認事項 / What to check

- CIが通るかを確認する

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
