### PR TITLE
Fix mailer doesn't launch on TargetSdkVersion 30.

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/Properties/AndroidManifest.xml
+++ b/Covid19Radar/Covid19Radar.Android/Properties/AndroidManifest.xml
@@ -12,4 +12,18 @@
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.WAKE_LOCK" />
 	<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+	<queries>
+		<intent>
+			<action android:name="android.intent.action.SENDTO" />
+			<data android:scheme="mailto" />
+		</intent>
+		<intent>
+			<action android:name="android.intent.action.VIEW" />
+			<data android:scheme="mailto" />
+		</intent>
+		<intent>
+			<action android:name="android.intent.action.SEND" />
+			<data android:scheme="mailto" />
+		</intent>
+	</queries>
 </manifest>


### PR DESCRIPTION
## Issue 番号 / Issue ID

- Close #433 

## 目的 / Purpose

- targetSdkVersionを`30`に設定したときにメーラーが起動しない不具合を修正する

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

- targetSdkVersionを30に設定した状態で起動して「メールでお問い合わせ」「動作情報を送信」した後のメーラー起動が正常に動作することを確認する

## その他 / Other information

targetSdkVersionの更新はこのPull Requestには含めない。