### PR TITLE
Continue after reagree

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/MainActivity.cs
+++ b/Covid19Radar/Covid19Radar.Android/MainActivity.cs
@@ -99,12 +99,19 @@ namespace Covid19Radar.Droid
 
         private async Task NavigateToDestinationFromIntent(Intent intent)
         {
+            _loggerService.Value.StartMethod();
+
+
             if (intent.Data != null)
             {
+                _loggerService.Value.Info("Intent has data.");
+
                 var processingNumber = intent.Data.GetQueryParameter(AppConstants.LinkQueryKeyProcessingNumber);
 
                 if (processingNumber != null && Validator.IsValidProcessingNumber(processingNumber))
                 {
+                    _loggerService.Value.Info("ProcessingNumber is valid.");
+
                     var navigationParameters = new NavigationParameters();
                     navigationParameters = NotifyOtherPage.BuildNavigationParams(processingNumber, navigationParameters);
                     await AppInstance?.NavigateToSplashAsync(Destination.NotifyOtherPage, navigationParameters);
@@ -112,6 +119,7 @@ namespace Covid19Radar.Droid
                 else
                 {
                     _loggerService.Value.Error("Failed to navigate NotifyOtherPage with invalid processingNumber");
+                    await AppInstance?.NavigateToSplashAsync(Destination.HomePage, new NavigationParameters());
                 }
             }
             else if (intent.HasExtra(EXTRA_KEY_DESTINATION))
@@ -119,9 +127,17 @@ namespace Covid19Radar.Droid
                 int ordinal = intent.GetIntExtra(EXTRA_KEY_DESTINATION, (int)Destination.HomePage);
                 var destination = (Destination)Enum.ToObject(typeof(Destination), ordinal);
 
+                _loggerService.Value.Info($"Intent has destination: {destination}");
+
                 var navigationParameters = new NavigationParameters();
                 await AppInstance?.NavigateToSplashAsync(destination, navigationParameters);
             }
+            else
+            {
+                await AppInstance?.NavigateToSplashAsync(Destination.HomePage, new NavigationParameters());
+            }
+
+            _loggerService.Value.EndMethod();
         }
 
         protected override void OnActivityResult(int requestCode, Result resultCode, Intent data)

--- a/Covid19Radar/Covid19Radar/App.xaml.cs
+++ b/Covid19Radar/Covid19Radar/App.xaml.cs
@@ -44,7 +44,7 @@ namespace Covid19Radar
 
         public App(IPlatformInitializer initializer) : base(initializer, setFormsDependencyResolver: false) { }
 
-        protected override async void OnInitialized()
+        protected override void OnInitialized()
         {
             InitializeComponent();
 
@@ -55,27 +55,13 @@ namespace Covid19Radar
 
             LogUnobservedTaskExceptions();
 
-            var navigationParameters = new NavigationParameters();
-            var result = await NavigateToSplashAsync(Destination.HomePage, navigationParameters);
-            if (!result.Success)
-            {
-                LoggerService.Info($"Failed transition.");
-
-                MainPage = new ExceptionPage
-                {
-                    BindingContext = new ExceptionPageViewModel()
-                    {
-                        Message = result.Exception.Message
-                    }
-                };
-                System.Diagnostics.Debugger.Break();
-            }
-
             LoggerService.EndMethod();
         }
 
         public async Task<INavigationResult> NavigateToSplashAsync(Destination destination, NavigationParameters navigationParameters)
         {
+            LoggerService.Info($"Destination: {destination}");
+
             navigationParameters = SplashPage.BuildNavigationParams(destination, navigationParameters);
             return await NavigationService.NavigateAsync(Destination.SplashPage.ToPath(), navigationParameters);
         }

--- a/Covid19Radar/Covid19Radar/Destination.cs
+++ b/Covid19Radar/Covid19Radar/Destination.cs
@@ -15,14 +15,14 @@ namespace Covid19Radar
         NotifyOtherPage,
     }
 
-    internal static class DestinationExtensions
+    public static class DestinationExtensions
     {
         private static string SplashPagePath = "/" + nameof(SplashPage);
         private static string HomePagePath => "/" + nameof(MenuPage) + "/" + nameof(NavigationPage) + "/" + nameof(HomePage);
         private static string ContactedNotifyPagePath => HomePagePath + "/" + nameof(ContactedNotifyPage);
         private static string NotifyOtherPagePath => HomePagePath + "/" + nameof(NotifyOtherPage);
 
-        internal static string ToPath(this Destination destination)
+        public static string ToPath(this Destination destination)
         {
             return destination switch
             {

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/ReAgreePrivacyPolicyPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/ReAgreePrivacyPolicyPageViewModel.cs
@@ -29,6 +29,8 @@ namespace Covid19Radar.ViewModels
             set { SetProperty(ref _updateText, value); }
         }
 
+        private INavigationParameters _navigationParameters;
+
         public Func<string, BrowserLaunchMode, Task> BrowserOpenAsync = Browser.OpenAsync;
 
         public ReAgreePrivacyPolicyPageViewModel(
@@ -58,7 +60,9 @@ namespace Covid19Radar.ViewModels
             _loggerService.StartMethod();
 
             _userDataRepository.SaveLastUpdateDate(TermsType.PrivacyPolicy, UpdateDateTimeUtc);
-            _ = await NavigationService.NavigateAsync("/" + nameof(MenuPage) + "/" + nameof(NavigationPage) + "/" + nameof(HomePage));
+
+            Destination destination = _navigationParameters.GetValue<Destination>(SplashPage.DestinationKey);
+            _ = await NavigationService.NavigateAsync(destination.ToPath(), _navigationParameters);
 
             _loggerService.EndMethod();
         });
@@ -71,6 +75,8 @@ namespace Covid19Radar.ViewModels
             TermsUpdateInfoModel.Detail updateInfo = (TermsUpdateInfoModel.Detail) parameters["updatePrivacyPolicyInfo"];
             UpdateDateTimeUtc = updateInfo.UpdateDateTimeUtc;
             UpdateText = updateInfo.Text;
+
+            _navigationParameters = parameters;
 
             _loggerService.EndMethod();
         }

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/ReAgreePrivacyPolicyPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/ReAgreePrivacyPolicyPageViewModel.cs
@@ -61,7 +61,11 @@ namespace Covid19Radar.ViewModels
 
             _userDataRepository.SaveLastUpdateDate(TermsType.PrivacyPolicy, UpdateDateTimeUtc);
 
-            Destination destination = _navigationParameters.GetValue<Destination>(SplashPage.DestinationKey);
+            Destination destination = Destination.HomePage;
+            if (_navigationParameters.ContainsKey(SplashPage.DestinationKey))
+            {
+                destination = _navigationParameters.GetValue<Destination>(SplashPage.DestinationKey);
+            }
             _ = await NavigationService.NavigateAsync(destination.ToPath(), _navigationParameters);
 
             _loggerService.EndMethod();

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/ReAgreeTermsOfServicePageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/ReAgreeTermsOfServicePageViewModel.cs
@@ -30,6 +30,8 @@ namespace Covid19Radar.ViewModels
             set { SetProperty(ref _updateText, value); }
         }
 
+        private INavigationParameters _navigationParameters;
+
         public Func<string, BrowserLaunchMode, Task> BrowserOpenAsync = Browser.OpenAsync;
 
         public ReAgreeTermsOfServicePageViewModel(
@@ -61,15 +63,13 @@ namespace Covid19Radar.ViewModels
             _userDataRepository.SaveLastUpdateDate(TermsType.TermsOfService, UpdateDateTimeUtc);
             if (_termsUpdateService.IsUpdated(TermsType.PrivacyPolicy, UpdateInfo))
             {
-                var param = new NavigationParameters
-                {
-                    { "updatePrivacyPolicyInfo", UpdateInfo.PrivacyPolicy }
-                };
-                _ = await NavigationService.NavigateAsync(nameof(ReAgreePrivacyPolicyPage), param);
+                _navigationParameters.Add("updatePrivacyPolicyInfo", UpdateInfo.PrivacyPolicy);
+                _ = await NavigationService.NavigateAsync(nameof(ReAgreePrivacyPolicyPage), _navigationParameters);
             }
             else
             {
-                _ = await NavigationService.NavigateAsync("/" + nameof(MenuPage) + "/" + nameof(NavigationPage) + "/" + nameof(HomePage));
+                Destination destination = _navigationParameters.GetValue<Destination>(SplashPage.DestinationKey);
+                _ = await NavigationService.NavigateAsync(destination.ToPath(), _navigationParameters);
             }
 
             _loggerService.EndMethod();
@@ -83,6 +83,8 @@ namespace Covid19Radar.ViewModels
             UpdateInfo = (TermsUpdateInfoModel) parameters["updateInfo"];
             UpdateDateTimeUtc = UpdateInfo.TermsOfService.UpdateDateTimeUtc;
             UpdateText = UpdateInfo.TermsOfService.Text;
+
+            _navigationParameters = parameters;
 
             _loggerService.EndMethod();
         }

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/ReAgreeTermsOfServicePageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/ReAgreeTermsOfServicePageViewModel.cs
@@ -68,7 +68,11 @@ namespace Covid19Radar.ViewModels
             }
             else
             {
-                Destination destination = _navigationParameters.GetValue<Destination>(SplashPage.DestinationKey);
+                Destination destination = Destination.HomePage;
+                if (_navigationParameters.ContainsKey(SplashPage.DestinationKey))
+                {
+                    destination = _navigationParameters.GetValue<Destination>(SplashPage.DestinationKey);
+                }
                 _ = await NavigationService.NavigateAsync(destination.ToPath(), _navigationParameters);
             }
 

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/SplashPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/SplashPageViewModel.cs
@@ -52,21 +52,15 @@ namespace Covid19Radar.ViewModels
 
                 if (_termsUpdateService.IsUpdated(TermsType.TermsOfService, termsUpdateInfo))
                 {
-                    var param = new NavigationParameters
-                {
-                    { "updateInfo", termsUpdateInfo }
-                };
+                    parameters.Add("updateInfo", termsUpdateInfo);
                     _loggerService.Info($"Transition to ReAgreeTermsOfServicePage");
-                    _ = await NavigationService.NavigateAsync(nameof(ReAgreeTermsOfServicePage), param);
+                    _ = await NavigationService.NavigateAsync(nameof(ReAgreeTermsOfServicePage), parameters);
                 }
                 else if (_termsUpdateService.IsUpdated(TermsType.PrivacyPolicy, termsUpdateInfo))
                 {
-                    var param = new NavigationParameters
-                {
-                    { "updatePrivacyPolicyInfo", termsUpdateInfo.PrivacyPolicy }
-                };
+                    parameters.Add("updatePrivacyPolicyInfo", termsUpdateInfo.PrivacyPolicy);
                     _loggerService.Info($"Transition to ReAgreePrivacyPolicyPage");
-                    _ = await NavigationService.NavigateAsync(nameof(ReAgreePrivacyPolicyPage), param);
+                    _ = await NavigationService.NavigateAsync(nameof(ReAgreePrivacyPolicyPage), parameters);
                 }
                 else if (parameters.GetValue<Destination>(SplashPage.DestinationKey) == Destination.ContactedNotifyPage)
                 {

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ReAgreePrivacyPolicyPageViewModelTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ReAgreePrivacyPolicyPageViewModelTests.cs
@@ -103,7 +103,25 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
             mockUserDataRepository.Setup(x => x.SaveLastUpdateDate(TermsType.PrivacyPolicy, updateInfo.UpdateDateTimeUtc));
             reAgreePrivacyPolicyPageViewModel.OnClickReAgreeCommand.Execute(null);
 
-            mockNavigationService.Verify(x => x.NavigateAsync("/" + nameof(MenuPage) + "/" + nameof(NavigationPage) + "/" + nameof(HomePage)), Times.Once());
+            mockNavigationService.Verify(x => x.NavigateAsync(Destination.HomePage.ToPath(), param), Times.Once());
+        }
+
+        [Fact]
+        public void OnClickReAgreeCommandWithDestinationTest()
+        {
+            var reAgreePrivacyPolicyPageViewModel = CreateViewModel();
+            var updateInfo = new TermsUpdateInfoModel.Detail { Text = "", UpdateDateTimeJst = DateTime.Now };
+            var param = new NavigationParameters
+            {
+                { "destination", Destination.ContactedNotifyPage },
+                { "updatePrivacyPolicyInfo", updateInfo }
+            };
+            reAgreePrivacyPolicyPageViewModel.Initialize(param);
+
+            mockUserDataRepository.Setup(x => x.SaveLastUpdateDate(TermsType.PrivacyPolicy, updateInfo.UpdateDateTimeUtc));
+            reAgreePrivacyPolicyPageViewModel.OnClickReAgreeCommand.Execute(null);
+
+            mockNavigationService.Verify(x => x.NavigateAsync(Destination.ContactedNotifyPage.ToPath(), param), Times.Once());
         }
     }
 }

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ReAgreeTermsOfServicePageViewModelTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ReAgreeTermsOfServicePageViewModelTests.cs
@@ -117,11 +117,8 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
             mockTermsUpdateService.Setup(x => x.IsUpdated(TermsType.PrivacyPolicy, updateInfo)).Returns(true);
             reAgreeTermsOfServicePageViewModel.OnClickReAgreeCommand.Execute(null);
 
-            var resultParam = new NavigationParameters
-            {
-                {"updatePrivacyPolicyInfo", updateInfo.PrivacyPolicy }
-            };
-            mockNavigationService.Verify(x => x.NavigateAsync(nameof(ReAgreePrivacyPolicyPage), resultParam), Times.Once());
+            param.Add("updatePrivacyPolicyInfo", updateInfo.PrivacyPolicy);
+            mockNavigationService.Verify(x => x.NavigateAsync(nameof(ReAgreePrivacyPolicyPage), param), Times.Once());
         }
 
         [Fact]
@@ -143,7 +140,30 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
             mockTermsUpdateService.Setup(x => x.IsUpdated(TermsType.PrivacyPolicy, updateInfo)).Returns(false);
             reAgreeTermsOfServicePageViewModel.OnClickReAgreeCommand.Execute(null);
 
-            mockNavigationService.Verify(x => x.NavigateAsync("/" + nameof(MenuPage) + "/" + nameof(NavigationPage) + "/" + nameof(HomePage)), Times.Once());
+            mockNavigationService.Verify(x => x.NavigateAsync(Destination.HomePage.ToPath(), param), Times.Once());
+        }
+
+        [Fact]
+        public void OnClickReAgreeCommandWithDestinationTest()
+        {
+            var reAgreeTermsOfServicePageViewModel = CreateViewModel();
+            var updateInfo = new TermsUpdateInfoModel
+            {
+                TermsOfService = new TermsUpdateInfoModel.Detail { Text = "利用規約テキスト", UpdateDateTimeJst = new DateTime(2020, 11, 01) },
+                PrivacyPolicy = new TermsUpdateInfoModel.Detail { Text = "プライバシーポリシーテキスト", UpdateDateTimeJst = new DateTime(2020, 11, 02) }
+            };
+            var param = new NavigationParameters
+            {
+                { "destination", Destination.NotifyOtherPage },
+                { "updateInfo", updateInfo }
+            };
+            reAgreeTermsOfServicePageViewModel.Initialize(param);
+
+            mockUserDataRepository.Setup(x => x.SaveLastUpdateDate(TermsType.TermsOfService, updateInfo.TermsOfService.UpdateDateTimeUtc));
+            mockTermsUpdateService.Setup(x => x.IsUpdated(TermsType.PrivacyPolicy, updateInfo)).Returns(false);
+            reAgreeTermsOfServicePageViewModel.OnClickReAgreeCommand.Execute(null);
+
+            mockNavigationService.Verify(x => x.NavigateAsync(Destination.NotifyOtherPage.ToPath(), param), Times.Once());
         }
     }
 }


### PR DESCRIPTION
## Issue 番号 / Issue ID

- Close #466
- Close #465

## 目的 / Purpose

- AppLinks/ローカル通知からCOCOAを起動するケースで目的の画面に遷移しない場合がある不具合を修正する。

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

<!--
  当てはまるもの 1 つに「x」とマークしてください。
  Mark one with an "x".
-->

```
[x] Yes
[ ] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

- AppLinksからCOCOAを開いた場合、必ず陽性情報登録画面を表示する
- ローカル通知からCOCOAを開いた場合、必ず接触一覧画面を表示する
- AppLinksからCOCOAを開いた場合、利用規約・プライバシーポリシーの再同意画面を経ても、必ず陽性情報登録画面を表示する
- ローカル通知からCOCOAを開いた場合、利用規約・プライバシーポリシーの再同意画面を経ても、必ず接触一覧画面を表示する

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
