### PR TITLE
[Android] Show ContactedNotifyPage when notification is tapped.

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/Services/LocalNotificationService.cs
+++ b/Covid19Radar/Covid19Radar.Android/Services/LocalNotificationService.cs
@@ -60,7 +60,7 @@ namespace Covid19Radar.Droid.Services
         {
             _loggerService.StartMethod();
 
-            Intent intent = MainActivity.NewIntent(Platform.AppContext);
+            Intent intent = MainActivity.NewIntent(Platform.AppContext, Destination.ContactedNotifyPage);
             PendingIntent pendingIntent = PendingIntent.GetActivity(
                 Platform.AppContext,
                 REQUEST_CODE,

--- a/Covid19Radar/Covid19Radar.iOS/AppDelegate.cs
+++ b/Covid19Radar/Covid19Radar.iOS/AppDelegate.cs
@@ -56,7 +56,7 @@ namespace Covid19Radar.iOS
             _notificationCenterDelegate.OnRecieved += (UserNotificationCenterDelegate sender, UNNotificationResponse response) => {
                 // TODO:- C#だと循環参照しない？
                 // TODO:- 起動時遷移のときに連続して呼ばれるのは大丈夫か要確認(アニメーションがないので大丈夫そう？)
-                _prismApp?.NavigateToSplash(DeepLinkDestination.ContactedNotifyPage); 
+                _prismApp?.NavigateToSplash(Destination.ContactedNotifyPage);
             };
             UNUserNotificationCenter.Current.Delegate = _notificationCenterDelegate;
 

--- a/Covid19Radar/Covid19Radar/App.xaml.cs
+++ b/Covid19Radar/Covid19Radar/App.xaml.cs
@@ -28,12 +28,6 @@ using Xamarin.ExposureNotifications;
 [assembly: XamlCompilation(XamlCompilationOptions.Compile)]
 namespace Covid19Radar
 {
-    public enum DeepLinkDestination: int
-    {
-        HomePage,
-        ContactedNotifyPage
-    }
-
     public partial class App : PrismApplication
     {
         private ILoggerService LoggerService;
@@ -57,18 +51,16 @@ namespace Covid19Radar
             LogFileService = Container.Resolve<ILogFileService>();
             LogFileService.AddSkipBackupAttribute();
 
-            // Local Notification tap event listener
-            //NotificationCenter.Current.NotificationTapped += OnNotificationTapped;
             LogUnobservedTaskExceptions();
-            NavigateToSplash(DeepLinkDestination.HomePage);
+            NavigateToSplash(Destination.HomePage);
 
             LoggerService.EndMethod();
         }
 
-        public async void NavigateToSplash(DeepLinkDestination destination)
+        public async void NavigateToSplash(Destination destination)
         {
             var param = SplashPage.CreateNavigationParams(destination);
-            INavigationResult result = await NavigationService.NavigateAsync("/" + nameof(SplashPage), param);
+            INavigationResult result = await NavigationService.NavigateAsync(Destination.SplashPage.ToPath(), param);
 
             if (!result.Success)
             {
@@ -83,6 +75,15 @@ namespace Covid19Radar
                 };
                 System.Diagnostics.Debugger.Break();
             }
+        }
+
+        public async Task NavigateTo(Destination destination)
+        {
+            LoggerService.StartMethod();
+
+            await NavigationService.NavigateAsync(destination.ToPath());
+
+            LoggerService.EndMethod();
         }
 
         public static void InitExposureNotification()
@@ -126,11 +127,6 @@ namespace Covid19Radar
             var container = (ServiceLocator.Current as ContainerServiceLocator).CopyContainerWithRegistrations();
             return new DryIocContainerExtension(container);
         }
-
-        //protected void OnNotificationTapped(NotificationTappedEventArgs e)
-        //{
-        //    NavigationService.NavigateAsync(nameof(MenuPage) + "/" + nameof(NavigationPage) + "/" + nameof(HomePage));
-        //}
 
         protected override void RegisterTypes(IContainerRegistry containerRegistry)
         {

--- a/Covid19Radar/Covid19Radar/Destination.cs
+++ b/Covid19Radar/Covid19Radar/Destination.cs
@@ -1,0 +1,34 @@
+﻿/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using Covid19Radar.Views;
+using Xamarin.Forms;
+
+namespace Covid19Radar
+{
+    public enum Destination : int
+    {
+        SplashPage,
+        HomePage,
+        ContactedNotifyPage,
+    }
+
+    internal static class DestinationExtensions
+    {
+        private static string SplashPagePath = "/" + nameof(SplashPage);
+        private static string HomePagePath => "/" + nameof(MenuPage) + "/" + nameof(NavigationPage) + "/" + nameof(HomePage);
+        private static string ContactedNotifyPagePath => HomePagePath + "/" + nameof(ContactedNotifyPage);
+
+        internal static string ToPath(this Destination destination)
+        {
+            return destination switch
+            {
+                Destination.SplashPage => SplashPagePath,
+                Destination.HomePage => HomePagePath,
+                Destination.ContactedNotifyPage => ContactedNotifyPagePath,
+                _ => throw new System.NotImplementedException()
+            };
+        }
+    }
+}

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/SplashPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/SplashPageViewModel.cs
@@ -6,14 +6,11 @@ using Covid19Radar.Services;
 using Covid19Radar.Services.Logs;
 using Covid19Radar.Views;
 using Prism.Navigation;
-using Xamarin.Forms;
 
 namespace Covid19Radar.ViewModels
 {
     public class SplashPageViewModel : ViewModelBase
     {
-        private string HomePagePath => "/" + nameof(MenuPage) + "/" + nameof(NavigationPage) + "/" + nameof(HomePage); //TODO パスをクラスに切り出す
-
         private readonly ITermsUpdateService _termsUpdateService;
         private readonly ILoggerService _loggerService;
         private readonly IUserDataService _userDataService;
@@ -57,15 +54,15 @@ namespace Covid19Radar.ViewModels
                     _loggerService.Info($"Transition to ReAgreePrivacyPolicyPage");
                     _ = await NavigationService.NavigateAsync(nameof(ReAgreePrivacyPolicyPage), param);
                 }
-                else if (parameters.GetValue<DeepLinkDestination>(SplashPage.DeepLinkDestinationKey) == DeepLinkDestination.ContactedNotifyPage)
+                else if (parameters.GetValue<Destination>(SplashPage.DestinationKey) == Destination.ContactedNotifyPage)
                 {
-                    _loggerService.Info($"Transition to ContactPage");
-                    _ = await NavigationService.NavigateAsync(HomePagePath + "/" + nameof(ContactedNotifyPage));
+                    _loggerService.Info($"Transition to DeepLinkDestination.ContactedNotifyPage");
+                    _ = await NavigationService.NavigateAsync(Destination.ContactedNotifyPage.ToPath());
                 }
                 else
                 {
                     _loggerService.Info($"Transition to HomePage");
-                    _ = await NavigationService.NavigateAsync(HomePagePath);
+                    _ = await NavigationService.NavigateAsync(Destination.HomePage.ToPath());
                 }
             }
             else

--- a/Covid19Radar/Covid19Radar/Views/HomePage/SplashPage.xaml.cs
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/SplashPage.xaml.cs
@@ -11,13 +11,13 @@ namespace Covid19Radar.Views
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class SplashPage : ContentPage
     {
-        public const string DeepLinkDestinationKey = "destination";
+        public const string DestinationKey = "destination";
 
-        public static NavigationParameters CreateNavigationParams(DeepLinkDestination destination)
+        public static NavigationParameters CreateNavigationParams(Destination destination)
         {
             return new NavigationParameters()
             {
-                { DeepLinkDestinationKey, destination }
+                { DestinationKey, destination }
             };
         }
 


### PR DESCRIPTION
## Issue 番号 / Issue ID

- #207
- #290

## 目的 / Purpose

<!--
  その変更を提案する意図をご説明ください。どの問題が解決したり、機能的な追加がなされたりしますか。
  Describe the intention of the changes being proposed. What problem does it solve or functionality does it add?
-->

- 接触を知らせる通知をタップすると、直接接触情報の確認画面を開くようにする。

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[x] Yes
[ ] No
```

## Pull Request の種類 / Pull Request type

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
gh pr checkout 292
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

-

## その他 / Other information

「アプリを起動するときにホーム画面でなく特定のページを開く」という仕組みはさまざまな用途がありそうなので、ここでやり方を押さえておきたい。