### PR TITLE
Fix locale-dependent tests

### DIFF
--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ReAgreePrivacyPolicyPageViewModelTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ReAgreePrivacyPolicyPageViewModelTests.cs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using Covid19Radar.Model;
 using Covid19Radar.Services;
@@ -58,6 +59,9 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
         [Fact]
         public void OpenWebViewCommandTests()
         {
+            // The test is locale dependent
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+
             var reAgreePrivacyPolicyPageViewModel = CreateViewModel();
             var param = new NavigationParameters
             {

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ReAgreePrivacyPolicyPageViewModelTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ReAgreePrivacyPolicyPageViewModelTests.cs
@@ -3,9 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 using System;
-using System.Globalization;
 using System.Threading.Tasks;
 using Covid19Radar.Model;
+using Covid19Radar.Resources;
 using Covid19Radar.Services;
 using Covid19Radar.Services.Logs;
 using Covid19Radar.ViewModels;
@@ -59,9 +59,6 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
         [Fact]
         public void OpenWebViewCommandTests()
         {
-            // The test is locale dependent
-            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
-
             var reAgreePrivacyPolicyPageViewModel = CreateViewModel();
             var param = new NavigationParameters
             {
@@ -83,7 +80,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
             reAgreePrivacyPolicyPageViewModel.OpenWebView.Execute(null);
 
             Assert.Equal(1, actualCalls);
-            Assert.Equal("https://www.mhlw.go.jp/cocoa/privacypolicy_english.html", actualUri);
+            Assert.Equal(AppResources.UrlPrivacyPolicy, actualUri);
             Assert.Equal(BrowserLaunchMode.SystemPreferred, actualLaunchMode);
         }
 

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ReAgreeTermsOfServicePageViewModelTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ReAgreeTermsOfServicePageViewModelTests.cs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using Covid19Radar.Model;
 using Covid19Radar.Services;
@@ -62,6 +63,9 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
         [Fact]
         public void OpenWebViewCommandTests()
         {
+            // The test is locale dependent
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+
             var reAgreeTermsOfServicePageViewModel = CreateViewModel();
             var updateInfo = new TermsUpdateInfoModel
             {

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ReAgreeTermsOfServicePageViewModelTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ReAgreeTermsOfServicePageViewModelTests.cs
@@ -3,9 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 using System;
-using System.Globalization;
 using System.Threading.Tasks;
 using Covid19Radar.Model;
+using Covid19Radar.Resources;
 using Covid19Radar.Services;
 using Covid19Radar.Services.Logs;
 using Covid19Radar.ViewModels;
@@ -63,9 +63,6 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
         [Fact]
         public void OpenWebViewCommandTests()
         {
-            // The test is locale dependent
-            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
-
             var reAgreeTermsOfServicePageViewModel = CreateViewModel();
             var updateInfo = new TermsUpdateInfoModel
             {
@@ -92,7 +89,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
             reAgreeTermsOfServicePageViewModel.OpenWebView.Execute(null);
 
             Assert.Equal(1, actualCalls);
-            Assert.Equal("https://www.mhlw.go.jp/cocoa/kiyaku_english.html", actualUri);
+            Assert.Equal(AppResources.UrlTermOfUse, actualUri);
             Assert.Equal(BrowserLaunchMode.SystemPreferred, actualLaunchMode);
         }
 


### PR DESCRIPTION
## Issue 番号 / Issue ID

- Close #269

## 目的 / Purpose

- Englishロケールに依存したテストが、その他の言語設定の環境で実行したときに失敗する課題を解消する

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

該当するテストのロケールを英語以外に書き換えた上で実行して、テストが失敗することを確認する。
次に、InvariantCultureを設定することで問題が解決するかを確認する。

```
            CultureInfo.CurrentUICulture = new CultureInfo("ja");
            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
```

### コードの入手 / Get the code

```
gh pr checkout 273
```

## 確認事項 / What to check

#272 で別手法の提案あり。今後、ロケール依存のテストが増えたときのための検討課題とする。


## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
