### PR TITLE
Merge KeyString and KeyText

### DIFF
--- a/src/Covid19Radar.Api.Common/Models/IAndroidDeviceVerification.cs
+++ b/src/Covid19Radar.Api.Common/Models/IAndroidDeviceVerification.cs
@@ -6,13 +6,11 @@ namespace Covid19Radar.Api.Models
 {
     public interface IAndroidDeviceVerification
     {
-        public string KeyString { get; }
-
         public string AppPackageName { get; set; }
 
         public string[] Regions { get; }
 
-        public string KeysText { get; }
+        public string KeyString { get; }
 
         public string DeviceVerificationPayload { get; }
 

--- a/src/Covid19Radar.Api.Common/Models/IAndroidDeviceVerification.cs
+++ b/src/Covid19Radar.Api.Common/Models/IAndroidDeviceVerification.cs
@@ -10,7 +10,7 @@ namespace Covid19Radar.Api.Models
 
         public string[] Regions { get; }
 
-        public string KeyString { get; }
+        public string KeysTextForDeviceVerification { get; }
 
         public string DeviceVerificationPayload { get; }
 

--- a/src/Covid19Radar.Api.Common/Models/IAppleDeviceVerification.cs
+++ b/src/Covid19Radar.Api.Common/Models/IAppleDeviceVerification.cs
@@ -12,7 +12,7 @@ namespace Covid19Radar.Api.Models
 
 		public string[] Regions { get; }
 
-		public string KeyString { get; }
+		public string KeysTextForDeviceVerification { get; }
 
 		public string DeviceVerificationPayload { get; }
 

--- a/src/Covid19Radar.Api.Common/Models/IAppleDeviceVerification.cs
+++ b/src/Covid19Radar.Api.Common/Models/IAppleDeviceVerification.cs
@@ -12,7 +12,7 @@ namespace Covid19Radar.Api.Models
 
 		public string[] Regions { get; }
 
-		public string KeysText { get; }
+		public string KeyString { get; }
 
 		public string DeviceVerificationPayload { get; }
 

--- a/src/Covid19Radar.Api/Models/DiagnosisSubmissionParameter.cs
+++ b/src/Covid19Radar.Api/Models/DiagnosisSubmissionParameter.cs
@@ -35,17 +35,6 @@ namespace Covid19Radar.Api.Models
 		public string KeyString
 			=> string.Join(",", Keys.OrderBy(k => k.KeyData).Select(k => k.GetKeyString()));
 
-		[JsonIgnore]
-		public string KeysText
-		{
-			get
-			{
-				return Keys.OrderBy(_ => _.KeyData)
-					.Select(_ => _.KeyData)
-					.Aggregate((a, b) => a + b);
-			}
-		}
-
 		public class Key
 		{
 			[JsonProperty("keyData")]

--- a/src/Covid19Radar.Api/Models/DiagnosisSubmissionParameter.cs
+++ b/src/Covid19Radar.Api/Models/DiagnosisSubmissionParameter.cs
@@ -32,7 +32,7 @@ namespace Covid19Radar.Api.Models
 		public string Padding { get; set; }
 
 		[JsonIgnore]
-		public string KeyString
+		public string KeysTextForDeviceVerification
 			=> string.Join(",", Keys.OrderBy(k => k.KeyData).Select(k => k.GetKeyString()));
 
 		public class Key

--- a/src/Covid19Radar.Api/Models/V1DiagnosisSubmissionParameter.cs
+++ b/src/Covid19Radar.Api/Models/V1DiagnosisSubmissionParameter.cs
@@ -19,10 +19,6 @@ namespace Covid19Radar.Api.Models
 		[JsonProperty("keys")]
 		public new Key[] Keys { get; set; }
 
-		[JsonIgnore]
-		public new string KeyString
-			=> string.Join(",", Keys.OrderBy(k => k.KeyData).Select(k => k.GetKeyString()));
-
 		public new class Key
 		{
 			[JsonProperty("keyData")]

--- a/src/Covid19Radar.Api/Models/V1DiagnosisSubmissionParameter.cs
+++ b/src/Covid19Radar.Api/Models/V1DiagnosisSubmissionParameter.cs
@@ -23,17 +23,6 @@ namespace Covid19Radar.Api.Models
 		public new string KeyString
 			=> string.Join(",", Keys.OrderBy(k => k.KeyData).Select(k => k.GetKeyString()));
 
-		[JsonIgnore]
-		public new string KeysText
-		{
-			get
-			{
-				return Keys.OrderBy(_ => _.KeyData)
-					.Select(_ => _.KeyData)
-					.Aggregate((a, b) => a + b);
-			}
-		}
-
 		public new class Key
 		{
 			[JsonProperty("keyData")]

--- a/src/Covid19Radar.Api/Models/V3DiagnosisSubmissionParameter.cs
+++ b/src/Covid19Radar.Api/Models/V3DiagnosisSubmissionParameter.cs
@@ -48,16 +48,6 @@ namespace Covid19Radar.Api.Models
 		public string KeyString
 			=> string.Join(",", Keys.OrderBy(k => k.KeyData).Select(k => k.GetKeyString()));
 
-		[JsonIgnore]
-		public string KeysText {
-			get
-			{
-				return Keys.OrderBy(_ => _.KeyData)
-					.Select(_ => _.KeyData)
-					.Aggregate((a, b) => a + b);
-			}
-		}
-
 		public class Key
 		{
 			[JsonProperty("keyData")]

--- a/src/Covid19Radar.Api/Models/V3DiagnosisSubmissionParameter.cs
+++ b/src/Covid19Radar.Api/Models/V3DiagnosisSubmissionParameter.cs
@@ -45,7 +45,7 @@ namespace Covid19Radar.Api.Models
 		public string Padding { get; set; }
 
 		[JsonIgnore]
-		public string KeyString
+		public string KeysTextForDeviceVerification
 			=> string.Join(",", Keys.OrderBy(k => k.KeyData).Select(k => k.GetKeyString()));
 
 		public class Key

--- a/src/Covid19Radar.Api/Services/DeviceValidationAndroidService.cs
+++ b/src/Covid19Radar.Api/Services/DeviceValidationAndroidService.cs
@@ -225,7 +225,7 @@ namespace Covid19Radar.Api.Services
         }
 
         private static string GetAndroidNonceClearText(IAndroidDeviceVerification submission)
-                => string.Join("|", submission.AppPackageName, submission.KeyString, GetRegionString(submission.Regions), submission.VerificationPayload);
+                => string.Join("|", submission.AppPackageName, submission.KeysTextForDeviceVerification, GetRegionString(submission.Regions), submission.VerificationPayload);
 
         private static string GetRegionString(string[] regions)
             => string.Join(",", regions.Select(r => r.ToUpperInvariant()).OrderBy(r => r));

--- a/src/Covid19Radar.Api/Services/DeviceValidationAppleService.cs
+++ b/src/Covid19Radar.Api/Services/DeviceValidationAppleService.cs
@@ -63,11 +63,11 @@ namespace Covid19Radar.Api.Services
                 Timestamp = requestTime.ToUnixTimeMilliseconds()
             };
 
-            var keysText = appleDeviceVerification.KeysText;
+            var keyString = appleDeviceVerification.KeyString;
 
             using (var sha = SHA256.Create())
             {
-                var value = System.Text.Encoding.UTF8.GetBytes(appleDeviceVerification.AppPackageName + keysText + string.Join(',', appleDeviceVerification.Regions));
+                var value = Encoding.UTF8.GetBytes(appleDeviceVerification.AppPackageName + keyString + string.Join(',', appleDeviceVerification.Regions));
                 payload.TransactionId = Convert.ToBase64String(sha.ComputeHash(value));
             }
 

--- a/src/Covid19Radar.Api/Services/DeviceValidationAppleService.cs
+++ b/src/Covid19Radar.Api/Services/DeviceValidationAppleService.cs
@@ -63,11 +63,13 @@ namespace Covid19Radar.Api.Services
                 Timestamp = requestTime.ToUnixTimeMilliseconds()
             };
 
-            var keyString = appleDeviceVerification.KeyString;
-
             using (var sha = SHA256.Create())
             {
-                var value = Encoding.UTF8.GetBytes(appleDeviceVerification.AppPackageName + keyString + string.Join(',', appleDeviceVerification.Regions));
+                var value = Encoding.UTF8.GetBytes(
+                    appleDeviceVerification.AppPackageName
+                    + appleDeviceVerification.KeysTextForDeviceVerification
+                    + string.Join(',', appleDeviceVerification.Regions)
+                    );
                 payload.TransactionId = Convert.ToBase64String(sha.ComputeHash(value));
             }
 


### PR DESCRIPTION
~~#409 に依存した変更です。~~


## Issue 番号 / Issue ID

- #300
- #407

## 目的 / Purpose

- デバイス確認用のパラメーターに`KeyText`と`KeyString`が重複して存在する。これらはApple/Googleのデバイス確認APIを利用する際にコンテンツのハッシュ値を導くために使われているもので、KeyStringに統一しても差し支えないものと考える。

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[x] Yes
[ ] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

- 実際にこの変更をしたコードでApple/Googleのデバイス確認APIが通るかを確認したい

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
