### PR TITLE
Change ask permission for user-notification timing.

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/MainApplication.cs
+++ b/Covid19Radar/Covid19Radar.Android/MainApplication.cs
@@ -10,10 +10,6 @@ using Covid19Radar.Services.Logs;
 using Covid19Radar.Droid.Services.Logs;
 using Covid19Radar.Services;
 using Covid19Radar.Droid.Services;
-using AndroidX.Core.App;
-using Covid19Radar.Resources;
-using Android.OS;
-using CommonServiceLocator;
 
 namespace Covid19Radar.Droid
 {
@@ -24,8 +20,6 @@ namespace Covid19Radar.Droid
 #endif
     public class MainApplication : Application
     {
-        public const string NOTIFICATION_CHANNEL_ID = "notification_channel_cocoa_202107";
-
         public MainApplication(IntPtr handle, JniHandleOwnership transfer) : base(handle, transfer)
         {
         }
@@ -36,30 +30,6 @@ namespace Covid19Radar.Droid
 
             App.InitializeServiceLocator(RegisterPlatformTypes);
             App.UseMockExposureNotificationImplementationIfNeeded();
-
-            CreateNotificationChannel();
-
-#if DEBUG
-            ILocalNotificationService localNotificationService = ServiceLocator.Current.GetInstance<ILocalNotificationService>();
-            localNotificationService.ShowExposureNotification();
-#endif
-        }
-
-        private void CreateNotificationChannel()
-        {
-            if (Build.VERSION.SdkInt < BuildVersionCodes.O)
-            {
-                return;
-            }
-
-            NotificationChannelCompat notificationChannel = new NotificationChannelCompat
-                .Builder(NOTIFICATION_CHANNEL_ID, NotificationManagerCompat.ImportanceDefault)
-                .SetName(AppResources.AndroidNotificationChannelName)
-                .SetShowBadge(false)
-                .Build();
-
-            var nm = NotificationManagerCompat.From(this);
-            nm.CreateNotificationChannel(notificationChannel);
         }
 
         private void RegisterPlatformTypes(IContainer container)

--- a/Covid19Radar/Covid19Radar.Android/Services/LocalNotificationService.cs
+++ b/Covid19Radar/Covid19Radar.Android/Services/LocalNotificationService.cs
@@ -2,21 +2,62 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
+using Android.OS;
 using AndroidX.Core.App;
 using Covid19Radar.Resources;
 using Covid19Radar.Services;
+using Covid19Radar.Services.Logs;
 using Xamarin.Essentials;
 
 namespace Covid19Radar.Droid.Services
 {
     public class LocalNotificationService : ILocalNotificationService
     {
+        private const string NOTIFICATION_CHANNEL_ID = "notification_channel_cocoa_202107";
+
         private const int NOTIFICATION_ID_EXPOSURE = 0x1234;
 
-        public void ShowExposureNotification()
+        private readonly ILoggerService _loggerService;
+
+        public LocalNotificationService(ILoggerService loggerService)
         {
+            _loggerService = loggerService;
+        }
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+        public async Task PrepareAsync()
+        {
+            _loggerService.StartMethod();
+
+            if (Build.VERSION.SdkInt < BuildVersionCodes.O)
+            {
+                _loggerService.Info($"Platform version {Build.VERSION.SdkInt} is not supported NotificationChannel.");
+                _loggerService.EndMethod();
+                return;
+            }
+
+            NotificationChannelCompat notificationChannel = new NotificationChannelCompat
+                .Builder(NOTIFICATION_CHANNEL_ID, NotificationManagerCompat.ImportanceDefault)
+                .SetName(AppResources.AndroidNotificationChannelName)
+                .SetShowBadge(false)
+                .Build();
+
+            var nm = NotificationManagerCompat.From(Platform.AppContext);
+            nm.CreateNotificationChannel(notificationChannel);
+
+            _loggerService.Info($"NotificationChannel created.");
+            _loggerService.EndMethod();
+        }
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+        public async Task ShowExposureNotificationAsync()
+        {
+            _loggerService.StartMethod();
+
             Intent intent = MainActivity.NewIntent(Platform.AppContext);
             PendingIntent pendingIntent = PendingIntent.GetActivity(
                 Platform.AppContext,
@@ -26,7 +67,7 @@ namespace Covid19Radar.Droid.Services
                 );
 
             var notification = new NotificationCompat
-                .Builder(Platform.AppContext, MainApplication.NOTIFICATION_CHANNEL_ID)
+                .Builder(Platform.AppContext, NOTIFICATION_CHANNEL_ID)
                 .SetSmallIcon(Resource.Drawable.ic_notification)
                 .SetContentTitle(AppResources.LocalExposureNotificationTitle)
                 .SetContentText(AppResources.LocalExposureNotificationContent)
@@ -38,6 +79,10 @@ namespace Covid19Radar.Droid.Services
 
             var nm = NotificationManagerCompat.From(Platform.AppContext);
             nm.Notify(NOTIFICATION_ID_EXPOSURE, notification);
+
+            _loggerService.Info("Local exposure notification shown.");
+            _loggerService.EndMethod();
         }
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
     }
 }

--- a/Covid19Radar/Covid19Radar.iOS/AppDelegate.cs
+++ b/Covid19Radar/Covid19Radar.iOS/AppDelegate.cs
@@ -9,7 +9,6 @@ using Covid19Radar.Services;
 using Covid19Radar.Services.Logs;
 using DryIoc;
 using Foundation;
-using UserNotifications;
 using UIKit;
 using Xamarin.Forms;
 
@@ -48,11 +47,7 @@ namespace Covid19Radar.iOS
             FFImageLoading.Forms.Platform.CachedImageRenderer.Init();
             global::FFImageLoading.ImageService.Instance.Initialize(new FFImageLoading.Config.Configuration());
 
-            AskPermissionForUserNotification();
-
             LoadApplication(new App());
-
-
 
             UIApplication.SharedApplication.SetMinimumBackgroundFetchInterval(UIApplication.BackgroundFetchIntervalMinimum);
             return base.FinishedLaunching(app, options);
@@ -62,14 +57,6 @@ namespace Covid19Radar.iOS
         {
             base.OnActivated(uiApplication);
             MessagingCenter.Send((object)this, AppConstants.IosOnActivatedMessage);
-        }
-
-        private void AskPermissionForUserNotification()
-        {
-            UNUserNotificationCenter.Current.RequestAuthorization(UNAuthorizationOptions.Alert | UNAuthorizationOptions.Sound, (granted, error) =>
-            {
-                // TODO: 許諾の状態に応じてなにか対応を行うか/アラートのタイプ
-            });
         }
 
         private void RegisterPlatformTypes(IContainer container)

--- a/Covid19Radar/Covid19Radar/Services/ExposureNotificationHandler.cs
+++ b/Covid19Radar/Covid19Radar/Services/ExposureNotificationHandler.cs
@@ -127,7 +127,7 @@ namespace Covid19Radar.Services
 
             if (exposureInformationList.Count > 0)
             {
-                LocalNotificationService.ShowExposureNotification();
+                await LocalNotificationService.ShowExposureNotificationAsync();
             }
 
             loggerService.EndMethod();

--- a/Covid19Radar/Covid19Radar/Services/ILocalNotificationService.cs
+++ b/Covid19Radar/Covid19Radar/Services/ILocalNotificationService.cs
@@ -2,10 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+using System.Threading.Tasks;
+
 namespace Covid19Radar.Services
 {
     public interface ILocalNotificationService
     {
-        public void ShowExposureNotification();
+        public Task PrepareAsync();
+
+        public Task ShowExposureNotificationAsync();
     }
 }

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
@@ -88,6 +88,8 @@ namespace Covid19Radar.ViewModels
                 loggerService.Exception("Failed to exposure notification status.", ex);
                 loggerService.EndMethod();
             }
+
+            await localNotificationService.PrepareAsync();
         }
 
         public Command OnClickExposures => new Command(async () =>
@@ -127,11 +129,9 @@ namespace Covid19Radar.ViewModels
             loggerService.EndMethod();
         }
 
-        public override async void OnAppearing()
+        public override void OnAppearing()
         {
             base.OnAppearing();
-
-            await localNotificationService.PrepareAsync();
 
             SettingDaysOfUse();
         }

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
@@ -19,6 +19,7 @@ namespace Covid19Radar.ViewModels
         private readonly ILoggerService loggerService;
         private readonly IUserDataService userDataService;
         private readonly IExposureNotificationService exposureNotificationService;
+        private readonly ILocalNotificationService localNotificationService;
 
         private string _startDate;
         private string _pastDate;
@@ -34,12 +35,19 @@ namespace Covid19Radar.ViewModels
             set { SetProperty(ref _pastDate, value); }
         }
 
-        public HomePageViewModel(INavigationService navigationService, ILoggerService loggerService, IUserDataService userDataService, IExposureNotificationService exposureNotificationService) : base(navigationService)
+        public HomePageViewModel(
+            INavigationService navigationService,
+            ILoggerService loggerService,
+            IUserDataService userDataService,
+            IExposureNotificationService exposureNotificationService,
+            ILocalNotificationService localNotificationService
+            ) : base(navigationService)
         {
             Title = AppResources.HomePageTitle;
             this.loggerService = loggerService;
             this.userDataService = userDataService;
             this.exposureNotificationService = exposureNotificationService;
+            this.localNotificationService = localNotificationService;
         }
 
         public override async void Initialize(INavigationParameters parameters)
@@ -119,9 +127,12 @@ namespace Covid19Radar.ViewModels
             loggerService.EndMethod();
         }
 
-        public override void OnAppearing()
+        public override async void OnAppearing()
         {
             base.OnAppearing();
+
+            await localNotificationService.PrepareAsync();
+
             SettingDaysOfUse();
         }
 


### PR DESCRIPTION
Add logging on user-notification process.

## Issue 番号 / Issue ID

- #207
- #290

## 目的 / Purpose

通知チャンネルの登録（Android）と、ローカル通知の許諾（iOS）のタイミングがアプリ起動時だと、初回起動時、利用規約に合意していないユーザーからは気が早く見えてしまうので、ホーム画面を表示したタイミングに変更した。

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[x] Yes
[ ] No
```

## Pull Request の種類 / Pull Request type

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
gh pr checkout 296
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

- ログの取得内容（これはdevelopブランチへのPR時にcocoa-devに見てもらった方がよさそう）

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
