### PR TITLE
Fix the issue that privacy policy re-agreement page will be displayed every launch.

### DIFF
--- a/Covid19Radar/Covid19Radar/Model/TermsUpdateInfoModel.cs
+++ b/Covid19Radar/Covid19Radar/Model/TermsUpdateInfoModel.cs
@@ -17,11 +17,19 @@ namespace Covid19Radar.Model
 
         public class Detail
         {
+            private readonly TimeSpan TIME_DIFFERENCIAL_JST_UTC = TimeSpan.FromHours(+9);
+
             [JsonProperty("text")]
             public string Text { get; set; }
 
+            /// <summary>
+            /// Updated terms of service(or privacy policy) dateTime, that based on Japan Standard Time (UTC+9)
+            /// </summary>
             [JsonProperty("update_date")]
-            public DateTime UpdateDateTime { get; set; }
+            public DateTime UpdateDateTimeJst { get; set; }
+
+            public DateTime UpdateDateTimeUtc
+                => DateTime.SpecifyKind(UpdateDateTimeJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
         }
     }
 }

--- a/Covid19Radar/Covid19Radar/Services/Migration/Migrator_1_3_0.cs
+++ b/Covid19Radar/Covid19Radar/Services/Migration/Migrator_1_3_0.cs
@@ -15,6 +15,8 @@ namespace Covid19Radar.Services.Migration
         private const string TERMS_OF_SERVICE_LAST_UPDATE_DATETIME = "TermsOfServiceLastUpdateDateTime";
         private const string PRIVACY_POLICY_LAST_UPDATE_DATETIME = "PrivacyPolicyLastUpdateDateTime";
 
+        private readonly TimeSpan TIME_DIFFERENCIAL_JST_UTC = TimeSpan.FromHours(+9);
+
         private readonly IPreferencesService _preferencesService;
         private readonly ILoggerService _loggerService;
 
@@ -31,30 +33,38 @@ namespace Covid19Radar.Services.Migration
         {
             if (_preferencesService.ContainsKey(START_DATETIME))
             {
-                MigrateDateTimeToEpoch(START_DATETIME, PreferenceKey.StartDateTimeEpoch);
+                MigrateDateTimeToEpoch(START_DATETIME, PreferenceKey.StartDateTimeEpoch, TimeSpan.Zero);
             }
 
             if (_preferencesService.ContainsKey(TERMS_OF_SERVICE_LAST_UPDATE_DATETIME))
             {
-                MigrateDateTimeToEpoch(TERMS_OF_SERVICE_LAST_UPDATE_DATETIME, PreferenceKey.TermsOfServiceLastUpdateDateTimeEpoch);
+                MigrateDateTimeToEpoch(
+                    TERMS_OF_SERVICE_LAST_UPDATE_DATETIME,
+                    PreferenceKey.TermsOfServiceLastUpdateDateTimeEpoch,
+                    -TIME_DIFFERENCIAL_JST_UTC
+                    );
             }
 
             if (_preferencesService.ContainsKey(PRIVACY_POLICY_LAST_UPDATE_DATETIME))
             {
-                MigrateDateTimeToEpoch(PRIVACY_POLICY_LAST_UPDATE_DATETIME, PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch);
+                MigrateDateTimeToEpoch(
+                    PRIVACY_POLICY_LAST_UPDATE_DATETIME,
+                    PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch,
+                    -TIME_DIFFERENCIAL_JST_UTC
+                    );
             }
 
             return Task.CompletedTask;
         }
 
-        private void MigrateDateTimeToEpoch(string dateTimeKey, string epochKey)
+        private void MigrateDateTimeToEpoch(string dateTimeKey, string epochKey, TimeSpan differential)
         {
             string dateTimeStr = _preferencesService.GetValue(dateTimeKey, DateTime.UtcNow.ToString());
 
             DateTime dateTime;
             try
             {
-                dateTime = DateTime.SpecifyKind(DateTime.Parse(dateTimeStr), DateTimeKind.Utc);
+                dateTime = DateTime.SpecifyKind(DateTime.Parse(dateTimeStr) + differential, DateTimeKind.Utc);
             }
             catch (FormatException exception)
             {

--- a/Covid19Radar/Covid19Radar/Services/TermsUpdateService.cs
+++ b/Covid19Radar/Covid19Radar/Services/TermsUpdateService.cs
@@ -79,11 +79,13 @@ namespace Covid19Radar.Services
                 return false;
             }
 
+            var updateDatetime = info.UpdateDateTimeUtc;
+
             DateTime lastUpdateDate = userDataRepository.GetLastUpdateDate(termsType);
-            loggerService.Info($"termsType: {termsType}, lastUpdateDate: {lastUpdateDate}, info.UpdateDateTime: {info.UpdateDateTime}");
+            loggerService.Info($"termsType: {termsType}, lastUpdateDate: {lastUpdateDate}, updateDatetimeUtc: {updateDatetime}");
             loggerService.EndMethod();
 
-            return lastUpdateDate < info.UpdateDateTime;
+            return lastUpdateDate < updateDatetime;
         }
     }
 }

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/ReAgreePrivacyPolicyPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/ReAgreePrivacyPolicyPageViewModel.cs
@@ -21,7 +21,7 @@ namespace Covid19Radar.ViewModels
         private readonly ITermsUpdateService _termsUpdateService;
         private readonly IUserDataRepository _userDataRepository;
 
-        private DateTime UpdateDateTime { get; set; }
+        private DateTime UpdateDateTimeUtc { get; set; }
         private string _updateText;
         public string UpdateText
         {
@@ -57,7 +57,7 @@ namespace Covid19Radar.ViewModels
         {
             _loggerService.StartMethod();
 
-            _userDataRepository.SaveLastUpdateDate(TermsType.PrivacyPolicy, UpdateDateTime);
+            _userDataRepository.SaveLastUpdateDate(TermsType.PrivacyPolicy, UpdateDateTimeUtc);
             _ = await NavigationService.NavigateAsync("/" + nameof(MenuPage) + "/" + nameof(NavigationPage) + "/" + nameof(HomePage));
 
             _loggerService.EndMethod();
@@ -69,7 +69,7 @@ namespace Covid19Radar.ViewModels
 
             base.Initialize(parameters);
             TermsUpdateInfoModel.Detail updateInfo = (TermsUpdateInfoModel.Detail) parameters["updatePrivacyPolicyInfo"];
-            UpdateDateTime = updateInfo.UpdateDateTime;
+            UpdateDateTimeUtc = updateInfo.UpdateDateTimeUtc;
             UpdateText = updateInfo.Text;
 
             _loggerService.EndMethod();

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/ReAgreeTermsOfServicePageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/ReAgreeTermsOfServicePageViewModel.cs
@@ -22,7 +22,7 @@ namespace Covid19Radar.ViewModels
         private readonly IUserDataRepository _userDataRepository;
 
         private TermsUpdateInfoModel UpdateInfo;
-        private DateTime UpdateDateTime { get; set; }
+        private DateTime UpdateDateTimeUtc { get; set; }
         private string _updateText;
         public string UpdateText
         {
@@ -58,7 +58,7 @@ namespace Covid19Radar.ViewModels
         {
             _loggerService.StartMethod();
 
-            _userDataRepository.SaveLastUpdateDate(TermsType.TermsOfService, UpdateDateTime);
+            _userDataRepository.SaveLastUpdateDate(TermsType.TermsOfService, UpdateDateTimeUtc);
             if (_termsUpdateService.IsUpdated(TermsType.PrivacyPolicy, UpdateInfo))
             {
                 var param = new NavigationParameters
@@ -81,7 +81,7 @@ namespace Covid19Radar.ViewModels
 
             base.Initialize(parameters);
             UpdateInfo = (TermsUpdateInfoModel) parameters["updateInfo"];
-            UpdateDateTime = UpdateInfo.TermsOfService.UpdateDateTime;
+            UpdateDateTimeUtc = UpdateInfo.TermsOfService.UpdateDateTimeUtc;
             UpdateText = UpdateInfo.TermsOfService.Text;
 
             _loggerService.EndMethod();

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
@@ -30,6 +30,9 @@ namespace Covid19Radar.UnitTests.Services.Migration
         private static readonly TimeSpan TIME_DIFFERENCIAL_JST_UTC = TimeSpan.FromHours(+9);
         private static DateTime JstNow => DateTime.UtcNow + TIME_DIFFERENCIAL_JST_UTC;
 
+        private static DateTime JstToUtc(DateTime dateTimeJst)
+            => DateTime.SpecifyKind(dateTimeJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
+
         private const string FORMAT_TERMS_UPDATE_DATETIME = "yyyy/MM/dd HH:mm:ss";
 
         private static DateTime CreateTermsUpdateDateTime(DateTime dateTime)
@@ -732,12 +735,12 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.TermsOfServiceLastUpdateDateTimeEpoch, 0L);
-            //var termsOfServiceLastUpdateDateUtc = DateTime.SpecifyKind(termsOfServiceLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
-            Assert.Equal(termsOfServiceLastUpdateDateJst.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
+            var termsOfServiceLastUpdateDateUtc = JstToUtc(termsOfServiceLastUpdateDateJst);
+            Assert.Equal(termsOfServiceLastUpdateDateUtc.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
             var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch, 0L);
-            var privacyPolicyLastUpdateDateUtc = DateTime.SpecifyKind(privacyPolicyLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
+            var privacyPolicyLastUpdateDateUtc = JstToUtc(termsOfServiceLastUpdateDateJst);
             Assert.Equal(privacyPolicyLastUpdateDateUtc.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
@@ -794,12 +797,12 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.TermsOfServiceLastUpdateDateTimeEpoch, 0L);
-            var termsOfServiceLastUpdateDateUtc = DateTime.SpecifyKind(termsOfServiceLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
+            var termsOfServiceLastUpdateDateUtc = JstToUtc(termsOfServiceLastUpdateDateJst);
             Assert.Equal(termsOfServiceLastUpdateDateUtc.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
             var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch, 0L);
-            var privacyPolicyLastUpdateDateUtc = DateTime.SpecifyKind(privacyPolicyLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
+            var privacyPolicyLastUpdateDateUtc = JstToUtc(termsOfServiceLastUpdateDateJst);
             Assert.Equal(privacyPolicyLastUpdateDateUtc.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
@@ -890,12 +893,12 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.TermsOfServiceLastUpdateDateTimeEpoch, 0L);
-            var termsOfServiceLastUpdateDateUtc = DateTime.SpecifyKind(termsOfServiceLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
+            var termsOfServiceLastUpdateDateUtc = JstToUtc(termsOfServiceLastUpdateDateJst);
             Assert.Equal(termsOfServiceLastUpdateDateUtc.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
             var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch, 0L);
-            var privacyPolicyLastUpdateDateUtc = DateTime.SpecifyKind(privacyPolicyLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
+            var privacyPolicyLastUpdateDateUtc = JstToUtc(termsOfServiceLastUpdateDateJst);
             Assert.Equal(privacyPolicyLastUpdateDateUtc.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
@@ -63,6 +63,11 @@ namespace Covid19Radar.UnitTests.Services.Migration
                 );
         }
 
+        private const string FORMAT_TERMS_UPDATE_DATETIME = "yyyy/MM/dd HH:mm";
+
+        private static DateTime CreateTermsUpdateDateTime(DateTime dateTime)
+            => DateTime.ParseExact(dateTime.ToString(FORMAT_TERMS_UPDATE_DATETIME), FORMAT_TERMS_UPDATE_DATETIME, null);
+
         [Fact]
         public async Task Initialize100Async()
         {
@@ -209,8 +214,8 @@ namespace Covid19Radar.UnitTests.Services.Migration
             _mockEssentialService.SetupGet(x => x.AppVersion).Returns("1.0.0");
 
             var startDateTime = DateTime.UtcNow;
-            var termsOfServiceLastUpdateDateJst = DateTime.SpecifyKind(DateTime.Now.AddMinutes(1) + TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Unspecified);
-            var privacyPolicyLastUpdateDateJst = DateTime.SpecifyKind(DateTime.Now.AddMinutes(2) + TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Unspecified);
+            var termsOfServiceLastUpdateDateJst = CreateTermsUpdateDateTime(DateTime.Now.AddMinutes(1));
+            var privacyPolicyLastUpdateDateJst = CreateTermsUpdateDateTime(DateTime.Now.AddMinutes(2));
 
             var userExposureInfo1DateTime = DateTime.UtcNow;
             var userExposureInfo2DateTime = DateTime.UtcNow.AddDays(1);
@@ -726,13 +731,11 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.TermsOfServiceLastUpdateDateTimeEpoch, 0L);
-            var termsOfServiceLastUpdateDateUtc = DateTime.SpecifyKind(termsOfServiceLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
-            Assert.Equal(termsOfServiceLastUpdateDateUtc.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
+            Assert.Equal(termsOfServiceLastUpdateDateJst.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
             var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch, 0L);
-            var privacyPolicyLastUpdateDateUtc = DateTime.SpecifyKind(privacyPolicyLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
-            Assert.Equal(privacyPolicyLastUpdateDateUtc.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
+            Assert.Equal(privacyPolicyLastUpdateDateJst.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
             Assert.True(_dummyPreferencesService.ContainsKey(PreferenceKey.LastProcessTekTimestamp));
@@ -788,13 +791,11 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.TermsOfServiceLastUpdateDateTimeEpoch, 0L);
-            var termsOfServiceLastUpdateDateUtc = DateTime.SpecifyKind(termsOfServiceLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
-            Assert.Equal(termsOfServiceLastUpdateDateUtc.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
+            Assert.Equal(termsOfServiceLastUpdateDateJst.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
             var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch, 0L);
-            var privacyPolicyLastUpdateDateUtc = DateTime.SpecifyKind(privacyPolicyLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
-            Assert.Equal(privacyPolicyLastUpdateDateUtc.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
+            Assert.Equal(privacyPolicyLastUpdateDateJst.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
             Assert.True(_dummyPreferencesService.ContainsKey(PreferenceKey.LastProcessTekTimestamp));
@@ -884,13 +885,11 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.TermsOfServiceLastUpdateDateTimeEpoch, 0L);
-            var termsOfServiceLastUpdateDateUtc = DateTime.SpecifyKind(termsOfServiceLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
-            Assert.Equal(termsOfServiceLastUpdateDateUtc.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
+            Assert.Equal(termsOfServiceLastUpdateDateJst.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
             var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch, 0L);
-            var privacyPolicyLastUpdateDateUtc = DateTime.SpecifyKind(privacyPolicyLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
-            Assert.Equal(privacyPolicyLastUpdateDateUtc.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
+            Assert.Equal(privacyPolicyLastUpdateDateJst.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
             Assert.True(_dummyPreferencesService.ContainsKey(PreferenceKey.LastProcessTekTimestamp));

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Covid19Radar.Common;
 using Covid19Radar.Model;
@@ -213,6 +214,11 @@ namespace Covid19Radar.UnitTests.Services.Migration
             bool hasAppVersionAtPreference = true)
         {
             _mockEssentialService.SetupGet(x => x.AppVersion).Returns("1.0.0");
+
+            var now = DateTime.Now;
+            var offset = TimeZoneInfo.Local.GetUtcOffset(DateTime.UtcNow);
+
+            Debug.Print($"now: {now}, offset: {offset}");
 
             var startDateTime = DateTime.UtcNow;
             var termsOfServiceLastUpdateDateJst = CreateTermsUpdateDateTime(JstNow).AddMinutes(1);

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
@@ -215,8 +215,8 @@ namespace Covid19Radar.UnitTests.Services.Migration
             _mockEssentialService.SetupGet(x => x.AppVersion).Returns("1.0.0");
 
             var startDateTime = DateTime.UtcNow;
-            var termsOfServiceLastUpdateDateJst = DateTime.SpecifyKind(CreateTermsUpdateDateTime(JstNow.AddMinutes(1) + TIME_DIFFERENCIAL_JST_UTC), DateTimeKind.Unspecified);
-            var privacyPolicyLastUpdateDateJst = DateTime.SpecifyKind(CreateTermsUpdateDateTime(JstNow.AddMinutes(2) + TIME_DIFFERENCIAL_JST_UTC), DateTimeKind.Unspecified);
+            var termsOfServiceLastUpdateDateJst = DateTime.SpecifyKind(CreateTermsUpdateDateTime(JstNow.AddMinutes(1)), DateTimeKind.Unspecified);
+            var privacyPolicyLastUpdateDateJst = DateTime.SpecifyKind(CreateTermsUpdateDateTime(JstNow.AddMinutes(2)), DateTimeKind.Unspecified);
 
             var userExposureInfo1DateTime = DateTime.UtcNow;
             var userExposureInfo2DateTime = DateTime.UtcNow.AddDays(1);

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
@@ -740,7 +740,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // PrivacyPolicyLastUpdateDateTime
             var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch, 0L);
-            var privacyPolicyLastUpdateDateUtc = JstToUtc(termsOfServiceLastUpdateDateJst);
+            var privacyPolicyLastUpdateDateUtc = JstToUtc(privacyPolicyLastUpdateDateJst);
             Assert.Equal(privacyPolicyLastUpdateDateUtc.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
@@ -802,7 +802,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // PrivacyPolicyLastUpdateDateTime
             var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch, 0L);
-            var privacyPolicyLastUpdateDateUtc = JstToUtc(termsOfServiceLastUpdateDateJst);
+            var privacyPolicyLastUpdateDateUtc = JstToUtc(privacyPolicyLastUpdateDateJst);
             Assert.Equal(privacyPolicyLastUpdateDateUtc.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
@@ -898,7 +898,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // PrivacyPolicyLastUpdateDateTime
             var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch, 0L);
-            var privacyPolicyLastUpdateDateUtc = JstToUtc(termsOfServiceLastUpdateDateJst);
+            var privacyPolicyLastUpdateDateUtc = JstToUtc(privacyPolicyLastUpdateDateJst);
             Assert.Equal(privacyPolicyLastUpdateDateUtc.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
@@ -27,7 +27,8 @@ namespace Covid19Radar.UnitTests.Services.Migration
         private const string PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE = "TermsOfServiceLastUpdateDateTime";
         private const string PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE = "PrivacyPolicyLastUpdateDateTime";
 
-        private readonly TimeSpan TIME_DIFFERENCIAL_JST_UTC = TimeSpan.FromHours(+9);
+        private static readonly TimeSpan TIME_DIFFERENCIAL_JST_UTC = TimeSpan.FromHours(+9);
+        private static DateTime JstNow => DateTime.UtcNow + TIME_DIFFERENCIAL_JST_UTC;
 
         private readonly MockRepository _mockRepository = new MockRepository(MockBehavior.Default);
 
@@ -214,8 +215,8 @@ namespace Covid19Radar.UnitTests.Services.Migration
             _mockEssentialService.SetupGet(x => x.AppVersion).Returns("1.0.0");
 
             var startDateTime = DateTime.UtcNow;
-            var termsOfServiceLastUpdateDateJst = CreateTermsUpdateDateTime(DateTime.Now.AddMinutes(1) + TIME_DIFFERENCIAL_JST_UTC);
-            var privacyPolicyLastUpdateDateJst = CreateTermsUpdateDateTime(DateTime.Now.AddMinutes(2) + TIME_DIFFERENCIAL_JST_UTC);
+            var termsOfServiceLastUpdateDateJst = CreateTermsUpdateDateTime(JstNow).AddMinutes(1);
+            var privacyPolicyLastUpdateDateJst = CreateTermsUpdateDateTime(JstNow).AddMinutes(2);
 
             var userExposureInfo1DateTime = DateTime.UtcNow;
             var userExposureInfo2DateTime = DateTime.UtcNow.AddDays(1);
@@ -301,12 +302,12 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             Assert.True(_dummyPreferencesService.ContainsKey(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE));
-            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, JstNow.ToString());
             Assert.Equal(termsOfServiceLastUpdateDateJst.ToString(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
             Assert.True(_dummyPreferencesService.ContainsKey(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE));
-            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, JstNow.ToString());
             Assert.Equal(privacyPolicyLastUpdateDateJst.ToString(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
@@ -372,7 +373,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // PrivacyPolicyLastUpdateDateTime
             Assert.True(_dummyPreferencesService.ContainsKey(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE));
-            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, JstNow.ToString());
             Assert.Equal(privacyPolicyLastUpdateDateJst.ToString(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
@@ -433,7 +434,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             Assert.True(_dummyPreferencesService.ContainsKey(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE));
-            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, JstNow.ToString());
             Assert.Equal(termsOfServiceLastUpdateDateJst.ToString(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
@@ -497,11 +498,11 @@ namespace Covid19Radar.UnitTests.Services.Migration
             Assert.Equal(startDateTime.ToString(), startDateTimePref);
 
             // TermsOfServiceLastUpdateDateTime
-            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, JstNow.ToString());
             Assert.Equal(termsOfServiceLastUpdateDateJst.ToString(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
-            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, JstNow.ToString());
             Assert.Equal(privacyPolicyLastUpdateDateJst.ToString(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
@@ -577,11 +578,11 @@ namespace Covid19Radar.UnitTests.Services.Migration
             Assert.NotEqual(startDateTime.ToString(), startDateTimePref);
 
             // TermsOfServiceLastUpdateDateTime
-            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, JstNow.ToString());
             Assert.Equal(new DateTime().ToString(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
-            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, JstNow.ToString());
             Assert.Equal(new DateTime().ToString(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
@@ -662,11 +663,11 @@ namespace Covid19Radar.UnitTests.Services.Migration
             Assert.Equal(startDateTime.ToString(), startDateTimePref);
 
             // TermsOfServiceLastUpdateDateTime
-            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, JstNow.ToString());
             Assert.Equal(termsOfServiceLastUpdateDateJst.ToString(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
-            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, JstNow.ToString());
             Assert.Equal(privacyPolicyLastUpdateDateJst.ToString(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
@@ -63,7 +63,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
                 );
         }
 
-        private const string FORMAT_TERMS_UPDATE_DATETIME = "yyyy/MM/dd HH:mm";
+        private const string FORMAT_TERMS_UPDATE_DATETIME = "yyyy/MM/dd HH:mm:ss";
 
         private static DateTime CreateTermsUpdateDateTime(DateTime dateTime)
             => DateTime.ParseExact(dateTime.ToString(FORMAT_TERMS_UPDATE_DATETIME), FORMAT_TERMS_UPDATE_DATETIME, null);
@@ -214,8 +214,8 @@ namespace Covid19Radar.UnitTests.Services.Migration
             _mockEssentialService.SetupGet(x => x.AppVersion).Returns("1.0.0");
 
             var startDateTime = DateTime.UtcNow;
-            var termsOfServiceLastUpdateDateJst = CreateTermsUpdateDateTime(DateTime.Now.AddMinutes(1));
-            var privacyPolicyLastUpdateDateJst = CreateTermsUpdateDateTime(DateTime.Now.AddMinutes(2));
+            var termsOfServiceLastUpdateDateJst = CreateTermsUpdateDateTime(DateTime.Now.AddMinutes(1) + TIME_DIFFERENCIAL_JST_UTC);
+            var privacyPolicyLastUpdateDateJst = CreateTermsUpdateDateTime(DateTime.Now.AddMinutes(2) + TIME_DIFFERENCIAL_JST_UTC);
 
             var userExposureInfo1DateTime = DateTime.UtcNow;
             var userExposureInfo2DateTime = DateTime.UtcNow.AddDays(1);

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
@@ -27,7 +27,8 @@ namespace Covid19Radar.UnitTests.Services.Migration
         private const string PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE = "TermsOfServiceLastUpdateDateTime";
         private const string PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE = "PrivacyPolicyLastUpdateDateTime";
 
-        private readonly TimeSpan TIME_DIFFERENCIAL_JST_UTC = TimeSpan.FromHours(+9);
+        private static readonly TimeSpan TIME_DIFFERENCIAL_JST_UTC = TimeSpan.FromHours(+9);
+        private static DateTime JstNow => DateTime.UtcNow + TIME_DIFFERENCIAL_JST_UTC;
 
         private readonly MockRepository _mockRepository = new MockRepository(MockBehavior.Default);
 
@@ -209,8 +210,8 @@ namespace Covid19Radar.UnitTests.Services.Migration
             _mockEssentialService.SetupGet(x => x.AppVersion).Returns("1.0.0");
 
             var startDateTime = DateTime.UtcNow;
-            var termsOfServiceLastUpdateDateJst = DateTime.SpecifyKind(DateTime.Now.AddMinutes(1) + TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Unspecified);
-            var privacyPolicyLastUpdateDateJst = DateTime.SpecifyKind(DateTime.Now.AddMinutes(2) + TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Unspecified);
+            var termsOfServiceLastUpdateDateJst = DateTime.SpecifyKind(JstNow.AddMinutes(1) + TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Unspecified);
+            var privacyPolicyLastUpdateDateJst = DateTime.SpecifyKind(JstNow.AddMinutes(2) + TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Unspecified);
 
             var userExposureInfo1DateTime = DateTime.UtcNow;
             var userExposureInfo2DateTime = DateTime.UtcNow.AddDays(1);
@@ -296,12 +297,12 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             Assert.True(_dummyPreferencesService.ContainsKey(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE));
-            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, JstNow.ToString());
             Assert.Equal(termsOfServiceLastUpdateDateJst.ToString(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
             Assert.True(_dummyPreferencesService.ContainsKey(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE));
-            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, JstNow.ToString());
             Assert.Equal(privacyPolicyLastUpdateDateJst.ToString(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
@@ -367,7 +368,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // PrivacyPolicyLastUpdateDateTime
             Assert.True(_dummyPreferencesService.ContainsKey(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE));
-            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, JstNow.ToString());
             Assert.Equal(privacyPolicyLastUpdateDateJst.ToString(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
@@ -428,7 +429,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             Assert.True(_dummyPreferencesService.ContainsKey(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE));
-            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, JstNow.ToString());
             Assert.Equal(termsOfServiceLastUpdateDateJst.ToString(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
@@ -492,11 +493,11 @@ namespace Covid19Radar.UnitTests.Services.Migration
             Assert.Equal(startDateTime.ToString(), startDateTimePref);
 
             // TermsOfServiceLastUpdateDateTime
-            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, JstNow.ToString());
             Assert.Equal(termsOfServiceLastUpdateDateJst.ToString(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
-            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, JstNow.ToString());
             Assert.Equal(privacyPolicyLastUpdateDateJst.ToString(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
@@ -572,11 +573,11 @@ namespace Covid19Radar.UnitTests.Services.Migration
             Assert.NotEqual(startDateTime.ToString(), startDateTimePref);
 
             // TermsOfServiceLastUpdateDateTime
-            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, JstNow.ToString());
             Assert.Equal(new DateTime().ToString(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
-            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, JstNow.ToString());
             Assert.Equal(new DateTime().ToString(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
@@ -657,11 +658,11 @@ namespace Covid19Radar.UnitTests.Services.Migration
             Assert.Equal(startDateTime.ToString(), startDateTimePref);
 
             // TermsOfServiceLastUpdateDateTime
-            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, JstNow.ToString());
             Assert.Equal(termsOfServiceLastUpdateDateJst.ToString(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
-            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, JstNow.ToString());
             Assert.Equal(privacyPolicyLastUpdateDateJst.ToString(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using Covid19Radar.Common;
 using Covid19Radar.Model;
@@ -28,8 +27,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
         private const string PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE = "TermsOfServiceLastUpdateDateTime";
         private const string PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE = "PrivacyPolicyLastUpdateDateTime";
 
-        private static readonly TimeSpan TIME_DIFFERENCIAL_JST_UTC = TimeSpan.FromHours(+9);
-        private static DateTime JstNow => DateTime.UtcNow + TIME_DIFFERENCIAL_JST_UTC;
+        private readonly TimeSpan TIME_DIFFERENCIAL_JST_UTC = TimeSpan.FromHours(+9);
 
         private readonly MockRepository _mockRepository = new MockRepository(MockBehavior.Default);
 
@@ -64,11 +62,6 @@ namespace Covid19Radar.UnitTests.Services.Migration
                 _mockLoggerService.Object
                 );
         }
-
-        private const string FORMAT_TERMS_UPDATE_DATETIME = "yyyy/MM/dd HH:mm:ss";
-
-        private static DateTime CreateTermsUpdateDateTime(DateTime dateTime)
-            => DateTime.ParseExact(dateTime.ToString(FORMAT_TERMS_UPDATE_DATETIME), FORMAT_TERMS_UPDATE_DATETIME, null);
 
         [Fact]
         public async Task Initialize100Async()
@@ -215,14 +208,9 @@ namespace Covid19Radar.UnitTests.Services.Migration
         {
             _mockEssentialService.SetupGet(x => x.AppVersion).Returns("1.0.0");
 
-            var now = DateTime.Now;
-            var offset = TimeZoneInfo.Local.GetUtcOffset(DateTime.UtcNow);
-
-            Debug.Print($"now: {now}, offset: {offset}");
-
             var startDateTime = DateTime.UtcNow;
-            var termsOfServiceLastUpdateDateJst = DateTime.SpecifyKind(CreateTermsUpdateDateTime(JstNow.AddMinutes(1)), DateTimeKind.Unspecified);
-            var privacyPolicyLastUpdateDateJst = DateTime.SpecifyKind(CreateTermsUpdateDateTime(JstNow.AddMinutes(2)), DateTimeKind.Unspecified);
+            var termsOfServiceLastUpdateDateJst = DateTime.SpecifyKind(DateTime.Now.AddMinutes(1) + TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Unspecified);
+            var privacyPolicyLastUpdateDateJst = DateTime.SpecifyKind(DateTime.Now.AddMinutes(2) + TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Unspecified);
 
             var userExposureInfo1DateTime = DateTime.UtcNow;
             var userExposureInfo2DateTime = DateTime.UtcNow.AddDays(1);
@@ -308,12 +296,12 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             Assert.True(_dummyPreferencesService.ContainsKey(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE));
-            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, JstNow.ToString());
+            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.Now.ToString());
             Assert.Equal(termsOfServiceLastUpdateDateJst.ToString(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
             Assert.True(_dummyPreferencesService.ContainsKey(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE));
-            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, JstNow.ToString());
+            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.Now.ToString());
             Assert.Equal(privacyPolicyLastUpdateDateJst.ToString(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
@@ -379,7 +367,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // PrivacyPolicyLastUpdateDateTime
             Assert.True(_dummyPreferencesService.ContainsKey(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE));
-            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, JstNow.ToString());
+            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.Now.ToString());
             Assert.Equal(privacyPolicyLastUpdateDateJst.ToString(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
@@ -440,7 +428,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             Assert.True(_dummyPreferencesService.ContainsKey(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE));
-            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, JstNow.ToString());
+            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.Now.ToString());
             Assert.Equal(termsOfServiceLastUpdateDateJst.ToString(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
@@ -504,11 +492,11 @@ namespace Covid19Radar.UnitTests.Services.Migration
             Assert.Equal(startDateTime.ToString(), startDateTimePref);
 
             // TermsOfServiceLastUpdateDateTime
-            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, JstNow.ToString());
+            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.Now.ToString());
             Assert.Equal(termsOfServiceLastUpdateDateJst.ToString(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
-            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, JstNow.ToString());
+            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.Now.ToString());
             Assert.Equal(privacyPolicyLastUpdateDateJst.ToString(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
@@ -584,11 +572,11 @@ namespace Covid19Radar.UnitTests.Services.Migration
             Assert.NotEqual(startDateTime.ToString(), startDateTimePref);
 
             // TermsOfServiceLastUpdateDateTime
-            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, JstNow.ToString());
+            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.Now.ToString());
             Assert.Equal(new DateTime().ToString(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
-            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, JstNow.ToString());
+            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.Now.ToString());
             Assert.Equal(new DateTime().ToString(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
@@ -669,11 +657,11 @@ namespace Covid19Radar.UnitTests.Services.Migration
             Assert.Equal(startDateTime.ToString(), startDateTimePref);
 
             // TermsOfServiceLastUpdateDateTime
-            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, JstNow.ToString());
+            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.Now.ToString());
             Assert.Equal(termsOfServiceLastUpdateDateJst.ToString(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
-            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, JstNow.ToString());
+            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.Now.ToString());
             Assert.Equal(privacyPolicyLastUpdateDateJst.ToString(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
@@ -738,11 +726,13 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.TermsOfServiceLastUpdateDateTimeEpoch, 0L);
-            Assert.Equal(termsOfServiceLastUpdateDateJst.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
+            var termsOfServiceLastUpdateDateUtc = DateTime.SpecifyKind(termsOfServiceLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
+            Assert.Equal(termsOfServiceLastUpdateDateUtc.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
             var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch, 0L);
-            Assert.Equal(privacyPolicyLastUpdateDateJst.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
+            var privacyPolicyLastUpdateDateUtc = DateTime.SpecifyKind(privacyPolicyLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
+            Assert.Equal(privacyPolicyLastUpdateDateUtc.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
             Assert.True(_dummyPreferencesService.ContainsKey(PreferenceKey.LastProcessTekTimestamp));
@@ -798,11 +788,13 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.TermsOfServiceLastUpdateDateTimeEpoch, 0L);
-            Assert.Equal(termsOfServiceLastUpdateDateJst.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
+            var termsOfServiceLastUpdateDateUtc = DateTime.SpecifyKind(termsOfServiceLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
+            Assert.Equal(termsOfServiceLastUpdateDateUtc.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
             var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch, 0L);
-            Assert.Equal(privacyPolicyLastUpdateDateJst.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
+            var privacyPolicyLastUpdateDateUtc = DateTime.SpecifyKind(privacyPolicyLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
+            Assert.Equal(privacyPolicyLastUpdateDateUtc.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
             Assert.True(_dummyPreferencesService.ContainsKey(PreferenceKey.LastProcessTekTimestamp));
@@ -892,11 +884,13 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.TermsOfServiceLastUpdateDateTimeEpoch, 0L);
-            Assert.Equal(termsOfServiceLastUpdateDateJst.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
+            var termsOfServiceLastUpdateDateUtc = DateTime.SpecifyKind(termsOfServiceLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
+            Assert.Equal(termsOfServiceLastUpdateDateUtc.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
             var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch, 0L);
-            Assert.Equal(privacyPolicyLastUpdateDateJst.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
+            var privacyPolicyLastUpdateDateUtc = DateTime.SpecifyKind(privacyPolicyLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
+            Assert.Equal(privacyPolicyLastUpdateDateUtc.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
             Assert.True(_dummyPreferencesService.ContainsKey(PreferenceKey.LastProcessTekTimestamp));

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
@@ -27,6 +27,8 @@ namespace Covid19Radar.UnitTests.Services.Migration
         private const string PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE = "TermsOfServiceLastUpdateDateTime";
         private const string PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE = "PrivacyPolicyLastUpdateDateTime";
 
+        private readonly TimeSpan TIME_DIFFERENCIAL_JST_UTC = TimeSpan.FromHours(+9);
+
         private readonly MockRepository _mockRepository = new MockRepository(MockBehavior.Default);
 
         private readonly Mock<IMigrationProcessService> _migrationProcessService;
@@ -207,8 +209,8 @@ namespace Covid19Radar.UnitTests.Services.Migration
             _mockEssentialService.SetupGet(x => x.AppVersion).Returns("1.0.0");
 
             var startDateTime = DateTime.UtcNow;
-            var termsOfServiceLastUpdateDate = DateTime.UtcNow.AddMinutes(1);
-            var privacyPolicyLastUpdateDate = DateTime.UtcNow.AddMinutes(2);
+            var termsOfServiceLastUpdateDateJst = DateTime.SpecifyKind(DateTime.Now.AddMinutes(1) + TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Unspecified);
+            var privacyPolicyLastUpdateDateJst = DateTime.SpecifyKind(DateTime.Now.AddMinutes(2) + TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Unspecified);
 
             var userExposureInfo1DateTime = DateTime.UtcNow;
             var userExposureInfo2DateTime = DateTime.UtcNow.AddDays(1);
@@ -238,8 +240,8 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // Setup Application-properties
             await _dummyApplicationPropertyService.SavePropertiesAsync(APPLICATION_PROPERTY_USER_DATA_KEY, userDataString);
-            await _dummyApplicationPropertyService.SavePropertiesAsync(APPLICATION_PROPERTY_TERMS_OF_SERVICE_LAST_UPDATE_DATE_KEY, termsOfServiceLastUpdateDate);
-            await _dummyApplicationPropertyService.SavePropertiesAsync(APPLICATION_PROPERTY_PRIVACY_POLICY_LAST_UPDATE_DATE_KEY, privacyPolicyLastUpdateDate);
+            await _dummyApplicationPropertyService.SavePropertiesAsync(APPLICATION_PROPERTY_TERMS_OF_SERVICE_LAST_UPDATE_DATE_KEY, termsOfServiceLastUpdateDateJst);
+            await _dummyApplicationPropertyService.SavePropertiesAsync(APPLICATION_PROPERTY_PRIVACY_POLICY_LAST_UPDATE_DATE_KEY, privacyPolicyLastUpdateDateJst);
 
             await CreateService()
                 .MigrateAsync();
@@ -254,7 +256,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             return (
                 startDateTime,
-                termsOfServiceLastUpdateDate, privacyPolicyLastUpdateDate,
+                termsOfServiceLastUpdateDateJst, privacyPolicyLastUpdateDateJst,
                 lastProcesTekTimestamp,
                 userExposureInfo1, userExposureInfo2, userExposureSummary
                 );
@@ -265,7 +267,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
         {
             var (
                 startDateTime,
-                termsOfServiceLastUpdateDate, privacyPolicyLastUpdateDate,
+                termsOfServiceLastUpdateDateJst, privacyPolicyLastUpdateDateJst,
                 lastProcesTekTimestamp,
                 userExposureInfo1, userExposureInfo2, userExposureSummary
             ) = await SetUpVersion100();
@@ -294,13 +296,13 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             Assert.True(_dummyPreferencesService.ContainsKey(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE));
-            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.UtcNow.ToString());
-            Assert.Equal(termsOfServiceLastUpdateDate.ToString(), termsOfServiceLastUpdateDateTimePref);
+            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            Assert.Equal(termsOfServiceLastUpdateDateJst.ToString(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
             Assert.True(_dummyPreferencesService.ContainsKey(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE));
-            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.UtcNow.ToString());
-            Assert.Equal(privacyPolicyLastUpdateDate.ToString(), privacyPolicyLastUpdateDateTimePref);
+            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            Assert.Equal(privacyPolicyLastUpdateDateJst.ToString(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
             Assert.True(_dummyPreferencesService.ContainsKey(PreferenceKey.LastProcessTekTimestamp));
@@ -331,7 +333,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
         {
             var (
                 startDateTime,
-                termsOfServiceLastUpdateDate, privacyPolicyLastUpdateDate,
+                termsOfServiceLastUpdateDateJst, privacyPolicyLastUpdateDateJst,
                 lastProcesTekTimestamp,
                 userExposureInfo1, userExposureInfo2, userExposureSummary
             ) = await SetUpVersion100(isOptIned: false);
@@ -365,8 +367,8 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // PrivacyPolicyLastUpdateDateTime
             Assert.True(_dummyPreferencesService.ContainsKey(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE));
-            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.UtcNow.ToString());
-            Assert.Equal(privacyPolicyLastUpdateDate.ToString(), privacyPolicyLastUpdateDateTimePref);
+            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            Assert.Equal(privacyPolicyLastUpdateDateJst.ToString(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
             Assert.True(_dummyPreferencesService.ContainsKey(PreferenceKey.LastProcessTekTimestamp));
@@ -397,7 +399,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
         {
             var (
                 startDateTime,
-                termsOfServiceLastUpdateDate, privacyPolicyLastUpdateDate,
+                termsOfServiceLastUpdateDateJst, privacyPolicyLastUpdateDateJst,
                 lastProcesTekTimestamp,
                 userExposureInfo1, userExposureInfo2, userExposureSummary
             ) = await SetUpVersion100(isPrivaryPolicyAgreed: false);
@@ -426,8 +428,8 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             Assert.True(_dummyPreferencesService.ContainsKey(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE));
-            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.UtcNow.ToString());
-            Assert.Equal(termsOfServiceLastUpdateDate.ToString(), termsOfServiceLastUpdateDateTimePref);
+            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            Assert.Equal(termsOfServiceLastUpdateDateJst.ToString(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
             Assert.False(_dummyPreferencesService.ContainsKey(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE));
@@ -463,7 +465,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
         {
             var (
                 startDateTime,
-                termsOfServiceLastUpdateDate, privacyPolicyLastUpdateDate,
+                termsOfServiceLastUpdateDateJst, privacyPolicyLastUpdateDateJst,
                 lastProcesTekTimestamp,
                 userExposureInfo1, userExposureInfo2, userExposureSummary
             ) = await SetUpVersion100(hasAppVersionAtPreference: false);
@@ -490,12 +492,12 @@ namespace Covid19Radar.UnitTests.Services.Migration
             Assert.Equal(startDateTime.ToString(), startDateTimePref);
 
             // TermsOfServiceLastUpdateDateTime
-            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.UtcNow.ToString());
-            Assert.Equal(termsOfServiceLastUpdateDate.ToString(), termsOfServiceLastUpdateDateTimePref);
+            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            Assert.Equal(termsOfServiceLastUpdateDateJst.ToString(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
-            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.UtcNow.ToString());
-            Assert.Equal(privacyPolicyLastUpdateDate.ToString(), privacyPolicyLastUpdateDateTimePref);
+            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            Assert.Equal(privacyPolicyLastUpdateDateJst.ToString(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
             Assert.True(_dummyPreferencesService.ContainsKey(PreferenceKey.LastProcessTekTimestamp));
@@ -536,7 +538,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
         {
             var (
                 startDateTime,
-                termsOfServiceLastUpdateDate, privacyPolicyLastUpdateDate,
+                termsOfServiceLastUpdateDateJst, privacyPolicyLastUpdateDateJst,
                 lastProcesTekTimestamp,
                 userExposureInfo1, userExposureInfo2, userExposureSummary
             ) = await SetUpVersion100(hasAppVersionAtPreference: false);
@@ -570,11 +572,11 @@ namespace Covid19Radar.UnitTests.Services.Migration
             Assert.NotEqual(startDateTime.ToString(), startDateTimePref);
 
             // TermsOfServiceLastUpdateDateTime
-            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.UtcNow.ToString());
+            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.Now.ToString());
             Assert.Equal(new DateTime().ToString(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
-            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.UtcNow.ToString());
+            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.Now.ToString());
             Assert.Equal(new DateTime().ToString(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
@@ -636,7 +638,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
         {
             var (
                 startDateTime,
-                termsOfServiceLastUpdateDate, privacyPolicyLastUpdateDate,
+                termsOfServiceLastUpdateDateJst, privacyPolicyLastUpdateDateJst,
                 lastProcesTekTimestamp,
                 userExposureInfo1, userExposureInfo2, userExposureSummary
             ) = await SetUpVersion122(hasAppVersionAtPreference: false);
@@ -655,12 +657,12 @@ namespace Covid19Radar.UnitTests.Services.Migration
             Assert.Equal(startDateTime.ToString(), startDateTimePref);
 
             // TermsOfServiceLastUpdateDateTime
-            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.UtcNow.ToString());
-            Assert.Equal(termsOfServiceLastUpdateDate.ToString(), termsOfServiceLastUpdateDateTimePref);
+            var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            Assert.Equal(termsOfServiceLastUpdateDateJst.ToString(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
-            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.UtcNow.ToString());
-            Assert.Equal(privacyPolicyLastUpdateDate.ToString(), privacyPolicyLastUpdateDateTimePref);
+            var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE, DateTime.Now.ToString());
+            Assert.Equal(privacyPolicyLastUpdateDateJst.ToString(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
             Assert.True(_dummyPreferencesService.ContainsKey(PreferenceKey.LastProcessTekTimestamp));
@@ -691,7 +693,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
         {
             var (
                 startDateTime,
-                termsOfServiceLastUpdateDate, privacyPolicyLastUpdateDate,
+                termsOfServiceLastUpdateDateJst, privacyPolicyLastUpdateDateJst,
                 lastProcesTekTimestamp,
                 userExposureInfo1, userExposureInfo2, userExposureSummary
             ) = await SetUpVersion100(hasAppVersionAtPreference: false);
@@ -724,11 +726,13 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.TermsOfServiceLastUpdateDateTimeEpoch, 0L);
-            Assert.Equal(termsOfServiceLastUpdateDate.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
+            var termsOfServiceLastUpdateDateUtc = DateTime.SpecifyKind(termsOfServiceLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
+            Assert.Equal(termsOfServiceLastUpdateDateUtc.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
             var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch, 0L);
-            Assert.Equal(privacyPolicyLastUpdateDate.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
+            var privacyPolicyLastUpdateDateUtc = DateTime.SpecifyKind(privacyPolicyLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
+            Assert.Equal(privacyPolicyLastUpdateDateUtc.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
             Assert.True(_dummyPreferencesService.ContainsKey(PreferenceKey.LastProcessTekTimestamp));
@@ -759,7 +763,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
         {
             var (
                 startDateTime,
-                termsOfServiceLastUpdateDate, privacyPolicyLastUpdateDate,
+                termsOfServiceLastUpdateDateJst, privacyPolicyLastUpdateDateJst,
                 lastProcesTekTimestamp,
                 userExposureInfo1, userExposureInfo2, userExposureSummary
             ) = await SetUpVersion122(hasAppVersionAtPreference: false);
@@ -784,11 +788,13 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.TermsOfServiceLastUpdateDateTimeEpoch, 0L);
-            Assert.Equal(termsOfServiceLastUpdateDate.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
+            var termsOfServiceLastUpdateDateUtc = DateTime.SpecifyKind(termsOfServiceLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
+            Assert.Equal(termsOfServiceLastUpdateDateUtc.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
             var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch, 0L);
-            Assert.Equal(privacyPolicyLastUpdateDate.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
+            var privacyPolicyLastUpdateDateUtc = DateTime.SpecifyKind(privacyPolicyLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
+            Assert.Equal(privacyPolicyLastUpdateDateUtc.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
             Assert.True(_dummyPreferencesService.ContainsKey(PreferenceKey.LastProcessTekTimestamp));
@@ -852,7 +858,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
         {
             var (
                 startDateTime,
-                termsOfServiceLastUpdateDate, privacyPolicyLastUpdateDate,
+                termsOfServiceLastUpdateDateJst, privacyPolicyLastUpdateDateJst,
                 lastProcesTekTimestamp,
                 userExposureInfo1, userExposureInfo2, userExposureSummary
             ) = await SetUpVersion123();
@@ -878,11 +884,13 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.TermsOfServiceLastUpdateDateTimeEpoch, 0L);
-            Assert.Equal(termsOfServiceLastUpdateDate.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
+            var termsOfServiceLastUpdateDateUtc = DateTime.SpecifyKind(termsOfServiceLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
+            Assert.Equal(termsOfServiceLastUpdateDateUtc.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
             var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch, 0L);
-            Assert.Equal(privacyPolicyLastUpdateDate.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
+            var privacyPolicyLastUpdateDateUtc = DateTime.SpecifyKind(privacyPolicyLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
+            Assert.Equal(privacyPolicyLastUpdateDateUtc.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp
             Assert.True(_dummyPreferencesService.ContainsKey(PreferenceKey.LastProcessTekTimestamp));

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
@@ -221,8 +221,8 @@ namespace Covid19Radar.UnitTests.Services.Migration
             Debug.Print($"now: {now}, offset: {offset}");
 
             var startDateTime = DateTime.UtcNow;
-            var termsOfServiceLastUpdateDateJst = CreateTermsUpdateDateTime(JstNow).AddMinutes(1);
-            var privacyPolicyLastUpdateDateJst = CreateTermsUpdateDateTime(JstNow).AddMinutes(2);
+            var termsOfServiceLastUpdateDateJst = DateTime.SpecifyKind(CreateTermsUpdateDateTime(JstNow.AddMinutes(1)), DateTimeKind.Unspecified);
+            var privacyPolicyLastUpdateDateJst = DateTime.SpecifyKind(CreateTermsUpdateDateTime(JstNow.AddMinutes(2)), DateTimeKind.Unspecified);
 
             var userExposureInfo1DateTime = DateTime.UtcNow;
             var userExposureInfo2DateTime = DateTime.UtcNow.AddDays(1);

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
@@ -732,8 +732,8 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.TermsOfServiceLastUpdateDateTimeEpoch, 0L);
-            var termsOfServiceLastUpdateDateUtc = DateTime.SpecifyKind(termsOfServiceLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
-            Assert.Equal(termsOfServiceLastUpdateDateUtc.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
+            //var termsOfServiceLastUpdateDateUtc = DateTime.SpecifyKind(termsOfServiceLastUpdateDateJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
+            Assert.Equal(termsOfServiceLastUpdateDateJst.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
             var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch, 0L);

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
@@ -30,6 +30,11 @@ namespace Covid19Radar.UnitTests.Services.Migration
         private static readonly TimeSpan TIME_DIFFERENCIAL_JST_UTC = TimeSpan.FromHours(+9);
         private static DateTime JstNow => DateTime.UtcNow + TIME_DIFFERENCIAL_JST_UTC;
 
+        private const string FORMAT_TERMS_UPDATE_DATETIME = "yyyy/MM/dd HH:mm:ss";
+
+        private static DateTime CreateTermsUpdateDateTime(DateTime dateTime)
+            => DateTime.ParseExact(dateTime.ToString(FORMAT_TERMS_UPDATE_DATETIME), FORMAT_TERMS_UPDATE_DATETIME, null);
+
         private readonly MockRepository _mockRepository = new MockRepository(MockBehavior.Default);
 
         private readonly Mock<IMigrationProcessService> _migrationProcessService;
@@ -210,8 +215,8 @@ namespace Covid19Radar.UnitTests.Services.Migration
             _mockEssentialService.SetupGet(x => x.AppVersion).Returns("1.0.0");
 
             var startDateTime = DateTime.UtcNow;
-            var termsOfServiceLastUpdateDateJst = DateTime.SpecifyKind(JstNow.AddMinutes(1) + TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Unspecified);
-            var privacyPolicyLastUpdateDateJst = DateTime.SpecifyKind(JstNow.AddMinutes(2) + TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Unspecified);
+            var termsOfServiceLastUpdateDateJst = DateTime.SpecifyKind(CreateTermsUpdateDateTime(JstNow.AddMinutes(1) + TIME_DIFFERENCIAL_JST_UTC), DateTimeKind.Unspecified);
+            var privacyPolicyLastUpdateDateJst = DateTime.SpecifyKind(CreateTermsUpdateDateTime(JstNow.AddMinutes(2) + TIME_DIFFERENCIAL_JST_UTC), DateTimeKind.Unspecified);
 
             var userExposureInfo1DateTime = DateTime.UtcNow;
             var userExposureInfo2DateTime = DateTime.UtcNow.AddDays(1);

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/TermsUpdateServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/TermsUpdateServiceTests.cs
@@ -52,8 +52,8 @@ namespace Covid19Radar.UnitTests.Services
         {
             var info = new TermsUpdateInfoModel
             {
-                TermsOfService = new TermsUpdateInfoModel.Detail { UpdateDateTime = DateTime.UtcNow },
-                PrivacyPolicy = new TermsUpdateInfoModel.Detail { UpdateDateTime = DateTime.UtcNow }
+                TermsOfService = new TermsUpdateInfoModel.Detail { UpdateDateTimeJst = DateTime.UtcNow },
+                PrivacyPolicy = new TermsUpdateInfoModel.Detail { UpdateDateTimeJst = DateTime.UtcNow }
             };
 
             var termsUpdateService = CreateService();
@@ -69,8 +69,8 @@ namespace Covid19Radar.UnitTests.Services
         {
             var info = new TermsUpdateInfoModel
             {
-                TermsOfService = new TermsUpdateInfoModel.Detail { UpdateDateTime = new DateTime(2020, 11, 2) },
-                PrivacyPolicy = new TermsUpdateInfoModel.Detail { UpdateDateTime = new DateTime(2020, 11, 2) }
+                TermsOfService = new TermsUpdateInfoModel.Detail { UpdateDateTimeJst = new DateTime(2020, 11, 2) },
+                PrivacyPolicy = new TermsUpdateInfoModel.Detail { UpdateDateTimeJst = new DateTime(2020, 11, 2) }
             };
 
             var termsUpdateService = CreateService();
@@ -87,8 +87,8 @@ namespace Covid19Radar.UnitTests.Services
         {
             var info = new TermsUpdateInfoModel
             {
-                TermsOfService = new TermsUpdateInfoModel.Detail { UpdateDateTime = new DateTime(2020, 11, 2) },
-                PrivacyPolicy = new TermsUpdateInfoModel.Detail { UpdateDateTime = new DateTime(2020, 11, 2) }
+                TermsOfService = new TermsUpdateInfoModel.Detail { UpdateDateTimeJst = new DateTime(2020, 11, 2) },
+                PrivacyPolicy = new TermsUpdateInfoModel.Detail { UpdateDateTimeJst = new DateTime(2020, 11, 2) }
             };
 
             var termsUpdateService = CreateService();

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ReAgreePrivacyPolicyPageViewModelTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ReAgreePrivacyPolicyPageViewModelTests.cs
@@ -51,7 +51,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
         public void InitializeTests()
         {
             var reAgreePrivacyPolicyPageViewModel = CreateViewModel();
-            var updateInfo = new TermsUpdateInfoModel.Detail { Text = "test", UpdateDateTime = new DateTime(2020, 11, 02) };
+            var updateInfo = new TermsUpdateInfoModel.Detail { Text = "test", UpdateDateTimeJst = new DateTime(2020, 11, 02) };
             var param = new NavigationParameters
             {
                 { "updatePrivacyPolicyInfo", updateInfo }
@@ -67,7 +67,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
             var reAgreePrivacyPolicyPageViewModel = CreateViewModel();
             var param = new NavigationParameters
             {
-                { "updatePrivacyPolicyInfo", new TermsUpdateInfoModel.Detail { Text = "", UpdateDateTime = DateTime.Now } }
+                { "updatePrivacyPolicyInfo", new TermsUpdateInfoModel.Detail { Text = "", UpdateDateTimeJst = DateTime.Now } }
             };
             reAgreePrivacyPolicyPageViewModel.Initialize(param);
 
@@ -93,14 +93,14 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
         public void OnClickReAgreeCommandTests()
         {
             var reAgreePrivacyPolicyPageViewModel = CreateViewModel();
-            var updateInfo = new TermsUpdateInfoModel.Detail { Text = "", UpdateDateTime = DateTime.Now };
+            var updateInfo = new TermsUpdateInfoModel.Detail { Text = "", UpdateDateTimeJst = DateTime.Now };
             var param = new NavigationParameters
             {
                 { "updatePrivacyPolicyInfo", updateInfo }
             };
             reAgreePrivacyPolicyPageViewModel.Initialize(param);
 
-            mockUserDataRepository.Setup(x => x.SaveLastUpdateDate(TermsType.PrivacyPolicy, updateInfo.UpdateDateTime));
+            mockUserDataRepository.Setup(x => x.SaveLastUpdateDate(TermsType.PrivacyPolicy, updateInfo.UpdateDateTimeUtc));
             reAgreePrivacyPolicyPageViewModel.OnClickReAgreeCommand.Execute(null);
 
             mockNavigationService.Verify(x => x.NavigateAsync("/" + nameof(MenuPage) + "/" + nameof(NavigationPage) + "/" + nameof(HomePage)), Times.Once());

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ReAgreeTermsOfServicePageViewModelTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ReAgreeTermsOfServicePageViewModelTests.cs
@@ -53,8 +53,8 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
             var reAgreeTermsOfServicePageViewModel = CreateViewModel();
             var updateInfo = new TermsUpdateInfoModel
             {
-                TermsOfService = new TermsUpdateInfoModel.Detail { Text = "利用規約テキスト", UpdateDateTime = new DateTime(2020, 11, 01) },
-                PrivacyPolicy = new TermsUpdateInfoModel.Detail { Text = "プライバシーポリシーテキスト", UpdateDateTime = new DateTime(2020, 11, 02) }
+                TermsOfService = new TermsUpdateInfoModel.Detail { Text = "利用規約テキスト", UpdateDateTimeJst = new DateTime(2020, 11, 01) },
+                PrivacyPolicy = new TermsUpdateInfoModel.Detail { Text = "プライバシーポリシーテキスト", UpdateDateTimeJst = new DateTime(2020, 11, 02) }
             };
             var param = new NavigationParameters
             {
@@ -71,8 +71,8 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
             var reAgreeTermsOfServicePageViewModel = CreateViewModel();
             var updateInfo = new TermsUpdateInfoModel
             {
-                TermsOfService = new TermsUpdateInfoModel.Detail { Text = "利用規約テキスト", UpdateDateTime = new DateTime(2020, 11, 01) },
-                PrivacyPolicy = new TermsUpdateInfoModel.Detail { Text = "プライバシーポリシーテキスト", UpdateDateTime = new DateTime(2020, 11, 02) }
+                TermsOfService = new TermsUpdateInfoModel.Detail { Text = "利用規約テキスト", UpdateDateTimeJst = new DateTime(2020, 11, 01) },
+                PrivacyPolicy = new TermsUpdateInfoModel.Detail { Text = "プライバシーポリシーテキスト", UpdateDateTimeJst = new DateTime(2020, 11, 02) }
             };
             var param = new NavigationParameters
             {
@@ -104,8 +104,8 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
             var reAgreeTermsOfServicePageViewModel = CreateViewModel();
             var updateInfo = new TermsUpdateInfoModel
             {
-                TermsOfService = new TermsUpdateInfoModel.Detail { Text = "利用規約テキスト", UpdateDateTime = new DateTime(2020, 11, 01) },
-                PrivacyPolicy = new TermsUpdateInfoModel.Detail { Text = "プライバシーポリシーテキスト", UpdateDateTime = new DateTime(2020, 11, 02) }
+                TermsOfService = new TermsUpdateInfoModel.Detail { Text = "利用規約テキスト", UpdateDateTimeJst = new DateTime(2020, 11, 01) },
+                PrivacyPolicy = new TermsUpdateInfoModel.Detail { Text = "プライバシーポリシーテキスト", UpdateDateTimeJst = new DateTime(2020, 11, 02) }
             };
             var param = new NavigationParameters
             {
@@ -113,7 +113,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
             };
             reAgreeTermsOfServicePageViewModel.Initialize(param);
 
-            mockUserDataRepository.Setup(x => x.SaveLastUpdateDate(TermsType.TermsOfService, updateInfo.TermsOfService.UpdateDateTime));
+            mockUserDataRepository.Setup(x => x.SaveLastUpdateDate(TermsType.TermsOfService, updateInfo.TermsOfService.UpdateDateTimeUtc));
             mockTermsUpdateService.Setup(x => x.IsUpdated(TermsType.PrivacyPolicy, updateInfo)).Returns(true);
             reAgreeTermsOfServicePageViewModel.OnClickReAgreeCommand.Execute(null);
 
@@ -130,8 +130,8 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
             var reAgreeTermsOfServicePageViewModel = CreateViewModel();
             var updateInfo = new TermsUpdateInfoModel
             {
-                TermsOfService = new TermsUpdateInfoModel.Detail { Text = "利用規約テキスト", UpdateDateTime = new DateTime(2020, 11, 01) },
-                PrivacyPolicy = new TermsUpdateInfoModel.Detail { Text = "プライバシーポリシーテキスト", UpdateDateTime = new DateTime(2020, 11, 02) }
+                TermsOfService = new TermsUpdateInfoModel.Detail { Text = "利用規約テキスト", UpdateDateTimeJst = new DateTime(2020, 11, 01) },
+                PrivacyPolicy = new TermsUpdateInfoModel.Detail { Text = "プライバシーポリシーテキスト", UpdateDateTimeJst = new DateTime(2020, 11, 02) }
             };
             var param = new NavigationParameters
             {
@@ -139,7 +139,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
             };
             reAgreeTermsOfServicePageViewModel.Initialize(param);
 
-            mockUserDataRepository.Setup(x => x.SaveLastUpdateDate(TermsType.TermsOfService, updateInfo.TermsOfService.UpdateDateTime));
+            mockUserDataRepository.Setup(x => x.SaveLastUpdateDate(TermsType.TermsOfService, updateInfo.TermsOfService.UpdateDateTimeUtc));
             mockTermsUpdateService.Setup(x => x.IsUpdated(TermsType.PrivacyPolicy, updateInfo)).Returns(false);
             reAgreeTermsOfServicePageViewModel.OnClickReAgreeCommand.Execute(null);
 


### PR DESCRIPTION
Updated terms of service(or privacy policy) dateTime, that based on Japan Standard Time (UTC+9).

## Issue 番号 / Issue ID

- Close #441

## 目的 / Purpose

- プライバシーポリシーの同意画面が何度も表示される不具合を修正した。

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[x] Yes
[ ] No
```

## Pull Request の種類 / Pull Request type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

 - `TermsUpdateInfoModel`の日付（`update_date`）はJSTとして取り扱う。
 - 内部的にはすべてUTCとして取り扱う。

## その他 / Other information
