### PR TITLE
Fix an issue that migration failed when DateTime is DateTime.MinValue.

### DIFF
--- a/COPYRIGHT_THIRD_PARTY_SOFTWARE_NOTICES.md
+++ b/COPYRIGHT_THIRD_PARTY_SOFTWARE_NOTICES.md
@@ -375,6 +375,40 @@ A "contributor" is any person that distributes its contribution under this licen
 (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement.
 
 ---
+## TimeZoneConverter
+---
+
+Copyright (c) 2017 Matt Johnson-Pint
+https://github.com/mattjohnsonpint/TimeZoneConverter
+
+While we certainly hope this software is useful, none of the authors or
+contributors place any guarantees as to the accuracy of the data or the
+results returned by using this library.
+
+This library is distributed under the terms of the MIT License:
+
+-----------------------------------------------------------------------------
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-----------------------------------------------------------------------------
+
+---
 ## Google.Protobuf
 ---
 

--- a/Covid19Radar/Covid19Radar.Android/Assets/license.html
+++ b/Covid19Radar/Covid19Radar.Android/Assets/license.html
@@ -1280,6 +1280,28 @@ same meaning here as under U.S. copyright law.</li>
 <p>(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement.</p>
 <hr>
 <h2>
+<a id="user-content-timezoneconverter" class="anchor" href="#timezoneconverter" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>TimeZoneConverter</h2>
+<hr>
+<p>The MIT License (MIT)</p>
+<p>Copyright (c) 2017 Matt Johnson-Pint</p>
+<p>https://github.com/mattjohnsonpint/TimeZoneConverter</p>
+<p>Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:</p>
+<p>The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.</p>
+<p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</p>
+<hr>
+<h2>
 <a id="user-content-googleprotobuf" class="anchor" href="#googleprotobuf" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Google.Protobuf</h2>
 <hr>
 <p>Copyright 2008 Google Inc.  All rights reserved.</p>

--- a/Covid19Radar/Covid19Radar.iOS/Resources/license.html
+++ b/Covid19Radar/Covid19Radar.iOS/Resources/license.html
@@ -1280,6 +1280,28 @@ same meaning here as under U.S. copyright law.</li>
 <p>(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement.</p>
 <hr>
 <h2>
+<a id="user-content-timezoneconverter" class="anchor" href="#timezoneconverter" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>TimeZoneConverter</h2>
+<hr>
+<p>The MIT License (MIT)</p>
+<p>Copyright (c) 2017 Matt Johnson-Pint</p>
+<p>https://github.com/mattjohnsonpint/TimeZoneConverter</p>
+<p>Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:</p>
+<p>The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.</p>
+<p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</p>
+<hr>
+<h2>
 <a id="user-content-googleprotobuf" class="anchor" href="#googleprotobuf" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Google.Protobuf</h2>
 <hr>
 <p>Copyright 2008 Google Inc.  All rights reserved.</p>

--- a/Covid19Radar/Covid19Radar/Common/AppConstants.cs
+++ b/Covid19Radar/Covid19Radar/Common/AppConstants.cs
@@ -2,10 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+using System;
+
 namespace Covid19Radar.Common
 {
     public static class AppConstants
     {
+        /// <summary>
+        /// COCOA's birthday.
+        /// </summary>
+        public static readonly DateTime COCOA_FIRST_RELEASE_DATE
+            = DateTime.SpecifyKind(new DateTime(2020, 06, 19, 9, 0, 0), DateTimeKind.Utc);
+
         /// <summary>
         /// Number of days covered from the date of diagnosis or onset
         /// </summary>

--- a/Covid19Radar/Covid19Radar/Covid19Radar.csproj
+++ b/Covid19Radar/Covid19Radar/Covid19Radar.csproj
@@ -68,6 +68,7 @@
     <PackageReference Include="Xamarin.Forms.Visual.Material" Version="4.6.0.967" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
     <PackageReference Include="CommonServiceLocator" Version="2.0.6" />
+    <PackageReference Include="TimeZoneConverter" Version="3.5.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Controls\CustomDatePicker.cs" />

--- a/Covid19Radar/Covid19Radar/Model/TermsUpdateInfoModel.cs
+++ b/Covid19Radar/Covid19Radar/Model/TermsUpdateInfoModel.cs
@@ -4,6 +4,7 @@
 
 using System;
 using Newtonsoft.Json;
+using TimeZoneConverter;
 
 namespace Covid19Radar.Model
 {
@@ -17,7 +18,7 @@ namespace Covid19Radar.Model
 
         public class Detail
         {
-            private readonly TimeSpan TIME_DIFFERENCIAL_JST_UTC = TimeSpan.FromHours(+9);
+            private readonly TimeZoneInfo TIMEZONE_JST = TZConvert.GetTimeZoneInfo("ASIA/Tokyo");
 
             [JsonProperty("text")]
             public string Text { get; set; }
@@ -29,7 +30,10 @@ namespace Covid19Radar.Model
             public DateTime UpdateDateTimeJst { get; set; }
 
             public DateTime UpdateDateTimeUtc
-                => DateTime.SpecifyKind(UpdateDateTimeJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
+                => TimeZoneInfo.ConvertTimeToUtc(
+                        DateTime.SpecifyKind(UpdateDateTimeJst, DateTimeKind.Unspecified),
+                        TIMEZONE_JST
+                        );
         }
     }
 }

--- a/Covid19Radar/Covid19Radar/Services/Migration/Migrator_1_3_0.cs
+++ b/Covid19Radar/Covid19Radar/Services/Migration/Migrator_1_3_0.cs
@@ -16,7 +16,7 @@ namespace Covid19Radar.Services.Migration
         private const string TERMS_OF_SERVICE_LAST_UPDATE_DATETIME = "TermsOfServiceLastUpdateDateTime";
         private const string PRIVACY_POLICY_LAST_UPDATE_DATETIME = "PrivacyPolicyLastUpdateDateTime";
 
-        private readonly DateTime COCOA_RELEASE_DATE
+        private readonly DateTime COCOA_FIRST_RELEASE_DATE
             = DateTime.SpecifyKind(new DateTime(2021, 06, 19, 9, 0, 0), DateTimeKind.Utc);
 
         private readonly TimeZoneInfo TIMEZONE_JST = TZConvert.GetTimeZoneInfo("ASIA/Tokyo");
@@ -49,7 +49,7 @@ namespace Covid19Radar.Services.Migration
                     TERMS_OF_SERVICE_LAST_UPDATE_DATETIME,
                     PreferenceKey.TermsOfServiceLastUpdateDateTimeEpoch,
                     timeZoneInfo: TIMEZONE_JST,
-                    fallbackDateTime: COCOA_RELEASE_DATE
+                    fallbackDateTime: COCOA_FIRST_RELEASE_DATE
                     );
             }
 
@@ -59,26 +59,26 @@ namespace Covid19Radar.Services.Migration
                     PRIVACY_POLICY_LAST_UPDATE_DATETIME,
                     PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch,
                     timeZoneInfo: TIMEZONE_JST,
-                    fallbackDateTime: COCOA_RELEASE_DATE
+                    fallbackDateTime: COCOA_FIRST_RELEASE_DATE
                     );
             }
 
             return Task.CompletedTask;
         }
 
-        public void MigrateDateTimeToEpoch(string dateTimeKey, string epochKey, TimeZoneInfo? timeZoneInfo, DateTime fallbackDateTime)
+        private void MigrateDateTimeToEpoch(string dateTimeKey, string epochKey, TimeZoneInfo? timeZoneInfo, DateTime fallbackDateTime)
         {
             string dateTimeStr = _preferencesService.GetValue(dateTimeKey, DateTime.UtcNow.ToString());
-            
+
             DateTime dateTime;
             try
             {
                 dateTime = DateTime.Parse(dateTimeStr);
 
                 // dateTime must be after COCOA_RELEASE_DATE.
-                if (dateTime < COCOA_RELEASE_DATE)
+                if (dateTime < COCOA_FIRST_RELEASE_DATE)
                 {
-                    dateTime = COCOA_RELEASE_DATE;
+                    dateTime = COCOA_FIRST_RELEASE_DATE;
                 }
 
                 if (timeZoneInfo is null)

--- a/Covid19Radar/Covid19Radar/Services/Migration/Migrator_1_3_0.cs
+++ b/Covid19Radar/Covid19Radar/Services/Migration/Migrator_1_3_0.cs
@@ -16,9 +16,6 @@ namespace Covid19Radar.Services.Migration
         private const string TERMS_OF_SERVICE_LAST_UPDATE_DATETIME = "TermsOfServiceLastUpdateDateTime";
         private const string PRIVACY_POLICY_LAST_UPDATE_DATETIME = "PrivacyPolicyLastUpdateDateTime";
 
-        private readonly DateTime COCOA_FIRST_RELEASE_DATE
-            = DateTime.SpecifyKind(new DateTime(2021, 06, 19, 9, 0, 0), DateTimeKind.Utc);
-
         private readonly TimeZoneInfo TIMEZONE_JST = TZConvert.GetTimeZoneInfo("ASIA/Tokyo");
 
         private readonly IPreferencesService _preferencesService;
@@ -49,7 +46,7 @@ namespace Covid19Radar.Services.Migration
                     TERMS_OF_SERVICE_LAST_UPDATE_DATETIME,
                     PreferenceKey.TermsOfServiceLastUpdateDateTimeEpoch,
                     timeZoneInfo: TIMEZONE_JST,
-                    fallbackDateTime: COCOA_FIRST_RELEASE_DATE
+                    fallbackDateTime: AppConstants.COCOA_FIRST_RELEASE_DATE
                     );
             }
 
@@ -59,7 +56,7 @@ namespace Covid19Radar.Services.Migration
                     PRIVACY_POLICY_LAST_UPDATE_DATETIME,
                     PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch,
                     timeZoneInfo: TIMEZONE_JST,
-                    fallbackDateTime: COCOA_FIRST_RELEASE_DATE
+                    fallbackDateTime: AppConstants.COCOA_FIRST_RELEASE_DATE
                     );
             }
 
@@ -75,10 +72,10 @@ namespace Covid19Radar.Services.Migration
             {
                 dateTime = DateTime.Parse(dateTimeStr);
 
-                // dateTime must be after COCOA_RELEASE_DATE.
-                if (dateTime < COCOA_FIRST_RELEASE_DATE)
+                // dateTime must be after COCOA_FIRST_RELEASE_DATE.
+                if (dateTime < AppConstants.COCOA_FIRST_RELEASE_DATE)
                 {
-                    dateTime = COCOA_FIRST_RELEASE_DATE;
+                    dateTime = AppConstants.COCOA_FIRST_RELEASE_DATE;
                 }
 
                 if (timeZoneInfo is null)

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
@@ -13,6 +13,7 @@ using Covid19Radar.Services.Logs;
 using Covid19Radar.Services.Migration;
 using Moq;
 using Newtonsoft.Json;
+using TimeZoneConverter;
 using Xunit;
 
 namespace Covid19Radar.UnitTests.Services.Migration
@@ -27,16 +28,12 @@ namespace Covid19Radar.UnitTests.Services.Migration
         private const string PREFERENCE_KEY_TERMS_OF_SERVICE_LAST_UPDATE_DATE = "TermsOfServiceLastUpdateDateTime";
         private const string PREFERENCE_KEY_PRIVACY_POLICY_LAST_UPDATE_DATE = "PrivacyPolicyLastUpdateDateTime";
 
-        private static readonly TimeSpan TIME_DIFFERENCIAL_JST_UTC = TimeSpan.FromHours(+9);
-        private static DateTime JstNow => DateTime.UtcNow + TIME_DIFFERENCIAL_JST_UTC;
+        private readonly TimeZoneInfo TIMEZONE_JST = TZConvert.GetTimeZoneInfo("ASIA/Tokyo");
 
-        private static DateTime JstToUtc(DateTime dateTimeJst)
-            => DateTime.SpecifyKind(dateTimeJst - TIME_DIFFERENCIAL_JST_UTC, DateTimeKind.Utc);
+        private DateTime JstNow => TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, TIMEZONE_JST);
 
-        private const string FORMAT_TERMS_UPDATE_DATETIME = "yyyy/MM/dd HH:mm:ss";
-
-        private static DateTime CreateTermsUpdateDateTime(DateTime dateTime)
-            => DateTime.ParseExact(dateTime.ToString(FORMAT_TERMS_UPDATE_DATETIME), FORMAT_TERMS_UPDATE_DATETIME, null);
+        private DateTime JstToUtc(DateTime dateTimeJst)
+            => TimeZoneInfo.ConvertTimeToUtc(DateTime.SpecifyKind(dateTimeJst, DateTimeKind.Unspecified));
 
         private readonly MockRepository _mockRepository = new MockRepository(MockBehavior.Default);
 
@@ -907,12 +904,12 @@ namespace Covid19Radar.UnitTests.Services.Migration
 
             // TermsOfServiceLastUpdateDateTime
             var termsOfServiceLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.TermsOfServiceLastUpdateDateTimeEpoch, 0L);
-            var termsOfServiceLastUpdateDateUtc = JstToUtc(DateTime.MinValue);
+            var termsOfServiceLastUpdateDateUtc = JstToUtc(AppConstants.COCOA_FIRST_RELEASE_DATE);
             Assert.Equal(termsOfServiceLastUpdateDateUtc.ToUnixEpoch(), termsOfServiceLastUpdateDateTimePref);
 
             // PrivacyPolicyLastUpdateDateTime
             var privacyPolicyLastUpdateDateTimePref = _dummyPreferencesService.GetValue(PreferenceKey.PrivacyPolicyLastUpdateDateTimeEpoch, 0L);
-            var privacyPolicyLastUpdateDateUtc = JstToUtc(DateTime.MinValue);
+            var privacyPolicyLastUpdateDateUtc = JstToUtc(AppConstants.COCOA_FIRST_RELEASE_DATE);
             Assert.Equal(privacyPolicyLastUpdateDateUtc.ToUnixEpoch(), privacyPolicyLastUpdateDateTimePref);
 
             // LastProcessTekTimestamp

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/Migration/MigrationServiceTests.cs
@@ -33,7 +33,7 @@ namespace Covid19Radar.UnitTests.Services.Migration
         private DateTime JstNow => TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, TIMEZONE_JST);
 
         private DateTime JstToUtc(DateTime dateTimeJst)
-            => TimeZoneInfo.ConvertTimeToUtc(DateTime.SpecifyKind(dateTimeJst, DateTimeKind.Unspecified));
+            => TimeZoneInfo.ConvertTimeToUtc(DateTime.SpecifyKind(dateTimeJst, DateTimeKind.Unspecified), TIMEZONE_JST);
 
         private readonly MockRepository _mockRepository = new MockRepository(MockBehavior.Default);
 


### PR DESCRIPTION
## Issue 番号 / Issue ID

- #520
- #523

## 目的 / Purpose

- タイムゾーンが指定されていない文字列をJSTとして取り扱った上でUTCに変換する中で、変換対照がDateTime.MinValueと同値（e.g. `0001/01/01 00:00:00`）であった場合に例外が発生してアプリが強制終了する不具合を修正する

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

<!--
  当てはまるもの 1 つに「x」とマークしてください。
  Mark one with an "x".
-->

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

既存の処理との互換性は`MigrationServiceTests`の中でカバーしている。
DateTimeがMinValueだったときのテストは  #524 で追加する。

## 確認事項 / What to check

- 使用開始日、規約への合意日ともにCOCOAのリリース日以前ではあり得ないので、それ以前であれば最小値としてリリース日に置き換える
- タイムゾーン処理は`TimeZoneInfo.ConvertTimeToUtc`で行う
- TimeZoneを取得するための名前がプラットフォームで異なるのは、TimeZoneConverterライブラリに任せる（テストが不要になったわけではない）

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
