### PR TITLE
Move WorkManager initialization to Application#onCreate

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/MainActivity.cs
+++ b/Covid19Radar/Covid19Radar.Android/MainActivity.cs
@@ -8,9 +8,6 @@ using Android.OS;
 using Android.Runtime;
 using Android.Content;
 using Acr.UserDialogs;
-using Xamarin.ExposureNotifications;
-using System;
-using AndroidX.Work;
 
 namespace Covid19Radar.Droid
 {
@@ -25,16 +22,6 @@ namespace Covid19Radar.Droid
             ToolbarResource = Resource.Layout.Toolbar;
             base.SetTheme(Resource.Style.MainTheme);
             base.OnCreate(savedInstanceState);
-
-            // Override WorkRequest configuration
-            // Must be run before being scheduled with `ExposureNotification.Init()` in `App.OnInitialized()`
-            var repeatInterval = TimeSpan.FromHours(6);
-            Action<PeriodicWorkRequest.Builder> requestBuilder = b =>
-               b.SetConstraints(new Constraints.Builder()
-                   .SetRequiresBatteryNotLow(true)
-                   .SetRequiredNetworkType(NetworkType.Connected)
-                   .Build());
-            ExposureNotification.ConfigureBackgroundWorkRequest(repeatInterval, requestBuilder);
 
             Xamarin.Forms.Forms.SetFlags("RadioButton_Experimental");
             Xamarin.Essentials.Platform.Init(this, savedInstanceState);

--- a/Covid19Radar/Covid19Radar.Android/MainApplication.cs
+++ b/Covid19Radar/Covid19Radar.Android/MainApplication.cs
@@ -10,6 +10,9 @@ using Covid19Radar.Services.Logs;
 using Covid19Radar.Droid.Services.Logs;
 using Covid19Radar.Services;
 using Covid19Radar.Droid.Services;
+using AndroidX.Work;
+using Xamarin.ExposureNotifications;
+using Java.IO;
 
 namespace Covid19Radar.Droid
 {
@@ -28,8 +31,23 @@ namespace Covid19Radar.Droid
         {
             base.OnCreate();
 
+            // for Debug only
+            string timestamp = DateTime.Now.ToString().Replace("/", "-").Replace(" ", "_");
+            var file = new File(DataDir, $"{timestamp}.txt");
+            file.CreateNewFile();
+
+            // Override WorkRequest configuration
+            // Must be run before being scheduled with `ExposureNotification.Init()` in `App.OnInitialized()`
+            var repeatInterval = TimeSpan.FromHours(6);
+            static void requestBuilder(PeriodicWorkRequest.Builder b) =>
+               b.SetConstraints(new Constraints.Builder()
+                   .SetRequiresBatteryNotLow(true)
+                   .SetRequiredNetworkType(NetworkType.Connected)
+                   .Build());
+            ExposureNotification.ConfigureBackgroundWorkRequest(repeatInterval, requestBuilder);
+
+            App.InitExposureNotification();
             App.InitializeServiceLocator(RegisterPlatformTypes);
-            App.UseMockExposureNotificationImplementationIfNeeded();
         }
 
         private void RegisterPlatformTypes(IContainer container)

--- a/Covid19Radar/Covid19Radar.Android/MainApplication.cs
+++ b/Covid19Radar/Covid19Radar.Android/MainApplication.cs
@@ -12,7 +12,6 @@ using Covid19Radar.Services;
 using Covid19Radar.Droid.Services;
 using AndroidX.Work;
 using Xamarin.ExposureNotifications;
-using Java.IO;
 
 namespace Covid19Radar.Droid
 {
@@ -30,11 +29,6 @@ namespace Covid19Radar.Droid
         public override void OnCreate()
         {
             base.OnCreate();
-
-            // for Debug only
-            string timestamp = DateTime.Now.ToString().Replace("/", "-").Replace(" ", "_");
-            var file = new File(DataDir, $"{timestamp}.txt");
-            file.CreateNewFile();
 
             App.InitializeServiceLocator(RegisterPlatformTypes);
 

--- a/Covid19Radar/Covid19Radar.Android/MainApplication.cs
+++ b/Covid19Radar/Covid19Radar.Android/MainApplication.cs
@@ -36,6 +36,8 @@ namespace Covid19Radar.Droid
             var file = new File(DataDir, $"{timestamp}.txt");
             file.CreateNewFile();
 
+            App.InitializeServiceLocator(RegisterPlatformTypes);
+
             // Override WorkRequest configuration
             // Must be run before being scheduled with `ExposureNotification.Init()` in `App.OnInitialized()`
             var repeatInterval = TimeSpan.FromHours(6);
@@ -47,7 +49,6 @@ namespace Covid19Radar.Droid
             ExposureNotification.ConfigureBackgroundWorkRequest(repeatInterval, requestBuilder);
 
             App.InitExposureNotification();
-            App.InitializeServiceLocator(RegisterPlatformTypes);
         }
 
         private void RegisterPlatformTypes(IContainer container)

--- a/Covid19Radar/Covid19Radar.iOS/AppDelegate.cs
+++ b/Covid19Radar/Covid19Radar.iOS/AppDelegate.cs
@@ -36,8 +36,9 @@ namespace Covid19Radar.iOS
         {
             NSUrlCache.SharedCache.RemoveAllCachedResponses();
 
-            App.InitExposureNotification();
             App.InitializeServiceLocator(RegisterPlatformTypes);
+
+            App.InitExposureNotification();
 
             Xamarin.Forms.Forms.SetFlags("RadioButton_Experimental");
 

--- a/Covid19Radar/Covid19Radar.iOS/AppDelegate.cs
+++ b/Covid19Radar/Covid19Radar.iOS/AppDelegate.cs
@@ -36,8 +36,8 @@ namespace Covid19Radar.iOS
         {
             NSUrlCache.SharedCache.RemoveAllCachedResponses();
 
+            App.InitExposureNotification();
             App.InitializeServiceLocator(RegisterPlatformTypes);
-            App.UseMockExposureNotificationImplementationIfNeeded();
 
             Xamarin.Forms.Forms.SetFlags("RadioButton_Experimental");
 

--- a/Covid19Radar/Covid19Radar/App.xaml.cs
+++ b/Covid19Radar/Covid19Radar/App.xaml.cs
@@ -86,7 +86,7 @@ namespace Covid19Radar
 #if USE_MOCK
             // For debug mode, set the mock api provider to interact
             // with some fake data
-            Xamarin.ExposureNotifications.ExposureNotification.OverrideNativeImplementation(new Services.TestNativeImplementation());
+            ExposureNotification.OverrideNativeImplementation(new Services.TestNativeImplementation());
 #endif
         }
 

--- a/Covid19Radar/Covid19Radar/App.xaml.cs
+++ b/Covid19Radar/Covid19Radar/App.xaml.cs
@@ -17,6 +17,7 @@ using Covid19Radar.Services.Logs;
 using System;
 using CommonServiceLocator;
 using Covid19Radar.Common;
+using Xamarin.ExposureNotifications;
 
 /*
  * Our mission...is
@@ -50,8 +51,6 @@ namespace Covid19Radar
             LogFileService = Container.Resolve<ILogFileService>();
             LogFileService.AddSkipBackupAttribute();
 
-            Xamarin.ExposureNotifications.ExposureNotification.Init();
-
             // Local Notification tap event listener
             //NotificationCenter.Current.NotificationTapped += OnNotificationTapped;
             LogUnobservedTaskExceptions();
@@ -75,7 +74,14 @@ namespace Covid19Radar
             LoggerService.EndMethod();
         }
 
-        public static void UseMockExposureNotificationImplementationIfNeeded()
+        public static void InitExposureNotification()
+        {
+            UseMockExposureNotificationImplementationIfNeeded();
+
+            ExposureNotification.Init();
+        }
+
+        private static void UseMockExposureNotificationImplementationIfNeeded()
         {
 #if USE_MOCK
             // For debug mode, set the mock api provider to interact


### PR DESCRIPTION
## Issue 番号 / Issue ID

<!--
  Issue 番号なき PR は受け付けません。
  PRs without the issue IDs are never accepted.
-->

- Close #196

## 目的 / Purpose

https://github.com/cocoa-mhlw/cocoa/issues/136#issuecomment-846334884 より。

Android版の接触確認API（Google Play Services）は、システムが接触確認アプリを停止してバックグランド処理が実行されない場合に備えて「Force-stop Handling」を備えている。
Google Play Servicesは、Force-stop Handlingで６時間に１回の頻度でアプリのプロセスを再度起動して、WorkManagerのJobを復帰する。

ところが、一部の端末（some popular devices）では、Force-stopされたかを判定する処理でSecurityExceptionが発生するため、Force-stop Handlingが完了せず、Jobの復帰が行われない可能性がある。

https://github.com/androidx/androidx/commit/9b770633fafed35c5185f1cc2b52612a451ccdb9#diff-7794a8af74a01c5c6d2ee10558482274048bd3aa011aaca99459c2c5049fd7dd

問題に対応するためWorkManagerにWorkerを登録する一連の処理を、現在の`App.xaml.cs`からAndroidの`Application#onCreate`に移動することで、Force-stop HandlingでApplicationプロセスが起動されたタイミングでWorkerを再セットするように変更する。

<!--
  その変更を提案する意図をご説明ください。どの問題が解決したり、機能的な追加がなされたりしますか。
  Describe the intention of the changes being proposed. What problem does it solve or functionality does it add?
-->

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

<!--
  当てはまるもの 1 つに「x」とマークしてください。
  Mark one with an "x".
-->

```
[x] Yes
[ ] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

## 確認事項 / What to check

 1. BuildType `Debug` でビルドする（Exposure Notificationアプリとしてシステムに登録する必要があるため）
 2. Android端末でCOCOAを起動する
 3. Device File Explorerなどで、COCOAのData Directoryに `timestamp`.txt が作成されていることを確認する（MainApplicationが起動する度に、起動時刻のファイルが作成される）
 4. `adb shell dumpsys jobscheduler`で、Job SchedulerにCOCOAのJob（Worker）が登録されていることを確認する（ [jobscheduler-202107152120.txt](https://github.com/cocoa-mhlw/cocoa/files/6827082/jobscheduler-202107152120.txt) ）
 5. `adb shell am force-stop [COCOAのパッケージ名]` で、COCOAを停止する
 6. `adb shell dumpsys jobscheduler`で、Job SchedulerにCOCOAのJob（Worker）が消えていることを確認する（ [jobscheduler-202107152121-forcestopped.txt](https://github.com/cocoa-mhlw/cocoa/files/6827085/jobscheduler-202107152121-forcestopped.txt) ）
 7. ６時間程度待つ
 8. Device File Explorerなどで、COCOAのData Directoryに 新しい`timestamp`.txt が作成されていることを確認する（Force-stop handlingでCOCOAのアプリケーションプロセスが再起動されたことを確認する）（ [Screen Shot 2021-07-16 at 10.06.20.png](https://user-images.githubusercontent.com/932136/125876736-b55f40e2-fd59-40ec-98f7-cec9f45a257f.png) ）
 9. `adb shell dumpsys jobscheduler`で、Job SchedulerにCOCOAのJob（Worker）が（ふたたび）登録されていることを確認する
（ [jobscheduler-202107161006-forcestophandling.txt](https://github.com/cocoa-mhlw/cocoa/files/6827089/jobscheduler-202107161006-forcestophandling.txt) ）

### iOS側のコードレビュー注意

ExposureNotificationの初期化処理を`App`からAndroidおよびiOSのコードに移動させたため、iOS側にも影響がある。

アプリ起動時に`ExposureNotification.ios.cs`の`PlatformScheduleFetch`が呼ばれることは確認しているが、念のためチェックが必要と考えます。

チェックしました。
起動時に`PlatformScheduleFetch`が呼ばれていることと、約4時間ごとにバックグラウンド処理が実行されることを確認しています（ 
[ios_log-init_work_application_oncreate.txt](https://github.com/cocoa-mhlw/cocoa/files/6829190/ios_log-init_work_application_oncreate.txt) ）。


## その他 / Other information

特になし。