### PR TITLE
単体テストの言語依存を解消 (#269)

### DIFF
--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/IUseFixedCulture.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/IUseFixedCulture.cs
@@ -1,0 +1,25 @@
+﻿/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#nullable enable
+
+using System.Globalization;
+using Xunit;
+
+namespace Covid19Radar.UnitTests
+{
+    public interface IUseFixedCulture : IClassFixture<CultureFixer> { }
+
+    public sealed class CultureFixer
+    {
+        public CultureFixer()
+        {
+            var c = CultureInfo.InvariantCulture;
+            CultureInfo.DefaultThreadCurrentCulture   = c;
+            CultureInfo.DefaultThreadCurrentUICulture = c;
+            CultureInfo.CurrentCulture                = c;
+            CultureInfo.CurrentUICulture              = c;
+        }
+    }
+}

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ReAgreePrivacyPolicyPageViewModelTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ReAgreePrivacyPolicyPageViewModelTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace Covid19Radar.UnitTests.ViewModels.HomePage
 {
-    public class ReAgreePrivacyPolicyPageViewModelTests
+    public class ReAgreePrivacyPolicyPageViewModelTests : IUseFixedCulture
     {
         private readonly MockRepository mockRepository;
         private readonly Mock<INavigationService> mockNavigationService;

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ReAgreeTermsOfServicePageViewModelTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ReAgreeTermsOfServicePageViewModelTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace Covid19Radar.UnitTests.ViewModels.HomePage
 {
-    public class ReAgreeTermsOfServicePageViewModelTests
+    public class ReAgreeTermsOfServicePageViewModelTests : IUseFixedCulture
     {
         private readonly MockRepository mockRepository;
         private readonly Mock<INavigationService> mockNavigationService;


### PR DESCRIPTION
## Issue 番号
- Fixed #269

## 目的
- リソースを使用する単体テストの言語依存を解消しました。

## 破壊的変更をもたらしますか
```
[ ] Yes
[x] No
```

## Pull Request の種類
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Unit Test Changes
```

## 検証方法

### コードの入手
```
git clone https://github.com/Takym/cocoa.git
cd cocoa
git checkout tests/OpenWebViewCommandTests
dotnet restore
```

### コードの検証
1. Visual Studio を起動する
2. ソリューションファイルを開く
3. テストエクスプローラを開く
4. テストを全て実行する

## 確認事項 / What to check

- [ ] 言語に依存する可能性のあるテスト処理は `IUseFixedCulture` を付与してください。
    - 蛇足ですが、`IUseFixedCulture` の **`I`** は一人称としても **<u>I</u>nterface** としても解釈のできる名前にしました。