### PR TITLE
Prevent unexpected page transition when home icon was tapped.

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/MainActivity.cs
+++ b/Covid19Radar/Covid19Radar.Android/MainActivity.cs
@@ -135,7 +135,10 @@ namespace Covid19Radar.Droid
         {
             base.OnNewIntent(intent);
 
-            await NavigateToDestinationFromIntent(intent);
+            if (intent.Data != null)
+            {
+                await NavigateToDestinationFromIntent(intent);
+            }
         }
 
     }


### PR DESCRIPTION
## Issue 番号 / Issue ID

- Close #477

## 目的 / Purpose

- アプリを起動後、ホーム画面のアイコンをタップしたときに予期せぬ画面遷移をする可能性がある懸念の解消

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

AppLinksかどうかは`Intent.Data`がnullかそうでないかで判定している。

## 確認事項 / What to check

- AppLinksタップ時に `OnNewIntent` -> `NavigateToDestinationFromIntent`が実行されること
- アプリを起動後、バックグラウンドに遷移して、ホーム画面のアイコンをタップしたときに、`OnNewIntent`から`NavigateToDestinationFromIntent`が **実行されないこと**

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
