### PR TITLE
Revert "[COCOA2]CI上でビルドが通るようにNuget.confgの内容を変更"

### DIFF
--- a/Nuget.config
+++ b/Nuget.config
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <packageSources>
-        <add key="MyNuget" value="%BUILD_SOURCESDIRECTORY%/TempNugetFeed" />
-        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+        <add key="MyNuget" value="./TempNugetFeed" />
     </packageSources>
     <activePackageSource>
         <add key="All" value="(Aggregate source)" />


### PR DESCRIPTION
feature/cocoa2ブランチでGithub上でのGithub Actionのほうがコケていた。
https://github.com/cocoa-mhlw/cocoa/actions/runs/1283228193

Azure用の環境変数を設定するとGithub Actionのほうがコケるようになっていたので一旦revertする
https://github.com/cocoa-mhlw/cocoa/pull/415


