### PR TITLE
Fix exposure unit always Japanese.

### DIFF
--- a/Covid19Radar/Covid19Radar/Resources/AppResources.Designer.cs
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.Designer.cs
@@ -125,6 +125,30 @@ namespace Covid19Radar.Resources {
             }
         }
         
+        public static string ExposuresPageExposureUnitPluralZero {
+            get {
+                return ResourceManager.GetString("ExposuresPageExposureUnitPluralZero", resourceCulture);
+            }
+        }
+        
+        public static string ExposuresPageExposureUnitPluralOnce {
+            get {
+                return ResourceManager.GetString("ExposuresPageExposureUnitPluralOnce", resourceCulture);
+            }
+        }
+        
+        public static string ExposuresPageExposureUnitPluralTwice {
+            get {
+                return ResourceManager.GetString("ExposuresPageExposureUnitPluralTwice", resourceCulture);
+            }
+        }
+        
+        public static string ExposuresPageExposureUnitPlural {
+            get {
+                return ResourceManager.GetString("ExposuresPageExposureUnitPlural", resourceCulture);
+            }
+        }
+        
         public static string ExposuresPageNoExposures {
             get {
                 return ResourceManager.GetString("ExposuresPageNoExposures", resourceCulture);

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.Designer.cs
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.Designer.cs
@@ -125,12 +125,6 @@ namespace Covid19Radar.Resources {
             }
         }
         
-        public static string ExposuresPageExposureUnitPluralZero {
-            get {
-                return ResourceManager.GetString("ExposuresPageExposureUnitPluralZero", resourceCulture);
-            }
-        }
-        
         public static string ExposuresPageExposureUnitPluralOnce {
             get {
                 return ResourceManager.GetString("ExposuresPageExposureUnitPluralOnce", resourceCulture);

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.Designer.cs
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.Designer.cs
@@ -137,12 +137,6 @@ namespace Covid19Radar.Resources {
             }
         }
         
-        public static string ExposuresPageExposureUnitPluralTwice {
-            get {
-                return ResourceManager.GetString("ExposuresPageExposureUnitPluralTwice", resourceCulture);
-            }
-        }
-        
         public static string ExposuresPageExposureUnitPlural {
             get {
                 return ResourceManager.GetString("ExposuresPageExposureUnitPlural", resourceCulture);

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.en.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.en.resx
@@ -56,6 +56,14 @@
     <value>How to use</value>
     <comment>Tab How to use</comment>
   </data>
+  <data name="ExposuresPageExposureUnitPluralOnce" xml:space="preserve">
+    <value>1 exposure</value>
+    <comment>1回の接触</comment>
+  </data>
+  <data name="ExposuresPageExposureUnitPlural" xml:space="preserve">
+    <value>{0} exposures</value>
+    <comment>{0}回の接触</comment>
+  </data>
 	<data name="ExposuresPageNoExposures" xml:space="preserve">
     <value>No known exposures</value>
     <comment>If not found exposures data</comment>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
@@ -506,6 +506,22 @@
     <value>BluetoothがOffになっています。Bluetoothを有効にしてください。</value>
     <comment>BluetoothがOffになっています。Bluetoothを有効にしてください。</comment>
   </data>
+	<data name="ExposuresPageExposureUnitPluralZero" xml:space="preserve">
+    <value>接触なし</value>
+    <comment>回の接触</comment>
+  </data>
+	<data name="ExposuresPageExposureUnitPluralOnce" xml:space="preserve">
+    <value>1回の接触</value>
+    <comment>回の接触</comment>
+  </data>
+	<data name="ExposuresPageExposureUnitPluralTwice" xml:space="preserve">
+    <value>2回の接触</value>
+    <comment>回の接触</comment>
+  </data>
+	<data name="ExposuresPageExposureUnitPlural" xml:space="preserve">
+    <value>{0}回の接触</value>
+    <comment>回の接触</comment>
+  </data>
 	<data name="ExposuresPageTitle" xml:space="preserve">
     <value>過去14日間の接触一覧</value>
     <comment>過去14日間の接触一覧</comment>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
@@ -514,10 +514,6 @@
     <value>1回の接触</value>
     <comment>回の接触</comment>
   </data>
-	<data name="ExposuresPageExposureUnitPluralTwice" xml:space="preserve">
-    <value>2回の接触</value>
-    <comment>回の接触</comment>
-  </data>
 	<data name="ExposuresPageExposureUnitPlural" xml:space="preserve">
     <value>{0}回の接触</value>
     <comment>回の接触</comment>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
@@ -506,17 +506,13 @@
     <value>BluetoothがOffになっています。Bluetoothを有効にしてください。</value>
     <comment>BluetoothがOffになっています。Bluetoothを有効にしてください。</comment>
   </data>
-	<data name="ExposuresPageExposureUnitPluralZero" xml:space="preserve">
-    <value>接触なし</value>
-    <comment>回の接触</comment>
-  </data>
 	<data name="ExposuresPageExposureUnitPluralOnce" xml:space="preserve">
     <value>1回の接触</value>
-    <comment>回の接触</comment>
+    <comment>1回の接触</comment>
   </data>
 	<data name="ExposuresPageExposureUnitPlural" xml:space="preserve">
     <value>{0}回の接触</value>
-    <comment>回の接触</comment>
+    <comment>{0}回の接触</comment>
   </data>
 	<data name="ExposuresPageTitle" xml:space="preserve">
     <value>過去14日間の接触一覧</value>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.resx
@@ -169,6 +169,22 @@
     <value>How to use</value>
     <comment>Tab How to use</comment>
   </data>
+	<data name="ExposuresPageExposureUnitPluralZero" xml:space="preserve">
+    <value>0 exposure</value>
+    <comment>回の接触</comment>
+  </data>
+	<data name="ExposuresPageExposureUnitPluralOnce" xml:space="preserve">
+    <value>Once exposure</value>
+    <comment>回の接触</comment>
+  </data>
+	<data name="ExposuresPageExposureUnitPluralTwice" xml:space="preserve">
+    <value>Twice exposures</value>
+    <comment>回の接触</comment>
+  </data>
+	<data name="ExposuresPageExposureUnitPlural" xml:space="preserve">
+    <value>{0} exposures</value>
+    <comment>回の接触</comment>
+  </data>
 	<data name="ExposuresPageNoExposures" xml:space="preserve">
     <value>No known exposures</value>
     <comment>If not found exposures data</comment>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.resx
@@ -174,11 +174,7 @@
     <comment>回の接触</comment>
   </data>
 	<data name="ExposuresPageExposureUnitPluralOnce" xml:space="preserve">
-    <value>Once exposure</value>
-    <comment>回の接触</comment>
-  </data>
-	<data name="ExposuresPageExposureUnitPluralTwice" xml:space="preserve">
-    <value>Twice exposures</value>
+    <value>1 exposure</value>
     <comment>回の接触</comment>
   </data>
 	<data name="ExposuresPageExposureUnitPlural" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.resx
@@ -169,17 +169,13 @@
     <value>How to use</value>
     <comment>Tab How to use</comment>
   </data>
-	<data name="ExposuresPageExposureUnitPluralZero" xml:space="preserve">
-    <value>0 exposure</value>
-    <comment>回の接触</comment>
-  </data>
 	<data name="ExposuresPageExposureUnitPluralOnce" xml:space="preserve">
     <value>1 exposure</value>
-    <comment>回の接触</comment>
+    <comment>1回の接触</comment>
   </data>
 	<data name="ExposuresPageExposureUnitPlural" xml:space="preserve">
     <value>{0} exposures</value>
-    <comment>回の接触</comment>
+    <comment>{0}回の接触</comment>
   </data>
 	<data name="ExposuresPageNoExposures" xml:space="preserve">
     <value>No known exposures</value>

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposuresPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposuresPageViewModel.cs
@@ -5,7 +5,6 @@
 using Covid19Radar.Resources;
 using Covid19Radar.Services;
 using Prism.Navigation;
-using System;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
@@ -37,27 +36,6 @@ namespace Covid19Radar.ViewModels
                     _exposures.Add(ens);
                 }
             }
-
-            _exposures.Add(new ExposureSummary()
-            {
-                ExposureDate = DateTime.UtcNow.ToLocalTime().ToString("D", CultureInfo.CurrentCulture),
-                ExposureCountInt = 0
-            });
-            _exposures.Add(new ExposureSummary()
-            {
-                ExposureDate = DateTime.UtcNow.ToLocalTime().ToString("D", CultureInfo.CurrentCulture),
-                ExposureCountInt = 1
-            });
-            _exposures.Add(new ExposureSummary()
-            {
-                ExposureDate = DateTime.UtcNow.ToLocalTime().ToString("D", CultureInfo.CurrentCulture),
-                ExposureCountInt = 2
-            });
-            _exposures.Add(new ExposureSummary()
-            {
-                ExposureDate = DateTime.UtcNow.ToLocalTime().ToString("D", CultureInfo.CurrentCulture),
-                ExposureCountInt = 3
-            });
         }
     }
 

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposuresPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposuresPageViewModel.cs
@@ -32,7 +32,7 @@ namespace Covid19Radar.ViewModels
                 {
                     var ens = new ExposureSummary();
                     ens.ExposureDate = en.Key.ToLocalTime().ToString("D", CultureInfo.CurrentCulture);
-                    ens.ExposureCountInt = en.Count();
+                    ens.SetExposureCount(en.Count());
                     _exposures.Add(ens);
                 }
             }
@@ -43,12 +43,15 @@ namespace Covid19Radar.ViewModels
     {
         public string ExposureDate { get; set; }
 
-        private string _exposureCount;
+        private string _exposurePluralizeCount;
 
-        public string ExposureCount { get => _exposureCount; }
-        public int ExposureCountInt { set => _exposureCount = PluralizeCount(value); }
+        public string ExposurePluralizeCount => _exposurePluralizeCount;
 
-        private string PluralizeCount(int count)
+        public void SetExposureCount(int value) {
+            _exposurePluralizeCount = PluralizeCount(value);
+        }
+
+        private static string PluralizeCount(int count)
         {
             return count switch
             {

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposuresPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposuresPageViewModel.cs
@@ -74,7 +74,6 @@ namespace Covid19Radar.ViewModels
         {
             return count switch
             {
-                0 => AppResources.ExposuresPageExposureUnitPluralZero,
                 1 => AppResources.ExposuresPageExposureUnitPluralOnce,
                 _ => string.Format(AppResources.ExposuresPageExposureUnitPlural, count),
             };

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposuresPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposuresPageViewModel.cs
@@ -2,9 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-using Covid19Radar.Model;
+using Covid19Radar.Resources;
 using Covid19Radar.Services;
 using Prism.Navigation;
+using System;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
@@ -22,7 +23,7 @@ namespace Covid19Radar.ViewModels
 
         public ExposuresPageViewModel(INavigationService navigationService, IExposureNotificationService exposureNotificationService) : base(navigationService)
         {
-            Title = Resources.AppResources.MainExposures;
+            Title = AppResources.MainExposures;
             _exposures = new ObservableCollection<ExposureSummary>();
 
             var exposureInformationList = exposureNotificationService.GetExposureInformationListToDisplay();
@@ -32,16 +33,52 @@ namespace Covid19Radar.ViewModels
                 {
                     var ens = new ExposureSummary();
                     ens.ExposureDate = en.Key.ToLocalTime().ToString("D", CultureInfo.CurrentCulture);
-                    ens.ExposureCount = en.Count().ToString();
+                    ens.ExposureCountInt = en.Count();
                     _exposures.Add(ens);
                 }
             }
+
+            _exposures.Add(new ExposureSummary()
+            {
+                ExposureDate = DateTime.UtcNow.ToLocalTime().ToString("D", CultureInfo.CurrentCulture),
+                ExposureCountInt = 0
+            });
+            _exposures.Add(new ExposureSummary()
+            {
+                ExposureDate = DateTime.UtcNow.ToLocalTime().ToString("D", CultureInfo.CurrentCulture),
+                ExposureCountInt = 1
+            });
+            _exposures.Add(new ExposureSummary()
+            {
+                ExposureDate = DateTime.UtcNow.ToLocalTime().ToString("D", CultureInfo.CurrentCulture),
+                ExposureCountInt = 2
+            });
+            _exposures.Add(new ExposureSummary()
+            {
+                ExposureDate = DateTime.UtcNow.ToLocalTime().ToString("D", CultureInfo.CurrentCulture),
+                ExposureCountInt = 3
+            });
         }
     }
 
     public class ExposureSummary
     {
         public string ExposureDate { get; set; }
-        public string ExposureCount { get; set; }
+
+        private string _exposureCount;
+
+        public string ExposureCount { get => _exposureCount; }
+        public int ExposureCountInt { set => _exposureCount = PluralizeCount(value); }
+
+        private string PluralizeCount(int count)
+        {
+            return count switch
+            {
+                0 => AppResources.ExposuresPageExposureUnitPluralZero,
+                1 => AppResources.ExposuresPageExposureUnitPluralOnce,
+                2 => AppResources.ExposuresPageExposureUnitPluralTwice,
+                _ => string.Format(AppResources.ExposuresPageExposureUnitPlural, count),
+            };
+        }
     }
 }

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposuresPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposuresPageViewModel.cs
@@ -76,7 +76,6 @@ namespace Covid19Radar.ViewModels
             {
                 0 => AppResources.ExposuresPageExposureUnitPluralZero,
                 1 => AppResources.ExposuresPageExposureUnitPluralOnce,
-                2 => AppResources.ExposuresPageExposureUnitPluralTwice,
                 _ => string.Format(AppResources.ExposuresPageExposureUnitPlural, count),
             };
         }

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
@@ -98,7 +98,7 @@ namespace Covid19Radar.ViewModels
 
             var count = exposureNotificationService.GetExposureCountToDisplay();
             loggerService.Info($"Exposure count: {count}");
-            if (true)
+            if (count > 0)
             {
                 await NavigationService.NavigateAsync(nameof(ContactedNotifyPage));
                 loggerService.EndMethod();

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
@@ -98,7 +98,7 @@ namespace Covid19Radar.ViewModels
 
             var count = exposureNotificationService.GetExposureCountToDisplay();
             loggerService.Info($"Exposure count: {count}");
-            if (count > 0)
+            if (true)
             {
                 await NavigationService.NavigateAsync(nameof(ContactedNotifyPage));
                 loggerService.EndMethod();

--- a/Covid19Radar/Covid19Radar/Views/HomePage/ExposuresPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/ExposuresPage.xaml
@@ -32,7 +32,6 @@
                                     <Label.FormattedText>
                                         <FormattedString>
                                             <Span Text="{Binding ExposureCount}" />
-                                            <Span Text="個" />
                                         </FormattedString>
                                     </Label.FormattedText>
                                 </Label>

--- a/Covid19Radar/Covid19Radar/Views/HomePage/ExposuresPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/ExposuresPage.xaml
@@ -31,7 +31,7 @@
                                 <Label Style="{StaticResource CardLabelSmall}">
                                     <Label.FormattedText>
                                         <FormattedString>
-                                            <Span Text="{Binding ExposureCount}" />
+                                            <Span Text="{Binding ExposurePluralizeCount}" />
                                         </FormattedString>
                                     </Label.FormattedText>
                                 </Label>

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ExposuresPageViewModelTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ExposuresPageViewModelTests.cs
@@ -72,7 +72,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
         }
 
         [Fact]
-        public void ExposureUnitTestOnce()
+        public void ExposureUnitOnceTest()
         {
             var date = DateTime.UtcNow.Date;
             List<UserExposureInfo> testList = new List<UserExposureInfo>()
@@ -90,7 +90,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
         }
 
         [Fact]
-        public void ExposureUnitTestPlural()
+        public void ExposureUnitPluralTest()
         {
             var date = DateTime.UtcNow.Date;
 

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ExposuresPageViewModelTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ExposuresPageViewModelTests.cs
@@ -1,0 +1,112 @@
+﻿/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+using System;
+using System.Collections.Generic;
+using Covid19Radar.Model;
+using Covid19Radar.Resources;
+using Covid19Radar.Services;
+using Covid19Radar.ViewModels;
+using Moq;
+using Prism.Navigation;
+using Xunit;
+
+namespace Covid19Radar.UnitTests.ViewModels.HomePage
+{
+    public class ExposurePageViewModelTests
+    {
+        private readonly MockRepository mockRepository;
+        private readonly Mock<INavigationService> mockNavigationService;
+        private readonly Mock<IExposureNotificationService> mockExposureNotificationService;
+
+        public ExposurePageViewModelTests()
+        {
+            mockRepository = new MockRepository(MockBehavior.Default);
+            mockNavigationService = mockRepository.Create<INavigationService>();
+            mockExposureNotificationService = mockRepository.Create<IExposureNotificationService>();
+        }
+
+        private ExposuresPageViewModel CreateViewModel()
+        {
+            return new ExposuresPageViewModel(
+                mockNavigationService.Object,
+                mockExposureNotificationService.Object);
+        }
+
+        [Fact]
+        public void ExposureSummaryGroupingTest1()
+        {
+            var date = DateTime.UtcNow.Date;
+
+            List<UserExposureInfo> dummyList = new List<UserExposureInfo>()
+            {
+                new UserExposureInfo(date, TimeSpan.FromMinutes(15), 99, 99, UserRiskLevel.High),
+                new UserExposureInfo(date, TimeSpan.FromMinutes(20), 98, 98, UserRiskLevel.Medium),
+            };
+            mockExposureNotificationService.Setup(x => x.GetExposureInformationListToDisplay()).Returns(dummyList);
+
+            var vm = CreateViewModel();
+            vm.Initialize(new NavigationParameters());
+
+            Assert.Single(vm.Exposures);
+        }
+
+        [Fact]
+        public void ExposureSummaryGroupingTest2()
+        {
+            var date1 = DateTime.UtcNow.Date;
+            var date2 = DateTime.UtcNow.Date - TimeSpan.FromDays(1);
+
+            List<UserExposureInfo> testList = new List<UserExposureInfo>()
+            {
+                new UserExposureInfo(date1, TimeSpan.FromMinutes(15), 99, 99, UserRiskLevel.High),
+                new UserExposureInfo(date2, TimeSpan.FromMinutes(20), 98, 98, UserRiskLevel.Medium),
+            };
+            mockExposureNotificationService.Setup(x => x.GetExposureInformationListToDisplay()).Returns(testList);
+
+            var vm = CreateViewModel();
+            vm.Initialize(new NavigationParameters());
+
+            Assert.Equal(2, vm.Exposures.Count);
+        }
+
+        [Fact]
+        public void ExposureUnitTestOnce()
+        {
+            var date = DateTime.UtcNow.Date;
+            List<UserExposureInfo> testList = new List<UserExposureInfo>()
+            {
+                new UserExposureInfo(date, TimeSpan.FromMinutes(15), 99, 99, UserRiskLevel.High),
+            };
+            mockExposureNotificationService.Setup(x => x.GetExposureInformationListToDisplay()).Returns(testList);
+
+            var vm = CreateViewModel();
+            vm.Initialize(new NavigationParameters());
+
+            Assert.Single(vm.Exposures);
+
+            Assert.Equal(AppResources.ExposuresPageExposureUnitPluralOnce, vm.Exposures[0].ExposureCount);
+        }
+
+        [Fact]
+        public void ExposureUnitTestPlural()
+        {
+            var date = DateTime.UtcNow.Date;
+
+            List<UserExposureInfo> testList = new List<UserExposureInfo>()
+            {
+                new UserExposureInfo(date, TimeSpan.FromMinutes(15), 99, 99, UserRiskLevel.High),
+                new UserExposureInfo(date, TimeSpan.FromMinutes(20), 98, 98, UserRiskLevel.Medium)
+            };
+            mockExposureNotificationService.Setup(x => x.GetExposureInformationListToDisplay()).Returns(testList);
+
+            var vm = CreateViewModel();
+            vm.Initialize(new NavigationParameters());
+
+            Assert.Single(vm.Exposures);
+
+            Assert.Equal(string.Format(AppResources.ExposuresPageExposureUnitPlural, 2), vm.Exposures[0].ExposureCount);
+        }
+    }
+}

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ExposuresPageViewModelTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ExposuresPageViewModelTests.cs
@@ -86,7 +86,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
 
             Assert.Single(vm.Exposures);
 
-            Assert.Equal(AppResources.ExposuresPageExposureUnitPluralOnce, vm.Exposures[0].ExposureCount);
+            Assert.Equal(AppResources.ExposuresPageExposureUnitPluralOnce, vm.Exposures[0].ExposurePluralizeCount);
         }
 
         [Fact]
@@ -106,7 +106,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
 
             Assert.Single(vm.Exposures);
 
-            Assert.Equal(string.Format(AppResources.ExposuresPageExposureUnitPlural, 2), vm.Exposures[0].ExposureCount);
+            Assert.Equal(string.Format(AppResources.ExposuresPageExposureUnitPlural, 2), vm.Exposures[0].ExposurePluralizeCount);
         }
     }
 }


### PR DESCRIPTION
## Issue 番号 / Issue ID

- Close #180

## 目的 / Purpose

- 接触一覧を表示したときの各日付における接触数が日本語以外の言語でも「○個」と表示される課題を解決する

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

<!--
  当てはまるもの 1 つに「x」とマークしてください。
  Mark one with an "x".
-->

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

デバッグ用コードがあるので、マージ前に削除する。

## 確認事項 / What to check

- 英語の表示を Once exposure, Twice exposures, 3 exposures と番号によってアルファベットでの表現にしてみたけれど、本当にこれが見やすいか。 1 exposure, 2 exposures, 3 exposures, の方が見やすいのではないか。
- むしろ exposure という単位は適当か？（日本語だと「n回の接触」）
- 中国語の翻訳が必要。

## その他 / Other information

### 英語
<img width="744" alt="Screen Shot 2021-08-10 at 20 26 09" src="https://user-images.githubusercontent.com/932136/128860206-41110d75-cfda-4bae-acd6-8053eaba0a1a.png">

### 日本語
<img width="744" alt="Screen Shot 2021-08-10 at 20 28 22" src="https://user-images.githubusercontent.com/932136/128860251-f537daaf-a442-42a4-9cac-2fd1d77f3af1.png">
