### PR TITLE
機能が重複しているメソッドの整理

### DIFF
--- a/Covid19Radar/Covid19Radar/Common/PreferenceKey.cs
+++ b/Covid19Radar/Covid19Radar/Common/PreferenceKey.cs
@@ -18,6 +18,9 @@ namespace Covid19Radar.Common
         public static string CanConfirmExposure = "CanConfirmExposure";
         public static string LastConfirmedDateTimeEpoch = "LastConfirmedDateTimeEpoch";
 
+        public const string DAILY_SUMMARIES = "daily_summaries";
+        public const string EXPOSURE_WINDOWS = "exposure_windows";
+
         // for secure storage
         public static string ExposureInformation = "ExposureInformation";
     }

--- a/Covid19Radar/Covid19Radar/Common/PreferenceKey.cs
+++ b/Covid19Radar/Covid19Radar/Common/PreferenceKey.cs
@@ -18,8 +18,8 @@ namespace Covid19Radar.Common
         public static string CanConfirmExposure = "CanConfirmExposure";
         public static string LastConfirmedDateTimeEpoch = "LastConfirmedDateTimeEpoch";
 
-        public const string DAILY_SUMMARIES = "daily_summaries";
-        public const string EXPOSURE_WINDOWS = "exposure_windows";
+        public const string DailySummaries = "DailySummaries";
+        public const string ExposureWindows = "ExposureWindows";
 
         // for secure storage
         public static string ExposureInformation = "ExposureInformation";

--- a/Covid19Radar/Covid19Radar/Repository/UserDataRepository.cs
+++ b/Covid19Radar/Covid19Radar/Repository/UserDataRepository.cs
@@ -31,10 +31,6 @@ namespace Covid19Radar.Repository
 
         void RemoveAllUpdateDate();
 
-        long GetLastProcessTekTimestamp(string region);
-        void SetLastProcessTekTimestamp(string region, long created);
-        void RemoveLastProcessTekTimestamp();
-
         void SetCanConfirmExposure(bool canConfirmExposure);
         bool IsCanConfirmExposure();
 
@@ -85,11 +81,6 @@ namespace Covid19Radar.Repository
 
     public class UserDataRepository : IUserDataRepository
     {
-        private const string KEY_LAST_PROCESS_DIAGNOSIS_KEY_TIMESTAMP = "last_process_diagnosis_key_timestamp";
-
-        private const string KEY_DAILY_SUMMARIES = "daily_summaries";
-        private const string KEY_EXPOSURE_WINDOWS = "exposure_windows";
-
         private const string EMPTY_LIST_JSON = "[]";
 
         private readonly IPreferencesService _preferencesService;
@@ -112,7 +103,7 @@ namespace Covid19Radar.Repository
             {
                 var result = 0L;
 
-                var jsonString = _preferencesService.GetValue<string>(KEY_LAST_PROCESS_DIAGNOSIS_KEY_TIMESTAMP, null);
+                var jsonString = _preferencesService.GetValue<string>(PreferenceKey.LastProcessTekTimestamp, null);
                 if (!string.IsNullOrEmpty(jsonString))
                 {
                     var dict = JsonConvert.DeserializeObject<Dictionary<string, long>>(jsonString);
@@ -136,7 +127,7 @@ namespace Covid19Radar.Repository
 
             try
             {
-                var jsonString = _preferencesService.GetValue<string>(KEY_LAST_PROCESS_DIAGNOSIS_KEY_TIMESTAMP, null);
+                var jsonString = _preferencesService.GetValue<string>(PreferenceKey.LastProcessTekTimestamp, null);
 
                 Dictionary<string, long> newDict;
                 if (!string.IsNullOrEmpty(jsonString))
@@ -148,7 +139,7 @@ namespace Covid19Radar.Repository
                     newDict = new Dictionary<string, long>();
                 }
                 newDict[region] = timestamp;
-                _preferencesService.SetValue(KEY_LAST_PROCESS_DIAGNOSIS_KEY_TIMESTAMP, JsonConvert.SerializeObject(newDict));
+                _preferencesService.SetValue(PreferenceKey.LastProcessTekTimestamp, JsonConvert.SerializeObject(newDict));
 
                 return Task.CompletedTask;
             }
@@ -164,7 +155,7 @@ namespace Covid19Radar.Repository
 
             try
             {
-                _preferencesService.RemoveValue(KEY_LAST_PROCESS_DIAGNOSIS_KEY_TIMESTAMP);
+                _preferencesService.RemoveValue(PreferenceKey.LastProcessTekTimestamp);
                 return Task.CompletedTask;
             }
             finally
@@ -266,8 +257,8 @@ namespace Covid19Radar.Repository
 
             try
             {
-                _preferencesService.SetValue(KEY_DAILY_SUMMARIES, dailySummaryListJson);
-                _preferencesService.SetValue(KEY_EXPOSURE_WINDOWS, exposureWindowListJson);
+                _preferencesService.SetValue(PreferenceKey.DAILY_SUMMARIES, dailySummaryListJson);
+                _preferencesService.SetValue(PreferenceKey.EXPOSURE_WINDOWS, exposureWindowListJson);
                 return Task.CompletedTask;
             }
             finally
@@ -282,7 +273,7 @@ namespace Covid19Radar.Repository
 
             try
             {
-                string dailySummariesJson = _preferencesService.GetValue(KEY_DAILY_SUMMARIES, EMPTY_LIST_JSON);
+                string dailySummariesJson = _preferencesService.GetValue(PreferenceKey.DAILY_SUMMARIES, EMPTY_LIST_JSON);
                 return Task.FromResult(
                     JsonConvert.DeserializeObject<List<DailySummary>>(dailySummariesJson)
                 );
@@ -306,7 +297,7 @@ namespace Covid19Radar.Repository
 
             try
             {
-                string exposureWindowListJson = _preferencesService.GetValue(KEY_EXPOSURE_WINDOWS, EMPTY_LIST_JSON);
+                string exposureWindowListJson = _preferencesService.GetValue(PreferenceKey.EXPOSURE_WINDOWS, EMPTY_LIST_JSON);
                 return Task.FromResult(
                     JsonConvert.DeserializeObject<List<ExposureWindow>>(exposureWindowListJson)
                 );
@@ -330,7 +321,7 @@ namespace Covid19Radar.Repository
 
             try
             {
-                _preferencesService.RemoveValue(KEY_DAILY_SUMMARIES);
+                _preferencesService.RemoveValue(PreferenceKey.DAILY_SUMMARIES);
                 return Task.CompletedTask;
             }
             finally
@@ -345,7 +336,7 @@ namespace Covid19Radar.Repository
 
             try
             {
-                _preferencesService.RemoveValue(KEY_EXPOSURE_WINDOWS);
+                _preferencesService.RemoveValue(PreferenceKey.EXPOSURE_WINDOWS);
                 return Task.CompletedTask;
             }
             finally
@@ -431,48 +422,6 @@ namespace Covid19Radar.Repository
             _loggerService.StartMethod();
             _preferencesService.RemoveValue(PreferenceKey.TermsOfServiceLastUpdateDateTimeEpoch);
             _preferencesService.RemoveValue(PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch);
-            _loggerService.EndMethod();
-        }
-
-        public long GetLastProcessTekTimestamp(string region)
-        {
-            _loggerService.StartMethod();
-            var result = 0L;
-            var jsonString = _preferencesService.GetValue<string>(PreferenceKey.LastProcessTekTimestamp, null);
-            if (!string.IsNullOrEmpty(jsonString))
-            {
-                var dict = JsonConvert.DeserializeObject<Dictionary<string, long>>(jsonString);
-                if (dict.ContainsKey(region))
-                {
-                    result = dict[region];
-                }
-            }
-            _loggerService.EndMethod();
-            return result;
-        }
-
-        public void SetLastProcessTekTimestamp(string region, long created)
-        {
-            _loggerService.StartMethod();
-            var jsonString = _preferencesService.GetValue<string>(PreferenceKey.LastProcessTekTimestamp, null);
-            Dictionary<string, long> newDict;
-            if (!string.IsNullOrEmpty(jsonString))
-            {
-                newDict = JsonConvert.DeserializeObject<Dictionary<string, long>>(jsonString);
-            }
-            else
-            {
-                newDict = new Dictionary<string, long>();
-            }
-            newDict[region] = created;
-            _preferencesService.SetValue(PreferenceKey.LastProcessTekTimestamp, JsonConvert.SerializeObject(newDict));
-            _loggerService.EndMethod();
-        }
-
-        public void RemoveLastProcessTekTimestamp()
-        {
-            _loggerService.StartMethod();
-            _preferencesService.RemoveValue(PreferenceKey.LastProcessTekTimestamp);
             _loggerService.EndMethod();
         }
 

--- a/Covid19Radar/Covid19Radar/Repository/UserDataRepository.cs
+++ b/Covid19Radar/Covid19Radar/Repository/UserDataRepository.cs
@@ -257,8 +257,8 @@ namespace Covid19Radar.Repository
 
             try
             {
-                _preferencesService.SetValue(PreferenceKey.DAILY_SUMMARIES, dailySummaryListJson);
-                _preferencesService.SetValue(PreferenceKey.EXPOSURE_WINDOWS, exposureWindowListJson);
+                _preferencesService.SetValue(PreferenceKey.DailySummaries, dailySummaryListJson);
+                _preferencesService.SetValue(PreferenceKey.ExposureWindows, exposureWindowListJson);
                 return Task.CompletedTask;
             }
             finally
@@ -273,7 +273,7 @@ namespace Covid19Radar.Repository
 
             try
             {
-                string dailySummariesJson = _preferencesService.GetValue(PreferenceKey.DAILY_SUMMARIES, EMPTY_LIST_JSON);
+                string dailySummariesJson = _preferencesService.GetValue(PreferenceKey.DailySummaries, EMPTY_LIST_JSON);
                 return Task.FromResult(
                     JsonConvert.DeserializeObject<List<DailySummary>>(dailySummariesJson)
                 );
@@ -297,7 +297,7 @@ namespace Covid19Radar.Repository
 
             try
             {
-                string exposureWindowListJson = _preferencesService.GetValue(PreferenceKey.EXPOSURE_WINDOWS, EMPTY_LIST_JSON);
+                string exposureWindowListJson = _preferencesService.GetValue(PreferenceKey.ExposureWindows, EMPTY_LIST_JSON);
                 return Task.FromResult(
                     JsonConvert.DeserializeObject<List<ExposureWindow>>(exposureWindowListJson)
                 );
@@ -321,7 +321,7 @@ namespace Covid19Radar.Repository
 
             try
             {
-                _preferencesService.RemoveValue(PreferenceKey.DAILY_SUMMARIES);
+                _preferencesService.RemoveValue(PreferenceKey.DailySummaries);
                 return Task.CompletedTask;
             }
             finally
@@ -336,7 +336,7 @@ namespace Covid19Radar.Repository
 
             try
             {
-                _preferencesService.RemoveValue(PreferenceKey.EXPOSURE_WINDOWS);
+                _preferencesService.RemoveValue(PreferenceKey.ExposureWindows);
                 return Task.CompletedTask;
             }
             finally

--- a/Covid19Radar/Covid19Radar/ViewModels/Settings/SettingsPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/Settings/SettingsPageViewModel.cs
@@ -77,7 +77,7 @@ namespace Covid19Radar.ViewModels
                 exposureConfigurationRepository.RemoveExposureConfiguration();
 
                 userDataRepository.RemoveStartDate();
-                userDataRepository.RemoveLastProcessTekTimestamp();
+                await userDataRepository.RemoveLastProcessDiagnosisKeyTimestampAsync();
                 userDataRepository.RemoveAllUpdateDate();
                 userDataRepository.RemoveAllExposureNotificationStatus();
 

--- a/Covid19Radar/Covid19Radar/ViewModels/Settings/SettingsPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/Settings/SettingsPageViewModel.cs
@@ -77,7 +77,6 @@ namespace Covid19Radar.ViewModels
                 exposureConfigurationRepository.RemoveExposureConfiguration();
 
                 userDataRepository.RemoveStartDate();
-                await userDataRepository.RemoveLastProcessDiagnosisKeyTimestampAsync();
                 userDataRepository.RemoveAllUpdateDate();
                 userDataRepository.RemoveAllExposureNotificationStatus();
 


### PR DESCRIPTION
## Issue 番号 / Issue ID

- #300

## 目的 / Purpose

- 接触確認をした診断キーの最終タイムスタンプの保存が`LastProcessTekTimestamp`と`LastProcessDiagnosisKeyTimestamp`で重複していたので整理する（`LastProcessTekTimestamp`を消す）。

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

<!--
  当てはまるもの 1 つに「x」とマークしてください。
  Mark one with an "x".
-->

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

-

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
