### PR TITLE
開発中のカプチーノ版COCOAでENを有効化しなかった時に先に進まない問題修正

### DIFF
--- a/Covid19Radar/Covid19Radar/Services/AbsExposureNotificationApiService.cs
+++ b/Covid19Radar/Covid19Radar/Services/AbsExposureNotificationApiService.cs
@@ -30,7 +30,7 @@ namespace Covid19Radar.Services
             }
             catch(Exception ex)
             {
-                _loggerService.Exception("Failed to check version.", ex);
+                _loggerService.Exception("Failed to start exposure notification", ex);
             }
             finally
             {

--- a/Covid19Radar/Covid19Radar/Services/AbsExposureNotificationApiService.cs
+++ b/Covid19Radar/Covid19Radar/Services/AbsExposureNotificationApiService.cs
@@ -30,7 +30,7 @@ namespace Covid19Radar.Services
             }
             catch(Exception ex)
             {
-                _loggerService.Exception("Failed to start exposure notification.", ex);
+                _loggerService.Exception("Failed to start exposure notification", ex);
             }
             finally
             {

--- a/Covid19Radar/Covid19Radar/Services/AbsExposureNotificationApiService.cs
+++ b/Covid19Radar/Covid19Radar/Services/AbsExposureNotificationApiService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Chino;
 using Covid19Radar.Services.Logs;
@@ -27,8 +28,9 @@ namespace Covid19Radar.Services
                 }
                 await StartAsync();
             }
-            catch
+            catch(Exception ex)
             {
+                _loggerService.Exception("Failed to check version.", ex);
             }
             finally
             {

--- a/Covid19Radar/Covid19Radar/Services/AbsExposureNotificationApiService.cs
+++ b/Covid19Radar/Covid19Radar/Services/AbsExposureNotificationApiService.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Chino;
 using Covid19Radar.Services.Logs;
@@ -28,9 +27,8 @@ namespace Covid19Radar.Services
                 }
                 await StartAsync();
             }
-            catch(Exception ex)
+            catch
             {
-                _loggerService.Exception("Failed to check version.", ex);
             }
             finally
             {

--- a/Covid19Radar/Covid19Radar/Services/AbsExposureNotificationApiService.cs
+++ b/Covid19Radar/Covid19Radar/Services/AbsExposureNotificationApiService.cs
@@ -30,7 +30,7 @@ namespace Covid19Radar.Services
             }
             catch(Exception ex)
             {
-                _loggerService.Exception("Failed to start exposure notification", ex);
+                _loggerService.Exception("Failed to start exposure notification.", ex);
             }
             finally
             {

--- a/Covid19Radar/Covid19Radar/Services/AbsExposureNotificationApiService.cs
+++ b/Covid19Radar/Covid19Radar/Services/AbsExposureNotificationApiService.cs
@@ -30,7 +30,7 @@ namespace Covid19Radar.Services
             }
             catch(Exception ex)
             {
-                _loggerService.Exception("Failed to start exposure notification", ex);
+                _loggerService.Exception("Failed to check version.", ex);
             }
             finally
             {

--- a/Covid19Radar/Covid19Radar/Services/AbsExposureNotificationApiService.cs
+++ b/Covid19Radar/Covid19Radar/Services/AbsExposureNotificationApiService.cs
@@ -26,15 +26,13 @@ namespace Covid19Radar.Services
                     return false;
                 }
                 await StartAsync();
-            }
-            catch
-            {
+                return true;
             }
             finally
             {
                 _loggerService.EndMethod();
+
             }
-            return true;
         }
 
         public async Task<bool> StopExposureNotificationAsync()

--- a/Covid19Radar/Covid19Radar/Services/AbsExposureNotificationApiService.cs
+++ b/Covid19Radar/Covid19Radar/Services/AbsExposureNotificationApiService.cs
@@ -26,13 +26,15 @@ namespace Covid19Radar.Services
                     return false;
                 }
                 await StartAsync();
-                return true;
+            }
+            catch
+            {
             }
             finally
             {
                 _loggerService.EndMethod();
-
             }
+            return true;
         }
 
         public async Task<bool> StopExposureNotificationAsync()

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
@@ -98,6 +98,7 @@ namespace Covid19Radar.ViewModels
             catch (ENException exception)
             {
                 loggerService.Exception("Failed to exposure notification start.", exception);
+                await UpdateStatusesAsync();
             }
             finally
             {

--- a/Covid19Radar/Covid19Radar/ViewModels/Tutorial/TutorialPage4ViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/Tutorial/TutorialPage4ViewModel.cs
@@ -38,6 +38,7 @@ namespace Covid19Radar.ViewModels
             catch (ENException exception)
             {
                 loggerService.Exception("ENException", exception);
+                await NavigationService.NavigateAsync(nameof(TutorialPage6));
             }
             finally
             {


### PR DESCRIPTION
## Issue 番号 / Issue ID

<!--
  Issue 番号なき PR は受け付けません。
  PRs without the issue IDs are never accepted.
-->

- Close #329

## 目的 / Purpose

<!--
  その変更を提案する意図をご説明ください。どの問題が解決したり、機能的な追加がなされたりしますか。
  Describe the intention of the changes being proposed. What problem does it solve or functionality does it add?
-->

- issueの内容に関して、ENの許諾を許可しなかったときに一瞬固まるという問題だと思って調査していたのですが、何も触らずに待っていると先に進まないことがわかりました
- また、ENの許諾をスキップした時に「アプリを再インストールするか〜」のアラートも出なくなっていました
- 原因はAbsExposureNotificationApiServiceのStartExposureNotificationAsync()で例外発生時にそこから処理が進まなかったためでした
- StartAsync()で例外発生(?)がしている時にcatchをつけて先に進めることで最終的にどのルートでもreturn trueをするように修正しました

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

<!--
  当てはまるもの 1 つに「x」とマークしてください。
  Mark one with an "x".
-->

```
[x] Yes
[ ] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test
- iOSアプリでCOCOA2を初回起動
- チュートリアルを進めて、接触確認の許諾アラートを出す
- 許諾を許可しない

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```
entitlementsをつかったDEBUGビルド
```

## 確認事項 / What to check

- returnはtrueで大丈夫か
- boolを返す必要があるか
- 非同期通信内でのtry-catchの使い方などC#の実装として問題ないか
- 以下の挙動が確認可能であれば
   - 許諾を許可しない時にチュートリアルで先に進む
   - 許諾を許可しない時にHomePageを表示した時にアラートが表示される

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
