### PR TITLE
Extract string resources to AppResources.

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/Services/LocalNotificationService.cs
+++ b/Covid19Radar/Covid19Radar.Android/Services/LocalNotificationService.cs
@@ -28,8 +28,8 @@ namespace Covid19Radar.Droid.Services
             var notification = new NotificationCompat
                 .Builder(Platform.AppContext, MainApplication.NOTIFICATION_CHANNEL_ID)
                 .SetSmallIcon(Resource.Drawable.ic_notification)
-                .SetContentTitle(AppResources.AndroidNotificationTitle)
-                .SetContentText(AppResources.AndroidNotificationText)
+                .SetContentTitle(AppResources.LocalExposureNotificationTitle)
+                .SetContentText(AppResources.LocalExposureNotificationContent)
                 .SetVisibility(NotificationCompat.VisibilitySecret)
                 .SetContentIntent(pendingIntent)
                 .SetLocalOnly(true)

--- a/Covid19Radar/Covid19Radar.iOS/Services/LocalNotificationService.cs
+++ b/Covid19Radar/Covid19Radar.iOS/Services/LocalNotificationService.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Covid19Radar.Resources;
 using Covid19Radar.Services;
 using Foundation;
 using UserNotifications;
@@ -32,8 +33,8 @@ namespace Covid19Radar.iOS.Services
                 var content = new UNMutableNotificationContent();
 
                 // TODO: 文言
-                content.Title = "重要なお知らせ";
-                content.Body = "新型コロナウイルス感染症の陽性登録者と接触した可能性があります。接触確認アプリにアクセスして陽性者との接触を確認してください。";
+                content.Title = AppResources.LocalExposureNotificationTitle;
+                content.Body = AppResources.LocalExposureNotificationContent;
 
                 // TODO: 発動タイミングは即時で大丈夫か
                 var request = UNNotificationRequest.FromIdentifier(new NSUuid().AsString(), content, null);

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.Designer.cs
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.Designer.cs
@@ -1487,15 +1487,15 @@ namespace Covid19Radar.Resources {
             }
         }
         
-        public static string AndroidNotificationTitle {
+        public static string LocalExposureNotificationTitle {
             get {
-                return ResourceManager.GetString("AndroidNotificationTitle", resourceCulture);
+                return ResourceManager.GetString("LocalExposureNotificationTitle", resourceCulture);
             }
         }
         
-        public static string AndroidNotificationText {
+        public static string LocalExposureNotificationContent {
             get {
-                return ResourceManager.GetString("AndroidNotificationText", resourceCulture);
+                return ResourceManager.GetString("LocalExposureNotificationContent", resourceCulture);
             }
         }
         

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.resx
@@ -1064,13 +1064,13 @@ Storage :</value>
     <value>Exposure notification</value>
     <comment>接触を通知</comment>
   </data>
-  <data name="AndroidNotificationTitle" xml:space="preserve">
-    <value>Exposure notification</value>
-    <comment>接触を通知</comment>
+  <data name="LocalExposureNotificationTitle" xml:space="preserve">
+    <value>Important Notice</value>
+    <comment>重要なお知らせ</comment>
   </data>
-  <data name="AndroidNotificationText" xml:space="preserve">
-    <value>You were in close contact with COVID-19 positive users.</value>
-    <comment>陽性者との接触が確認されました。</comment>
+  <data name="LocalExposureNotificationContent" xml:space="preserve">
+    <value>It is possible you have been in close proximity to a user who tested positive for COVID-19. Tap for more details</value>
+    <comment>新型コロナウイルス感染症の陽性登録者と接触した可能性があります。タップして詳細を確認してください</comment>
   </data>
 	<data name="NoteSymbol" xml:space="preserve">
     <value>* </value>


### PR DESCRIPTION
## Issue 番号 / Issue ID

- #207
- #290 

## 目的 / Purpose

- iOSの通知の文字列リソースをAppResourcesを使うようにする。
- Android版の通知と文字列を統合する

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

- AndroidとiOSで通知の文言は統一すべき？
- 通知の送信許諾ダイアログがアプリを起動してすぐ（規約も表示されていない状態で）表示されるので、可能であればホーム画面表示のタイミングになると良いかも。
- ただ現時点ではテキストの確認と調整を優先した方が良さそうですね。

## その他 / Other information
