### PR TITLE
表示対象でない過去の接触情報を端末から削除する

### DIFF
--- a/Covid19Radar/Covid19Radar/Repository/UserDataRepository.cs
+++ b/Covid19Radar/Covid19Radar/Repository/UserDataRepository.cs
@@ -41,6 +41,8 @@ namespace Covid19Radar.Repository
 
         void RemoveAllExposureNotificationStatus();
 
+        UserExposureSummary GetExposureSummary();
+
         List<UserExposureInfo> GetExposureInformationList();
         void SetExposureInformation(UserExposureSummary summary, List<UserExposureInfo> informationList);
         void RemoveExposureInformation();
@@ -252,6 +254,19 @@ namespace Covid19Radar.Repository
             _secureStorageService.RemoveValue(PreferenceKey.ExposureSummary);
             _secureStorageService.RemoveValue(PreferenceKey.ExposureInformation);
             _loggerService.EndMethod();
+        }
+
+        public UserExposureSummary GetExposureSummary()
+        {
+            _loggerService.StartMethod();
+            UserExposureSummary result = null;
+            var exposureSummaryJson = _secureStorageService.GetValue<string>(PreferenceKey.ExposureSummary);
+            if (!string.IsNullOrEmpty(exposureSummaryJson))
+            {
+                result = JsonConvert.DeserializeObject<UserExposureSummary>(exposureSummaryJson);
+            }
+            _loggerService.EndMethod();
+            return result;
         }
 
         public List<UserExposureInfo> GetExposureInformationListToDisplay()

--- a/Covid19Radar/Covid19Radar/Repository/UserDataRepository.cs
+++ b/Covid19Radar/Covid19Radar/Repository/UserDataRepository.cs
@@ -42,11 +42,11 @@ namespace Covid19Radar.Repository
         void RemoveAllExposureNotificationStatus();
 
         UserExposureSummary GetExposureSummary();
-
         List<UserExposureInfo> GetExposureInformationList();
         List<UserExposureInfo> GetExposureInformationList(int offsetDays);
         void SetExposureInformation(UserExposureSummary summary, List<UserExposureInfo> informationList);
         void RemoveExposureInformation();
+        void RemoveOutOfDateExposureInformation(int offsetDays);
 
         int GetExposureCount(int offsetDays);
     }
@@ -253,6 +253,16 @@ namespace Covid19Radar.Repository
             _loggerService.StartMethod();
             _secureStorageService.RemoveValue(PreferenceKey.ExposureSummary);
             _secureStorageService.RemoveValue(PreferenceKey.ExposureInformation);
+            _loggerService.EndMethod();
+        }
+
+        public void RemoveOutOfDateExposureInformation(int offsetDays)
+        {
+            _loggerService.StartMethod();
+
+            var informationList = GetExposureInformationList(offsetDays) ?? new List<UserExposureInfo>();
+            SetExposureInformation(GetExposureSummary(), informationList);
+
             _loggerService.EndMethod();
         }
 

--- a/Covid19Radar/Covid19Radar/Repository/UserDataRepository.cs
+++ b/Covid19Radar/Covid19Radar/Repository/UserDataRepository.cs
@@ -44,11 +44,11 @@ namespace Covid19Radar.Repository
         UserExposureSummary GetExposureSummary();
 
         List<UserExposureInfo> GetExposureInformationList();
+        List<UserExposureInfo> GetExposureInformationList(int offsetDays);
         void SetExposureInformation(UserExposureSummary summary, List<UserExposureInfo> informationList);
         void RemoveExposureInformation();
 
-        List<UserExposureInfo> GetExposureInformationListToDisplay();
-        int GetExposureCountToDisplay();
+        int GetExposureCount(int offsetDays);
     }
 
     public class UserDataRepository : IUserDataRepository
@@ -269,21 +269,22 @@ namespace Covid19Radar.Repository
             return result;
         }
 
-        public List<UserExposureInfo> GetExposureInformationListToDisplay()
+        public List<UserExposureInfo> GetExposureInformationList(int offsetDays)
         {
             _loggerService.StartMethod();
+            var date = DateTimeUtility.Instance.UtcNow.AddDays(offsetDays);
             var list = GetExposureInformationList()?
-                .Where(x => x.Timestamp.CompareTo(DateTimeUtility.Instance.UtcNow.AddDays(AppConstants.DaysOfExposureInformationToDisplay)) >= 0)
+                .Where(x => x.Timestamp.CompareTo(date) >= 0)
                 .ToList();
             _loggerService.EndMethod();
             return list;
         }
 
-        public int GetExposureCountToDisplay()
+        public int GetExposureCount(int offsetDays)
         {
             _loggerService.StartMethod();
             int result = 0;
-            var exposureInformationList = GetExposureInformationListToDisplay();
+            var exposureInformationList = GetExposureInformationList(offsetDays);
             if (exposureInformationList != null)
             {
                 result = exposureInformationList.Count;

--- a/Covid19Radar/Covid19Radar/Services/ExposureNotificationHandler.cs
+++ b/Covid19Radar/Covid19Radar/Services/ExposureNotificationHandler.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Acr.UserDialogs;
 using CommonServiceLocator;
+using Covid19Radar.Common;
 using Covid19Radar.Model;
 using Covid19Radar.Repository;
 using Covid19Radar.Resources;
@@ -88,7 +89,7 @@ namespace Covid19Radar.Services
             loggerService.StartMethod();
 
             var exposureNotificationService = ExposureNotificationService;
-            var exposureInformationList = UserDataRepository.GetExposureInformationList() ?? new List<UserExposureInfo>();
+            var exposureInformationList = UserDataRepository.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay) ?? new List<UserExposureInfo>();
 
             UserExposureSummary userExposureSummary = new UserExposureSummary(summary.DaysSinceLastExposure, summary.MatchedKeyCount, summary.HighestRiskScore, summary.AttenuationDurations, summary.SummationRiskScore);
 
@@ -162,7 +163,7 @@ namespace Covid19Radar.Services
                 await MigrationService.MigrateAsync();
 
                 // Remove out of date exposure informations.
-                var informationList = UserDataRepository.GetExposureInformationListToDisplay() ?? new List<UserExposureInfo>();
+                var informationList = UserDataRepository.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay) ?? new List<UserExposureInfo>();
                 var summary = UserDataRepository.GetExposureSummary();
                 UserDataRepository.SetExposureInformation(summary, informationList);
 

--- a/Covid19Radar/Covid19Radar/Services/ExposureNotificationHandler.cs
+++ b/Covid19Radar/Covid19Radar/Services/ExposureNotificationHandler.cs
@@ -161,6 +161,11 @@ namespace Covid19Radar.Services
             {
                 await MigrationService.MigrateAsync();
 
+                // Remove out of date exposure informations.
+                var informationList = UserDataRepository.GetExposureInformationListToDisplay() ?? new List<UserExposureInfo>();
+                var summary = UserDataRepository.GetExposureSummary();
+                UserDataRepository.SetExposureInformation(summary, informationList);
+
                 foreach (var serverRegion in AppSettings.Instance.SupportedRegions)
                 {
                     var lastCreated = UserDataRepository.GetLastProcessTekTimestamp(serverRegion);

--- a/Covid19Radar/Covid19Radar/Services/ExposureNotificationHandler.cs
+++ b/Covid19Radar/Covid19Radar/Services/ExposureNotificationHandler.cs
@@ -162,10 +162,7 @@ namespace Covid19Radar.Services
             {
                 await MigrationService.MigrateAsync();
 
-                // Remove out of date exposure informations.
-                var informationList = UserDataRepository.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay) ?? new List<UserExposureInfo>();
-                var summary = UserDataRepository.GetExposureSummary();
-                UserDataRepository.SetExposureInformation(summary, informationList);
+                UserDataRepository.RemoveOutOfDateExposureInformation(AppConstants.DaysOfExposureInformationToDisplay);
 
                 foreach (var serverRegion in AppSettings.Instance.SupportedRegions)
                 {

--- a/Covid19Radar/Covid19Radar/Services/ExposureNotificationHandler.cs
+++ b/Covid19Radar/Covid19Radar/Services/ExposureNotificationHandler.cs
@@ -88,7 +88,7 @@ namespace Covid19Radar.Services
             loggerService.StartMethod();
 
             var exposureNotificationService = ExposureNotificationService;
-            var exposureInformationList = exposureNotificationService.GetExposureInformationList() ?? new List<UserExposureInfo>();
+            var exposureInformationList = UserDataRepository.GetExposureInformationList() ?? new List<UserExposureInfo>();
 
             UserExposureSummary userExposureSummary = new UserExposureSummary(summary.DaysSinceLastExposure, summary.MatchedKeyCount, summary.HighestRiskScore, summary.AttenuationDurations, summary.SummationRiskScore);
 
@@ -130,7 +130,7 @@ namespace Covid19Radar.Services
                 loggerService.Info($"Save ExposureInformation. Count: {exposureInformationList.Count}");
 
                 exposureInformationList.Sort((a, b) => a.Timestamp.CompareTo(b.Timestamp));
-                exposureNotificationService.SetExposureInformation(userExposureSummary, exposureInformationList);
+                UserDataRepository.SetExposureInformation(userExposureSummary, exposureInformationList);
 
                 await LocalNotificationService.ShowExposureNotificationAsync();
             }
@@ -148,7 +148,6 @@ namespace Covid19Radar.Services
         public async Task FetchExposureKeyBatchFilesFromServerAsync(Func<IEnumerable<string>, Task> submitBatches, CancellationToken cancellationToken)
         {
             var loggerService = LoggerService;
-            var exposureNotificationService = ExposureNotificationService;
 
             if (Interlocked.Exchange(ref fetchExposureKeysIsRunning, 1) == 1)
             {

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/ContactedNotifyPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/ContactedNotifyPageViewModel.cs
@@ -2,18 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-using Covid19Radar.Services;
 using Covid19Radar.Services.Logs;
 using Prism.Navigation;
 using Xamarin.Forms;
 using Xamarin.Essentials;
 using Covid19Radar.Resources;
+using Covid19Radar.Repository;
 
 namespace Covid19Radar.ViewModels
 {
     public class ContactedNotifyPageViewModel : ViewModelBase
     {
-        private readonly ILoggerService loggerService;
+        private readonly IUserDataRepository _userDataRepository;
+        private readonly ILoggerService _loggerService;
+
         private string _exposureCount;
         public string ExposureCount
         {
@@ -21,21 +23,31 @@ namespace Covid19Radar.ViewModels
             set { SetProperty(ref _exposureCount, value); }
         }
 
-        public ContactedNotifyPageViewModel(INavigationService navigationService, ILoggerService loggerService, IExposureNotificationService exposureNotificationService) : base(navigationService)
+        public ContactedNotifyPageViewModel(
+            INavigationService navigationService,
+            IUserDataRepository userDataRepository,
+            ILoggerService loggerService
+            ) : base(navigationService)
         {
             Title = AppResources.TitileUserStatusSettings;
-            this.loggerService = loggerService;
-            ExposureCount = exposureNotificationService.GetExposureCountToDisplay().ToString();
+            _userDataRepository = userDataRepository;
+            _loggerService = loggerService;
+        }
+
+        public override void Initialize(INavigationParameters parameters)
+        {
+            base.Initialize(parameters);
+            ExposureCount = _userDataRepository.GetExposureCountToDisplay().ToString();
         }
 
         public Command OnClickByForm => new Command(async () =>
         {
-            loggerService.StartMethod();
+            _loggerService.StartMethod();
 
             var uri = AppResources.UrlContactedForm;
             await Browser.OpenAsync(uri, BrowserLaunchMode.SystemPreferred);
 
-            loggerService.EndMethod();
+            _loggerService.EndMethod();
         });
     }
 }

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/ContactedNotifyPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/ContactedNotifyPageViewModel.cs
@@ -8,6 +8,7 @@ using Xamarin.Forms;
 using Xamarin.Essentials;
 using Covid19Radar.Resources;
 using Covid19Radar.Repository;
+using Covid19Radar.Common;
 
 namespace Covid19Radar.ViewModels
 {
@@ -37,7 +38,7 @@ namespace Covid19Radar.ViewModels
         public override void Initialize(INavigationParameters parameters)
         {
             base.Initialize(parameters);
-            ExposureCount = _userDataRepository.GetExposureCountToDisplay().ToString();
+            ExposureCount = _userDataRepository.GetExposureCount(AppConstants.DaysOfExposureInformationToDisplay).ToString();
         }
 
         public Command OnClickByForm => new Command(async () =>

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposuresPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposuresPageViewModel.cs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 using Covid19Radar.Resources;
+using Covid19Radar.Common;
 using Covid19Radar.Repository;
 using Prism.Navigation;
 using System.Collections.ObjectModel;
@@ -37,7 +38,7 @@ namespace Covid19Radar.ViewModels
 
             _exposures = new ObservableCollection<ExposureSummary>();
 
-            var exposureInformationList = _userDataRepository.GetExposureInformationListToDisplay();
+            var exposureInformationList = _userDataRepository.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay);
             if (exposureInformationList != null)
             {
                 foreach (var en in exposureInformationList.GroupBy(eni => eni.Timestamp))

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposuresPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposuresPageViewModel.cs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 using Covid19Radar.Resources;
-using Covid19Radar.Services;
+using Covid19Radar.Repository;
 using Prism.Navigation;
 using System.Collections.ObjectModel;
 using System.Globalization;
@@ -13,6 +13,8 @@ namespace Covid19Radar.ViewModels
 {
     public class ExposuresPageViewModel : ViewModelBase
     {
+        private readonly IUserDataRepository _userDataRepository;
+
         public ObservableCollection<ExposureSummary> _exposures;
         public ObservableCollection<ExposureSummary> Exposures
         {
@@ -20,12 +22,22 @@ namespace Covid19Radar.ViewModels
             set { SetProperty(ref _exposures, value); }
         }
 
-        public ExposuresPageViewModel(INavigationService navigationService, IExposureNotificationService exposureNotificationService) : base(navigationService)
+        public ExposuresPageViewModel(
+            INavigationService navigationService,
+            IUserDataRepository userDataRepository
+            ) : base(navigationService)
         {
             Title = AppResources.MainExposures;
+            _userDataRepository = userDataRepository;
+        }
+
+        public override void Initialize(INavigationParameters parameters)
+        {
+            base.Initialize(parameters);
+
             _exposures = new ObservableCollection<ExposureSummary>();
 
-            var exposureInformationList = exposureNotificationService.GetExposureInformationListToDisplay();
+            var exposureInformationList = _userDataRepository.GetExposureInformationListToDisplay();
             if (exposureInformationList != null)
             {
                 foreach (var en in exposureInformationList.GroupBy(eni => eni.Timestamp))

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
@@ -125,7 +125,8 @@ namespace Covid19Radar.ViewModels
 
             await localNotificationService.DismissExposureNotificationAsync();
 
-            var count = exposureNotificationService.GetExposureCountToDisplay();
+            var count = userDataRepository.GetExposureCountToDisplay();
+
             loggerService.Info($"Exposure count: {count}");
             if (count > 0)
             {

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
@@ -125,7 +125,7 @@ namespace Covid19Radar.ViewModels
 
             await localNotificationService.DismissExposureNotificationAsync();
 
-            var count = userDataRepository.GetExposureCountToDisplay();
+            var count = userDataRepository.GetExposureCount(AppConstants.DaysOfExposureInformationToDisplay);
 
             loggerService.Info($"Exposure count: {count}");
             if (count > 0)

--- a/Covid19Radar/Covid19Radar/ViewModels/Settings/SettingsPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/Settings/SettingsPageViewModel.cs
@@ -70,10 +70,11 @@ namespace Covid19Radar.ViewModels
 
                 // Reset All Data and Optout
                 userDataRepository.RemoveStartDate();
-                exposureNotificationService.RemoveConfiguration();
+                userDataRepository.RemoveExposureInformation();
                 userDataRepository.RemoveLastProcessTekTimestamp();
                 userDataRepository.RemoveAllUpdateDate();
                 userDataRepository.RemoveAllExposureNotificationStatus();
+                exposureNotificationService.RemoveConfiguration();
 
                 _ = logFileService.DeleteLogsDir();
 

--- a/Covid19Radar/Covid19Radar/ViewModels/Settings/SettingsPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/Settings/SettingsPageViewModel.cs
@@ -70,7 +70,6 @@ namespace Covid19Radar.ViewModels
 
                 // Reset All Data and Optout
                 userDataRepository.RemoveStartDate();
-                exposureNotificationService.RemoveExposureInformation();
                 exposureNotificationService.RemoveConfiguration();
                 userDataRepository.RemoveLastProcessTekTimestamp();
                 userDataRepository.RemoveAllUpdateDate();

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Repository/UserDataRepositoryTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Repository/UserDataRepositoryTests.cs
@@ -4,9 +4,15 @@
 
 using System;
 using Covid19Radar.Common;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using Covid19Radar.Model;
 using Covid19Radar.Repository;
 using Covid19Radar.Services;
 using Covid19Radar.Services.Logs;
+using Covid19Radar.UnitTests.Mocks;
 using Moq;
 using Xunit;
 
@@ -17,16 +23,27 @@ namespace Covid19Radar.UnitTests.Repository
         private readonly MockRepository mockRepository;
         private readonly Mock<ILoggerService> mockLoggerService;
         private readonly Mock<IPreferencesService> mockPreferencesService;
+        private readonly Mock<ISecureStorageService> mockSecureStorageService;
+        private readonly Mock<IHttpClientService> mockHttpClientService;
+        private readonly Mock<IDateTimeUtility> mockDateTimeUtility;
 
         public UserDataRepositoryTests()
         {
             mockRepository = new MockRepository(MockBehavior.Default);
             mockLoggerService = mockRepository.Create<ILoggerService>();
             mockPreferencesService = mockRepository.Create<IPreferencesService>();
+            mockSecureStorageService = mockRepository.Create<ISecureStorageService>();
+            mockHttpClientService = mockRepository.Create<IHttpClientService>();
+            mockDateTimeUtility = mockRepository.Create<IDateTimeUtility>();
+            DateTimeUtility.Instance = mockDateTimeUtility.Object;
         }
 
         private IUserDataRepository CreateRepository()
-            => new UserDataRepository(mockPreferencesService.Object, mockLoggerService.Object);
+            => new UserDataRepository(
+                mockPreferencesService.Object,
+                mockSecureStorageService.Object,
+                mockLoggerService.Object
+                );
 
         #region LastConfirmedUtcDateTime
 
@@ -75,5 +92,253 @@ namespace Covid19Radar.UnitTests.Repository
 
         #endregion
 
+        [Fact]
+        public void GetExposureInformationListTests_Success()
+        {
+            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
+            {
+                // Make an error not to process code that cannot be Mocked
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            })));
+
+            var unitUnderTest = CreateRepository();
+
+            mockSecureStorageService.Setup(x => x.GetValue<string>("ExposureInformation", default)).Returns("[{\"Timestamp\":\"2020-12-21T10:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":2,\"TotalRiskScore\":19,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2020-12-21T11:00:00\",\"Duration\":\"00:15:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":20,\"TransmissionRiskLevel\":5}]");
+
+            var result = unitUnderTest.GetExposureInformationList(0);
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal(new DateTime(2020, 12, 21, 10, 00, 00), result[0].Timestamp);
+            Assert.Equal(new TimeSpan(0, 5, 0), result[0].Duration);
+            Assert.Equal(2, result[0].AttenuationValue);
+            Assert.Equal(19, result[0].TotalRiskScore);
+            Assert.Equal(UserRiskLevel.Medium, result[0].TransmissionRiskLevel);
+            Assert.Equal(new DateTime(2020, 12, 21, 11, 00, 00), result[1].Timestamp);
+            Assert.Equal(new TimeSpan(0, 15, 0), result[1].Duration);
+            Assert.Equal(3, result[1].AttenuationValue);
+            Assert.Equal(20, result[1].TotalRiskScore);
+            Assert.Equal(UserRiskLevel.MediumHigh, result[1].TransmissionRiskLevel);
+        }
+
+        [Fact]
+        public void GetExposureInformationListTests_NoData()
+        {
+            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
+            {
+                // Make an error not to process code that cannot be Mocked
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            })));
+
+            var unitUnderTest = CreateRepository();
+
+            mockSecureStorageService.Setup(x => x.GetValue<string>("ExposureInformation", default)).Returns((string)(object)null);
+
+            var result = unitUnderTest.GetExposureInformationList(0);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void SetExposureInformationTests_Success()
+        {
+            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
+            {
+                // Make an error not to process code that cannot be Mocked
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            })));
+
+            var unitUnderTest = CreateRepository();
+
+            var actualExposureSummaryJson = "";
+            mockSecureStorageService.Setup(x => x.SetValue("ExposureSummary", It.IsAny<string>())).Callback<string, string>((k, v) =>
+            {
+                actualExposureSummaryJson = v;
+            });
+
+            var actualExposureInformaionJson = "";
+            mockSecureStorageService.Setup(x => x.SetValue("ExposureInformation", It.IsAny<string>())).Callback<string, string>((k, v) =>
+            {
+                actualExposureInformaionJson = v;
+            });
+
+            var testExposureSummary = new UserExposureSummary(1, 2, 30, new[] { new TimeSpan(0, 5, 0), new TimeSpan(0, 10, 0) }, 40);
+            var testExposureInformation = new List<UserExposureInfo> {
+                new UserExposureInfo(new DateTime(2020,12,21), new TimeSpan(0, 10, 0), 20, 30, UserRiskLevel.Lowest),
+                new UserExposureInfo(new DateTime(2020,12,22), new TimeSpan(0, 20, 0), 30, 40, UserRiskLevel.Low)
+            };
+
+            unitUnderTest.SetExposureInformation(testExposureSummary, testExposureInformation);
+
+            mockSecureStorageService.Verify(x => x.SetValue("ExposureSummary", It.IsAny<string>()), Times.Once());
+            mockSecureStorageService.Verify(x => x.SetValue("ExposureInformation", It.IsAny<string>()), Times.Once());
+
+            Assert.NotEmpty(actualExposureSummaryJson);
+            Assert.Contains("\"DaysSinceLastExposure\":1", actualExposureSummaryJson);
+            Assert.Contains("\"MatchedKeyCount\":2", actualExposureSummaryJson);
+            Assert.Contains("\"HighestRiskScore\":30", actualExposureSummaryJson);
+            Assert.Contains("\"SummationRiskScore\":40", actualExposureSummaryJson);
+            Assert.Contains("\"AttenuationDurations\":[\"00:05:00\",\"00:10:00\"]", actualExposureSummaryJson);
+
+            Assert.NotEmpty(actualExposureInformaionJson);
+
+            var regex = new Regex("^\\[({.+}),({.+})\\]$");
+            var matches = regex.Matches(actualExposureInformaionJson);
+            Assert.Single(matches);
+            Assert.Equal(3, matches[0].Groups.Count);
+
+            var actualInfo1 = matches[0].Groups[1].Value;
+            Assert.Contains("\"Timestamp\":\"2020-12-21T00:00:00\"", actualInfo1);
+            Assert.Contains("\"Duration\":\"00:10:00\"", actualInfo1);
+            Assert.Contains("\"AttenuationValue\":20", actualInfo1);
+            Assert.Contains("\"TotalRiskScore\":30", actualInfo1);
+            Assert.Contains("\"TransmissionRiskLevel\":1", actualInfo1);
+
+            var actualInfo2 = matches[0].Groups[2].Value;
+            Assert.Contains("\"Timestamp\":\"2020-12-22T00:00:00\"", actualInfo2);
+            Assert.Contains("\"Duration\":\"00:20:00\"", actualInfo2);
+            Assert.Contains("\"AttenuationValue\":30", actualInfo2);
+            Assert.Contains("\"TotalRiskScore\":40", actualInfo2);
+            Assert.Contains("\"TransmissionRiskLevel\":2", actualInfo2);
+        }
+
+        [Fact]
+        public void RemoveExposureInformationTests()
+        {
+            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
+            {
+                // Make an error not to process code that cannot be Mocked
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            })));
+
+            var unitUnderTest = CreateRepository();
+
+            mockSecureStorageService.Reset();
+            mockLoggerService.Reset();
+
+            unitUnderTest.RemoveExposureInformation();
+
+            mockSecureStorageService.Verify(x => x.RemoveValue("ExposureSummary"), Times.Once());
+            mockSecureStorageService.Verify(x => x.RemoveValue("ExposureInformation"), Times.Once());
+
+            mockLoggerService.Verify(x => x.StartMethod("RemoveExposureInformation", It.IsAny<string>(), It.IsAny<int>()), Times.Once());
+            mockLoggerService.Verify(x => x.EndMethod("RemoveExposureInformation", It.IsAny<string>(), It.IsAny<int>()), Times.Once());
+        }
+
+        [Theory]
+        [InlineData(15, 4, 1)]
+        [InlineData(16, 4, 1)]
+        [InlineData(17, 3, 2)]
+        [InlineData(18, 2, 3)]
+        [InlineData(19, 1, 4)]
+        [InlineData(20, 0, 0)]
+        public void GetExposureInformationListToDisplayTests_Success(int day, int expectedCount, int expectedStartDay)
+        {
+            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
+            {
+                // Make an error not to process code that cannot be Mocked
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            })));
+
+            var unitUnderTest = CreateRepository();
+
+            mockSecureStorageService.Setup(x => x.GetValue<string>("ExposureInformation", default)).Returns("[{\"Timestamp\":\"2021-01-01T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-02T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-03T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-04T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4}]");
+            mockDateTimeUtility.Setup(x => x.UtcNow).Returns(new DateTime(2021, 1, day, 0, 0, 0));
+
+            var result = unitUnderTest.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay);
+
+            Assert.Equal(expectedCount, result.Count);
+            for (int idx = 0; idx < expectedCount; idx++)
+            {
+                Assert.Equal(new DateTime(2021, 1, expectedStartDay + idx, 0, 0, 0), result[idx].Timestamp);
+            }
+        }
+
+        [Fact]
+        public void GetExposureInformationListToDisplayTests_NoData()
+        {
+            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
+            {
+                // Make an error not to process code that cannot be Mocked
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            })));
+
+            var unitUnderTest = CreateRepository();
+
+            mockSecureStorageService.Setup(x => x.GetValue<string>("ExposureInformation", default)).Returns((string)(object)null);
+            mockDateTimeUtility.Setup(x => x.UtcNow).Returns(new DateTime(2021, 1, 1, 0, 0, 0));
+
+            var result = unitUnderTest.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay);
+
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData(17, 9, 0, 3, 2)]
+        [InlineData(17, 9, 1, 2, 3)]
+        public void GetExposureInformationListToDisplayTests_Jst(int day, int hour, int minute, int expectedCount, int expectedStartDay)
+        {
+            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
+            {
+                // Make an error not to process code that cannot be Mocked
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            })));
+
+            var unitUnderTest = CreateRepository();
+
+            mockSecureStorageService.Setup(x => x.GetValue<string>("ExposureInformation", default)).Returns("[{\"Timestamp\":\"2021-01-01T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-02T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-03T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-04T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4}]");
+            mockDateTimeUtility.Setup(x => x.UtcNow).Returns(new DateTime(2021, 1, day, hour, minute, 0).AddHours(-9));
+
+            var result = unitUnderTest.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay);
+
+            Assert.Equal(expectedCount, result.Count);
+            for (int idx = 0; idx < expectedCount; idx++)
+            {
+                Assert.Equal(new DateTime(2021, 1, expectedStartDay + idx, 0, 0, 0), result[idx].Timestamp);
+            }
+        }
+
+        [Theory]
+        [InlineData(15, 4)]
+        [InlineData(16, 4)]
+        [InlineData(17, 3)]
+        [InlineData(18, 2)]
+        [InlineData(19, 1)]
+        [InlineData(20, 0)]
+        public void GetExposureCountToDisplayTests_Success(int day, int expectedCount)
+        {
+            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
+            {
+                // Make an error not to process code that cannot be Mocked
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            })));
+
+            var unitUnderTest = CreateRepository();
+
+            mockSecureStorageService.Setup(x => x.GetValue<string>("ExposureInformation", default)).Returns("[{\"Timestamp\":\"2021-01-01T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-02T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-03T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-04T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4}]");
+            mockDateTimeUtility.Setup(x => x.UtcNow).Returns(new DateTime(2021, 1, day, 0, 0, 0));
+
+            var result = unitUnderTest.GetExposureCount(AppConstants.DaysOfExposureInformationToDisplay);
+
+            Assert.Equal(expectedCount, result);
+        }
+
+        [Fact]
+        public void GetExposureCountToDisplayTests_NoData()
+        {
+            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
+            {
+                // Make an error not to process code that cannot be Mocked
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            })));
+
+            var unitUnderTest = CreateRepository();
+
+            mockSecureStorageService.Setup(x => x.GetValue<string>("ExposureInformation", default)).Returns((string)(object)null);
+            mockDateTimeUtility.Setup(x => x.UtcNow).Returns(new DateTime(2021, 1, 1, 0, 0, 0));
+
+            var result = unitUnderTest.GetExposureCount(AppConstants.DaysOfExposureInformationToDisplay);
+
+            Assert.Equal(0, result);
+        }
     }
 }

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Repository/UserDataRepositoryTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Repository/UserDataRepositoryTests.cs
@@ -5,14 +5,11 @@
 using System;
 using Covid19Radar.Common;
 using System.Collections.Generic;
-using System.Net;
-using System.Net.Http;
 using System.Text.RegularExpressions;
 using Covid19Radar.Model;
 using Covid19Radar.Repository;
 using Covid19Radar.Services;
 using Covid19Radar.Services.Logs;
-using Covid19Radar.UnitTests.Mocks;
 using Moq;
 using Xunit;
 
@@ -24,7 +21,6 @@ namespace Covid19Radar.UnitTests.Repository
         private readonly Mock<ILoggerService> mockLoggerService;
         private readonly Mock<IPreferencesService> mockPreferencesService;
         private readonly Mock<ISecureStorageService> mockSecureStorageService;
-        private readonly Mock<IHttpClientService> mockHttpClientService;
         private readonly Mock<IDateTimeUtility> mockDateTimeUtility;
 
         public UserDataRepositoryTests()
@@ -33,7 +29,6 @@ namespace Covid19Radar.UnitTests.Repository
             mockLoggerService = mockRepository.Create<ILoggerService>();
             mockPreferencesService = mockRepository.Create<IPreferencesService>();
             mockSecureStorageService = mockRepository.Create<ISecureStorageService>();
-            mockHttpClientService = mockRepository.Create<IHttpClientService>();
             mockDateTimeUtility = mockRepository.Create<IDateTimeUtility>();
             DateTimeUtility.Instance = mockDateTimeUtility.Object;
         }
@@ -95,12 +90,6 @@ namespace Covid19Radar.UnitTests.Repository
         [Fact]
         public void GetExposureInformationListTests_Success()
         {
-            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
-            {
-                // Make an error not to process code that cannot be Mocked
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            })));
-
             var unitUnderTest = CreateRepository();
 
             mockSecureStorageService.Setup(x => x.GetValue<string>("ExposureInformation", default)).Returns("[{\"Timestamp\":\"2020-12-21T10:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":2,\"TotalRiskScore\":19,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2020-12-21T11:00:00\",\"Duration\":\"00:15:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":20,\"TransmissionRiskLevel\":5}]");
@@ -123,12 +112,6 @@ namespace Covid19Radar.UnitTests.Repository
         [Fact]
         public void GetExposureInformationListTests_NoData()
         {
-            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
-            {
-                // Make an error not to process code that cannot be Mocked
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            })));
-
             var unitUnderTest = CreateRepository();
 
             mockSecureStorageService.Setup(x => x.GetValue<string>("ExposureInformation", default)).Returns((string)(object)null);
@@ -141,12 +124,6 @@ namespace Covid19Radar.UnitTests.Repository
         [Fact]
         public void SetExposureInformationTests_Success()
         {
-            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
-            {
-                // Make an error not to process code that cannot be Mocked
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            })));
-
             var unitUnderTest = CreateRepository();
 
             var actualExposureSummaryJson = "";
@@ -204,12 +181,6 @@ namespace Covid19Radar.UnitTests.Repository
         [Fact]
         public void RemoveExposureInformationTests()
         {
-            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
-            {
-                // Make an error not to process code that cannot be Mocked
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            })));
-
             var unitUnderTest = CreateRepository();
 
             mockSecureStorageService.Reset();
@@ -250,12 +221,6 @@ namespace Covid19Radar.UnitTests.Repository
         [Fact]
         public void GetExposureInformationListToDisplayTests_NoData()
         {
-            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
-            {
-                // Make an error not to process code that cannot be Mocked
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            })));
-
             var unitUnderTest = CreateRepository();
 
             mockSecureStorageService.Setup(x => x.GetValue<string>("ExposureInformation", default)).Returns((string)(object)null);
@@ -271,12 +236,6 @@ namespace Covid19Radar.UnitTests.Repository
         [InlineData(17, 9, 1, 2, 3)]
         public void GetExposureInformationListToDisplayTests_Jst(int day, int hour, int minute, int expectedCount, int expectedStartDay)
         {
-            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
-            {
-                // Make an error not to process code that cannot be Mocked
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            })));
-
             var unitUnderTest = CreateRepository();
 
             mockSecureStorageService.Setup(x => x.GetValue<string>("ExposureInformation", default)).Returns("[{\"Timestamp\":\"2021-01-01T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-02T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-03T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-04T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4}]");
@@ -300,12 +259,6 @@ namespace Covid19Radar.UnitTests.Repository
         [InlineData(20, 0)]
         public void GetExposureCountToDisplayTests_Success(int day, int expectedCount)
         {
-            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
-            {
-                // Make an error not to process code that cannot be Mocked
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            })));
-
             var unitUnderTest = CreateRepository();
 
             mockSecureStorageService.Setup(x => x.GetValue<string>("ExposureInformation", default)).Returns("[{\"Timestamp\":\"2021-01-01T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-02T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-03T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-04T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4}]");
@@ -319,12 +272,6 @@ namespace Covid19Radar.UnitTests.Repository
         [Fact]
         public void GetExposureCountToDisplayTests_NoData()
         {
-            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
-            {
-                // Make an error not to process code that cannot be Mocked
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            })));
-
             var unitUnderTest = CreateRepository();
 
             mockSecureStorageService.Setup(x => x.GetValue<string>("ExposureInformation", default)).Returns((string)(object)null);

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/ExposureNotificationServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/ExposureNotificationServiceTests.cs
@@ -7,9 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text.RegularExpressions;
 using Covid19Radar.Common;
-using Covid19Radar.Model;
 using Covid19Radar.Services;
 using Covid19Radar.Services.Logs;
 using Covid19Radar.UnitTests.Mocks;
@@ -24,9 +22,7 @@ namespace Covid19Radar.UnitTests.Services
         private readonly MockRepository mockRepository;
         private readonly Mock<ILoggerService> mockLoggerService;
         private readonly Mock<IHttpClientService> mockHttpClientService;
-        private readonly Mock<ISecureStorageService> mockSecureStorageService;
         private readonly Mock<IPreferencesService> mockPreferencesService;
-        private readonly Mock<IApplicationPropertyService> mockApplicationPropertyService;
         private readonly Mock<IDateTimeUtility> mockDateTimeUtility;
 
         public ExposureNotificationServiceTests()
@@ -34,9 +30,7 @@ namespace Covid19Radar.UnitTests.Services
             mockRepository = new MockRepository(MockBehavior.Default);
             mockLoggerService = mockRepository.Create<ILoggerService>();
             mockHttpClientService = mockRepository.Create<IHttpClientService>();
-            mockSecureStorageService = mockRepository.Create<ISecureStorageService>();
             mockPreferencesService = mockRepository.Create<IPreferencesService>();
-            mockApplicationPropertyService = mockRepository.Create<IApplicationPropertyService>();
             mockDateTimeUtility = mockRepository.Create<IDateTimeUtility>();
             DateTimeUtility.Instance = mockDateTimeUtility.Object;
         }
@@ -46,9 +40,8 @@ namespace Covid19Radar.UnitTests.Services
             return new ExposureNotificationService(
                 mockLoggerService.Object,
                 mockHttpClientService.Object,
-                mockSecureStorageService.Object,
-                mockPreferencesService.Object,
-                mockApplicationPropertyService.Object);
+                mockPreferencesService.Object
+                );
         }
 
         [Theory]
@@ -114,255 +107,6 @@ namespace Covid19Radar.UnitTests.Services
             {
                 _ = unitUnderTest.FliterTemporaryExposureKeys(temporaryExposureKeys);
             });
-        }
-
-        [Fact]
-        public void GetExposureInformationListTests_Success()
-        {
-            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
-            {
-                // Make an error not to process code that cannot be Mocked
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            })));
-
-            var unitUnderTest = CreateService();
-
-            mockSecureStorageService.Setup(x => x.GetValue<string>("ExposureInformation", default)).Returns("[{\"Timestamp\":\"2020-12-21T10:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":2,\"TotalRiskScore\":19,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2020-12-21T11:00:00\",\"Duration\":\"00:15:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":20,\"TransmissionRiskLevel\":5}]");
-
-            var result = unitUnderTest.GetExposureInformationList();
-
-            Assert.Equal(2, result.Count);
-            Assert.Equal(new DateTime(2020, 12, 21, 10, 00, 00), result[0].Timestamp);
-            Assert.Equal(new TimeSpan(0, 5, 0), result[0].Duration);
-            Assert.Equal(2, result[0].AttenuationValue);
-            Assert.Equal(19, result[0].TotalRiskScore);
-            Assert.Equal(UserRiskLevel.Medium, result[0].TransmissionRiskLevel);
-            Assert.Equal(new DateTime(2020, 12, 21, 11, 00, 00), result[1].Timestamp);
-            Assert.Equal(new TimeSpan(0, 15, 0), result[1].Duration);
-            Assert.Equal(3, result[1].AttenuationValue);
-            Assert.Equal(20, result[1].TotalRiskScore);
-            Assert.Equal(UserRiskLevel.MediumHigh, result[1].TransmissionRiskLevel);
-        }
-
-        [Fact]
-        public void GetExposureInformationListTests_NoData()
-        {
-            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
-            {
-                // Make an error not to process code that cannot be Mocked
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            })));
-
-            var unitUnderTest = CreateService();
-
-            mockSecureStorageService.Setup(x => x.GetValue<string>("ExposureInformation", default)).Returns((string)(object)null);
-
-            var result = unitUnderTest.GetExposureInformationList();
-
-            Assert.Null(result);
-        }
-
-        [Fact]
-        public void SetExposureInformationTests_Success()
-        {
-            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
-            {
-                // Make an error not to process code that cannot be Mocked
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            })));
-
-            var unitUnderTest = CreateService();
-
-            var actualExposureSummaryJson = "";
-            mockSecureStorageService.Setup(x => x.SetValue("ExposureSummary", It.IsAny<string>())).Callback<string, string>((k, v) =>
-            {
-                actualExposureSummaryJson = v;
-            });
-
-            var actualExposureInformaionJson = "";
-            mockSecureStorageService.Setup(x => x.SetValue("ExposureInformation", It.IsAny<string>())).Callback<string, string>((k, v) =>
-            {
-                actualExposureInformaionJson = v;
-            });
-
-            var testExposureSummary = new UserExposureSummary(1, 2, 30, new[] { new TimeSpan(0, 5, 0), new TimeSpan(0, 10, 0) }, 40);
-            var testExposureInformation = new List<UserExposureInfo> {
-                new UserExposureInfo(new DateTime(2020,12,21), new TimeSpan(0, 10, 0), 20, 30, UserRiskLevel.Lowest),
-                new UserExposureInfo(new DateTime(2020,12,22), new TimeSpan(0, 20, 0), 30, 40, UserRiskLevel.Low)
-            };
-
-            unitUnderTest.SetExposureInformation(testExposureSummary, testExposureInformation);
-
-            mockSecureStorageService.Verify(x => x.SetValue("ExposureSummary", It.IsAny<string>()), Times.Once());
-            mockSecureStorageService.Verify(x => x.SetValue("ExposureInformation", It.IsAny<string>()), Times.Once());
-
-            Assert.NotEmpty(actualExposureSummaryJson);
-            Assert.Contains("\"DaysSinceLastExposure\":1", actualExposureSummaryJson);
-            Assert.Contains("\"MatchedKeyCount\":2", actualExposureSummaryJson);
-            Assert.Contains("\"HighestRiskScore\":30", actualExposureSummaryJson);
-            Assert.Contains("\"SummationRiskScore\":40", actualExposureSummaryJson);
-            Assert.Contains("\"AttenuationDurations\":[\"00:05:00\",\"00:10:00\"]", actualExposureSummaryJson);
-
-            Assert.NotEmpty(actualExposureInformaionJson);
-
-            var regex = new Regex("^\\[({.+}),({.+})\\]$");
-            var matches = regex.Matches(actualExposureInformaionJson);
-            Assert.Single(matches);
-            Assert.Equal(3, matches[0].Groups.Count);
-
-            var actualInfo1 = matches[0].Groups[1].Value;
-            Assert.Contains("\"Timestamp\":\"2020-12-21T00:00:00\"", actualInfo1);
-            Assert.Contains("\"Duration\":\"00:10:00\"", actualInfo1);
-            Assert.Contains("\"AttenuationValue\":20", actualInfo1);
-            Assert.Contains("\"TotalRiskScore\":30", actualInfo1);
-            Assert.Contains("\"TransmissionRiskLevel\":1", actualInfo1);
-
-            var actualInfo2 = matches[0].Groups[2].Value;
-            Assert.Contains("\"Timestamp\":\"2020-12-22T00:00:00\"", actualInfo2);
-            Assert.Contains("\"Duration\":\"00:20:00\"", actualInfo2);
-            Assert.Contains("\"AttenuationValue\":30", actualInfo2);
-            Assert.Contains("\"TotalRiskScore\":40", actualInfo2);
-            Assert.Contains("\"TransmissionRiskLevel\":2", actualInfo2);
-        }
-
-        [Fact]
-        public void RemoveExposureInformationTests()
-        {
-            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
-            {
-                // Make an error not to process code that cannot be Mocked
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            })));
-
-            var unitUnderTest = CreateService();
-
-            mockSecureStorageService.Reset();
-            mockLoggerService.Reset();
-
-            unitUnderTest.RemoveExposureInformation();
-
-            mockSecureStorageService.Verify(x => x.RemoveValue("ExposureSummary"), Times.Once());
-            mockSecureStorageService.Verify(x => x.RemoveValue("ExposureInformation"), Times.Once());
-
-            mockLoggerService.Verify(x => x.StartMethod("RemoveExposureInformation", It.IsAny<string>(), It.IsAny<int>()), Times.Once());
-            mockLoggerService.Verify(x => x.EndMethod("RemoveExposureInformation", It.IsAny<string>(), It.IsAny<int>()), Times.Once());
-        }
-
-        [Theory]
-        [InlineData(15, 4, 1)]
-        [InlineData(16, 4, 1)]
-        [InlineData(17, 3, 2)]
-        [InlineData(18, 2, 3)]
-        [InlineData(19, 1, 4)]
-        [InlineData(20, 0, 0)]
-        public void GetExposureInformationListToDisplayTests_Success(int day, int expectedCount, int expectedStartDay)
-        {
-            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
-            {
-                // Make an error not to process code that cannot be Mocked
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            })));
-
-            var unitUnderTest = CreateService();
-
-            mockSecureStorageService.Setup(x => x.GetValue<string>("ExposureInformation", default)).Returns("[{\"Timestamp\":\"2021-01-01T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-02T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-03T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-04T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4}]");
-            mockDateTimeUtility.Setup(x => x.UtcNow).Returns(new DateTime(2021, 1, day, 0, 0, 0));
-
-            var result = unitUnderTest.GetExposureInformationListToDisplay();
-
-            Assert.Equal(expectedCount, result.Count);
-            for (int idx = 0; idx < expectedCount; idx++)
-            {
-                Assert.Equal(new DateTime(2021, 1, expectedStartDay + idx, 0, 0, 0), result[idx].Timestamp);
-            }
-        }
-
-        [Fact]
-        public void GetExposureInformationListToDisplayTests_NoData()
-        {
-            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
-            {
-                // Make an error not to process code that cannot be Mocked
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            })));
-
-            var unitUnderTest = CreateService();
-
-            mockSecureStorageService.Setup(x => x.GetValue<string>("ExposureInformation", default)).Returns((string)(object)null);
-            mockDateTimeUtility.Setup(x => x.UtcNow).Returns(new DateTime(2021, 1, 1, 0, 0, 0));
-
-            var result = unitUnderTest.GetExposureInformationListToDisplay();
-
-            Assert.Null(result);
-        }
-
-        [Theory]
-        [InlineData(17, 9, 0, 3, 2)]
-        [InlineData(17, 9, 1, 2, 3)]
-        public void GetExposureInformationListToDisplayTests_Jst(int day, int hour, int minute, int expectedCount, int expectedStartDay)
-        {
-            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
-            {
-                // Make an error not to process code that cannot be Mocked
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            })));
-
-            var unitUnderTest = CreateService();
-
-            mockSecureStorageService.Setup(x => x.GetValue<string>("ExposureInformation", default)).Returns("[{\"Timestamp\":\"2021-01-01T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-02T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-03T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-04T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4}]");
-            mockDateTimeUtility.Setup(x => x.UtcNow).Returns(new DateTime(2021, 1, day, hour, minute, 0).AddHours(-9));
-
-            var result = unitUnderTest.GetExposureInformationListToDisplay();
-
-            Assert.Equal(expectedCount, result.Count);
-            for (int idx = 0; idx < expectedCount; idx++)
-            {
-                Assert.Equal(new DateTime(2021, 1, expectedStartDay + idx, 0, 0, 0), result[idx].Timestamp);
-            }
-        }
-
-        [Theory]
-        [InlineData(15, 4)]
-        [InlineData(16, 4)]
-        [InlineData(17, 3)]
-        [InlineData(18, 2)]
-        [InlineData(19, 1)]
-        [InlineData(20, 0)]
-        public void GetExposureCountToDisplayTests_Success(int day, int expectedCount)
-        {
-            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
-            {
-                // Make an error not to process code that cannot be Mocked
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            })));
-
-            var unitUnderTest = CreateService();
-
-            mockSecureStorageService.Setup(x => x.GetValue<string>("ExposureInformation", default)).Returns("[{\"Timestamp\":\"2021-01-01T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-02T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-03T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-04T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4}]");
-            mockDateTimeUtility.Setup(x => x.UtcNow).Returns(new DateTime(2021, 1, day, 0, 0, 0));
-
-            var result = unitUnderTest.GetExposureCountToDisplay();
-
-            Assert.Equal(expectedCount, result);
-        }
-
-        [Fact]
-        public void GetExposureCountToDisplayTests_NoData()
-        {
-            mockHttpClientService.Setup(x => x.Create()).Returns(new HttpClient(new MockHttpHandler((request, cancellationToken) =>
-            {
-                // Make an error not to process code that cannot be Mocked
-                return new HttpResponseMessage(HttpStatusCode.NotFound);
-            })));
-
-            var unitUnderTest = CreateService();
-
-            mockSecureStorageService.Setup(x => x.GetValue<string>("ExposureInformation", default)).Returns((string)(object)null);
-            mockDateTimeUtility.Setup(x => x.UtcNow).Returns(new DateTime(2021, 1, 1, 0, 0, 0));
-
-            var result = unitUnderTest.GetExposureCountToDisplay();
-
-            Assert.Equal(0, result);
         }
     }
 }

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ExposuresPageViewModelTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ExposuresPageViewModelTests.cs
@@ -5,8 +5,8 @@
 using System;
 using System.Collections.Generic;
 using Covid19Radar.Model;
+using Covid19Radar.Repository;
 using Covid19Radar.Resources;
-using Covid19Radar.Services;
 using Covid19Radar.ViewModels;
 using Moq;
 using Prism.Navigation;
@@ -18,20 +18,20 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
     {
         private readonly MockRepository mockRepository;
         private readonly Mock<INavigationService> mockNavigationService;
-        private readonly Mock<IExposureNotificationService> mockExposureNotificationService;
+        private readonly Mock<IUserDataRepository> mockUserDataRepository;
 
         public ExposurePageViewModelTests()
         {
             mockRepository = new MockRepository(MockBehavior.Default);
             mockNavigationService = mockRepository.Create<INavigationService>();
-            mockExposureNotificationService = mockRepository.Create<IExposureNotificationService>();
+            mockUserDataRepository = mockRepository.Create<IUserDataRepository>();
         }
 
         private ExposuresPageViewModel CreateViewModel()
         {
             return new ExposuresPageViewModel(
                 mockNavigationService.Object,
-                mockExposureNotificationService.Object);
+                mockUserDataRepository.Object);
         }
 
         [Fact]
@@ -44,7 +44,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
                 new UserExposureInfo(date, TimeSpan.FromMinutes(15), 99, 99, UserRiskLevel.High),
                 new UserExposureInfo(date, TimeSpan.FromMinutes(20), 98, 98, UserRiskLevel.Medium),
             };
-            mockExposureNotificationService.Setup(x => x.GetExposureInformationListToDisplay()).Returns(dummyList);
+            mockUserDataRepository.Setup(x => x.GetExposureInformationList(It.IsAny<int>())).Returns(dummyList);
 
             var vm = CreateViewModel();
             vm.Initialize(new NavigationParameters());
@@ -63,7 +63,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
                 new UserExposureInfo(date1, TimeSpan.FromMinutes(15), 99, 99, UserRiskLevel.High),
                 new UserExposureInfo(date2, TimeSpan.FromMinutes(20), 98, 98, UserRiskLevel.Medium),
             };
-            mockExposureNotificationService.Setup(x => x.GetExposureInformationListToDisplay()).Returns(testList);
+            mockUserDataRepository.Setup(x => x.GetExposureInformationList(It.IsAny<int>())).Returns(testList);
 
             var vm = CreateViewModel();
             vm.Initialize(new NavigationParameters());
@@ -79,7 +79,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
             {
                 new UserExposureInfo(date, TimeSpan.FromMinutes(15), 99, 99, UserRiskLevel.High),
             };
-            mockExposureNotificationService.Setup(x => x.GetExposureInformationListToDisplay()).Returns(testList);
+            mockUserDataRepository.Setup(x => x.GetExposureInformationList(It.IsAny<int>())).Returns(testList);
 
             var vm = CreateViewModel();
             vm.Initialize(new NavigationParameters());
@@ -99,7 +99,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
                 new UserExposureInfo(date, TimeSpan.FromMinutes(15), 99, 99, UserRiskLevel.High),
                 new UserExposureInfo(date, TimeSpan.FromMinutes(20), 98, 98, UserRiskLevel.Medium)
             };
-            mockExposureNotificationService.Setup(x => x.GetExposureInformationListToDisplay()).Returns(testList);
+            mockUserDataRepository.Setup(x => x.GetExposureInformationList(It.IsAny<int>())).Returns(testList);
 
             var vm = CreateViewModel();
             vm.Initialize(new NavigationParameters());


### PR DESCRIPTION
#343 に依存した変更です。

## Issue 番号 / Issue ID

- Close #217

## 目的 / Purpose

#121 の対応で、14日（タイムゾーンの関係で15日）を超えた接触情報を非表示にする対応をした（v1.2.4）。
これはストレージから必要なデータのみをフィルタリングしているだけで、実体のデータは端末内に残っている。
表示対象でない接触情報を「削除」する。

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[x] Yes
[ ] No
```

## Pull Request の種類 / Pull Request type

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

- 何件削除したか（どんなデータを削除したか）ログに出した方がいい？

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
