### PR TITLE
Fix unexpected page transition on android

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/Services/ExposureNotificationApiService.cs
+++ b/Covid19Radar/Covid19Radar.Android/Services/ExposureNotificationApiService.cs
@@ -31,17 +31,22 @@ namespace Covid19Radar.Droid.Services
 
         public override async Task StartAsync()
         {
+            await Client.StartAsync();
+        }
+
+        public override async Task<bool> StartExposureNotificationAsync()
+        {
             try
             {
-                await Client.StartAsync();
+                await StartAsync();
+                return true;
             }
             catch (ApiException apiException)
             {
                 if (apiException.StatusCode == CommonStatusCodes.ResolutionRequired)
                 {
                     apiException.Status.StartResolutionForResult(Platform.CurrentActivity, REQUEST_EN_START);
-                    throw new ENException(ENException.Code_Android.FAILED_UNAUTHORIZED,
-                        "StartAsync StartResolutionForResult");
+                    return false;
                 }
                 else
                 {

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
@@ -117,8 +117,11 @@ namespace Covid19Radar.ViewModels
 
             try
             {
-                _ = await exposureNotificationApiService.StartExposureNotificationAsync();
-                await UpdateView();
+                var success = await exposureNotificationApiService.StartExposureNotificationAsync();
+                if (success)
+                {
+                    await UpdateView();
+                }
 
             }
             catch (ENException exception)

--- a/Covid19Radar/Covid19Radar/ViewModels/Tutorial/TutorialPage4ViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/Tutorial/TutorialPage4ViewModel.cs
@@ -32,8 +32,11 @@ namespace Covid19Radar.ViewModels
 
             try
             {
-                await exposureNotificationApiService.StartExposureNotificationAsync();
-                await NavigationService.NavigateAsync(nameof(TutorialPage6));
+                var success = await exposureNotificationApiService.StartExposureNotificationAsync();
+                if (success)
+                {
+                    await NavigationService.NavigateAsync(nameof(TutorialPage6));
+                }
             }
             catch (ENException exception)
             {


### PR DESCRIPTION
## Issue 番号 / Issue ID

- #300

## 目的 / Purpose

- Android版でチュートリアルページの接触確認APIを有効にする際、ダイアログが出た瞬間に次のページに進んでいる不具合を修正する

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

<!--
  当てはまるもの 1 つに「x」とマークしてください。
  Mark one with an "x".
-->

```
[x] Yes
[ ] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

- Androidで問題が直っているかより、iOS版で問題なく動くかの確認をお願いします

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
