### PR TITLE
Make V3Diagnosis-api idempotent.

### DIFF
--- a/src/Covid19Radar.Api/V3DiagnosisApi.cs
+++ b/src/Covid19Radar.Api/V3DiagnosisApi.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using System.Web.Http;
 using Covid19Radar.Api.DataAccess;
@@ -110,11 +111,13 @@ namespace Covid19Radar.Api
             }
 
             var timestamp = (ulong)DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-            var keys = submissionParameter.Keys.Select(key => key.ToModel(submissionParameter, timestamp));
-
-            foreach (var k in keys)
+            using (SHA256 sha256 = SHA256.Create())
             {
-                await _tekRepository.UpsertAsync(k);
+                var keys = submissionParameter.Keys.Select(key => key.ToModel(submissionParameter, timestamp, sha256));
+                foreach (var k in keys)
+                {
+                    await _tekRepository.UpsertAsync(k);
+                }
             }
 
             return new OkObjectResult(JsonConvert.SerializeObject(submissionParameter));


### PR DESCRIPTION
## Issue 番号 / Issue ID

~~#495 に依存した変更です。~~ 独立させました！

- #300
- Close #412

## 目的 / Purpose

- PUTの結果を冪等にするため、クライアントから送信されたIdempotencyKeyを使ってPartitionKeyを設定する

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

- クライアントが送信した`IdempotencyKey`は直接保存しない
- "IdempotencyKey,TEK.KeyData, RollingStartNumber, RollingPeriod"を文字列として連結した上でSHA256のハッシュ値を取ったものをPartitionKeyとする
- PartitionKeyからidempotencyKeyの再計算は非常に困難
- 将来的に変更（Revoke）などの処理にはクライアントから登録に使ったIdempotencyKeyをつけることでPartitionKeyが再計算できる（更新できる）
- HKDF使う？
    - 今回の目的だと必要なさそう（一意なKeyとして使っているけど暗号鍵が欲しいわけではない）

### これはやるとしての別のIssue, 別のPull Requestで
- 一度の陽性情報登録で追加されるキーをまとめて取り扱い、サーバー側で生成した`SubmissionId`のようなものをつける？
    - 一度の陽性情報登録でどの程度のTEKが登録されるかなど統計値の算出にはあるとうれしい
    - 利用者プライバシー的に大丈夫？
        - 配布する診断キーには含めないが、サーバーが保有しているだけで問題となる可能性はある【要確認】

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
