### PR TITLE
Fix an issue that ScrollView truncates items when using StackLayout.

### DIFF
--- a/Covid19Radar/Covid19Radar/Views/HelpPage/HelpPage1.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HelpPage/HelpPage1.xaml
@@ -17,6 +17,11 @@
     NavigationPage.HasNavigationBar="True"
     Style="{StaticResource DefaultPageStyle}"
     Visual="Material">
+    <!--
+        Workaround for fixing ScrollView truncates items issue.
+        https://github.com/xamarin/Xamarin.Forms/issues/13597
+    -->
+    <ContentView>
     <ScrollView>
         <Grid Style="{StaticResource HelpPageGridLayout}">
             <Grid.RowDefinitions>
@@ -67,4 +72,5 @@
             </StackLayout>
         </Grid>
     </ScrollView>
+    </ContentView>
 </ContentPage>

--- a/Covid19Radar/Covid19Radar/Views/HelpPage/HelpPage2.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HelpPage/HelpPage2.xaml
@@ -16,6 +16,11 @@
     prism:ViewModelLocator.AutowireViewModel="True"
     Style="{StaticResource DefaultPageStyle}"
     Visual="Material">
+    <!--
+        Workaround for fixing ScrollView truncates items issue.
+        https://github.com/xamarin/Xamarin.Forms/issues/13597
+    -->
+    <ContentView>
     <ScrollView>
         <Grid Style="{StaticResource HelpPageGridLayout}">
             <Grid.RowDefinitions>
@@ -81,4 +86,5 @@
             </StackLayout>
         </Grid>
     </ScrollView>
+    </ContentView>
 </ContentPage>

--- a/Covid19Radar/Covid19Radar/Views/HelpPage/HelpPage3.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HelpPage/HelpPage3.xaml
@@ -16,6 +16,11 @@
     prism:ViewModelLocator.AutowireViewModel="True"
     Style="{StaticResource DefaultPageStyle}"
     Visual="Material">
+    <!--
+        Workaround for fixing ScrollView truncates items issue.
+        https://github.com/xamarin/Xamarin.Forms/issues/13597
+    -->
+    <ContentView>
     <ScrollView>
         <Grid Style="{StaticResource HelpPageGridLayout}" Margin="20">
             <Grid.RowDefinitions>
@@ -148,4 +153,5 @@
             </Grid>
         </Grid>
     </ScrollView>
+    </ContentView>
 </ContentPage>

--- a/Covid19Radar/Covid19Radar/Views/HelpPage/HelpPage4.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HelpPage/HelpPage4.xaml
@@ -15,6 +15,11 @@
     prism:ViewModelLocator.AutowireViewModel="True"
     Style="{StaticResource DefaultPageStyle}"
     Visual="Material">
+    <!--
+        Workaround for fixing ScrollView truncates items issue.
+        https://github.com/xamarin/Xamarin.Forms/issues/13597
+    -->
+    <ContentView>
     <ScrollView>
         <Grid Style="{StaticResource HelpPageGridLayout}">
             <Grid.RowDefinitions>
@@ -38,4 +43,5 @@
             </Grid>
         </Grid>
     </ScrollView>
+    </ContentView>
 </ContentPage>

--- a/Covid19Radar/Covid19Radar/Views/HelpPage/InqueryPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HelpPage/InqueryPage.xaml
@@ -15,6 +15,11 @@
     prism:ViewModelLocator.AutowireViewModel="True"
     Style="{StaticResource DefaultPageStyle}"
     Visual="Material">
+    <!--
+        Workaround for fixing ScrollView truncates items issue.
+        https://github.com/xamarin/Xamarin.Forms/issues/13597
+    -->
+    <ContentView>
     <ScrollView>
         <StackLayout
             Padding="10"
@@ -69,4 +74,5 @@
             <BoxView Style="{StaticResource DefaultLineStyle}" />
         </StackLayout>
     </ScrollView>
+    </ContentView>
 </ContentPage>

--- a/Covid19Radar/Covid19Radar/Views/HelpPage/SendLogConfirmationPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HelpPage/SendLogConfirmationPage.xaml
@@ -13,7 +13,7 @@
     Style="{StaticResource DefaultPageStyle}"
     Title="{x:Static resources:AppResources.SendLogConfirmationPageTitle}"
     Visual="Material">
-    <ContentPage.Content>
+    <ContentView>
         <ScrollView
             Margin="0"
             Padding="0">
@@ -69,5 +69,5 @@
                 Text="{x:Static resources:AppResources.SendLogConfirmationPageButton1}" />
             </StackLayout>
         </ScrollView>
-    </ContentPage.Content>
+    </ContentView>
 </ContentPage>

--- a/Covid19Radar/Covid19Radar/Views/HomePage/ContactedNotifyPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/ContactedNotifyPage.xaml
@@ -16,6 +16,11 @@
     prism:ViewModelLocator.AutowireViewModel="True"
     Style="{StaticResource DefaultPageStyle}"
     Visual="Material">
+    <!--
+        Workaround for fixing ScrollView truncates items issue.
+        https://github.com/xamarin/Xamarin.Forms/issues/13597
+    -->
+    <ContentView>
     <ScrollView>
         <StackLayout
             Padding="10"
@@ -74,4 +79,5 @@
                 Text="{x:Static resources:AppResources.ContactedNotifyPageButton1}" />
         </StackLayout>
     </ScrollView>
+    </ContentView>
 </ContentPage>

--- a/Covid19Radar/Covid19Radar/Views/HomePage/HomePage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/HomePage.xaml
@@ -25,6 +25,11 @@
             Text="{x:Static resources:AppResources.MainTutorial}" />
     </ContentPage.ToolbarItems>
 
+    <!--
+        Workaround for fixing ScrollView truncates items issue.
+        https://github.com/xamarin/Xamarin.Forms/issues/13597
+    -->
+    <ContentView>
     <ScrollView>
         <StackLayout
             Padding="15"
@@ -224,4 +229,5 @@
             </StackLayout>
         </StackLayout>
     </ScrollView>
+    </ContentView>
 </ContentPage>

--- a/Covid19Radar/Covid19Radar/Views/HomePage/HowToReceiveProcessingNumberPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/HowToReceiveProcessingNumberPage.xaml
@@ -16,6 +16,11 @@
     prism:ViewModelLocator.AutowireViewModel="True"
     Style="{StaticResource DefaultPageStyle}"
     Visual="Material">
+    <!--
+        Workaround for fixing ScrollView truncates items issue.
+        https://github.com/xamarin/Xamarin.Forms/issues/13597
+    -->
+    <ContentView>
     <ScrollView>
         <StackLayout
             Spacing="16"
@@ -90,4 +95,5 @@
             </Label>
         </StackLayout>
     </ScrollView>
+    </ContentView>
 </ContentPage>

--- a/Covid19Radar/Covid19Radar/Views/HomePage/NotContactPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/NotContactPage.xaml
@@ -16,6 +16,11 @@
     prism:ViewModelLocator.AutowireViewModel="True"
     Style="{StaticResource DefaultPageStyle}"
     Visual="Material">
+    <!--
+        Workaround for fixing ScrollView truncates items issue.
+        https://github.com/xamarin/Xamarin.Forms/issues/13597
+    -->
+    <ContentView>
     <ScrollView>
         <Grid Style="{StaticResource DefaultGridLayout}">
             <Grid.RowDefinitions>
@@ -61,4 +66,5 @@
             </Grid>
         </Grid>
     </ScrollView>
+    </ContentView>
 </ContentPage>

--- a/Covid19Radar/Covid19Radar/Views/HomePage/NotifyOtherPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/NotifyOtherPage.xaml
@@ -17,6 +17,11 @@
     prism:ViewModelLocator.AutowireViewModel="True"
     Style="{StaticResource DefaultPageStyle}"
     Visual="Material">
+    <!--
+        Workaround for fixing ScrollView truncates items issue.
+        https://github.com/xamarin/Xamarin.Forms/issues/13597
+    -->
+    <ContentView>
     <ScrollView>
         <StackLayout
             Padding="15,15,15,20">
@@ -51,13 +56,12 @@
                 <Label AutomationProperties.IsInAccessibleTree="{Binding IsVisibleWithSymptomsLayout}"
                         Style="{StaticResource DefaultLabel}"
                         Text="{x:Static resources:AppResources.NotifyOtherPageWithSymptomsDescription1}" />
-                <StackLayout Spacing="0"
-                                Margin="0, 5, 0, 10">
                     <Frame Padding="0"
                             BackgroundColor="#CECECE"
                             CornerRadius="7"
                             HasShadow="False"
-                            HorizontalOptions="FillAndExpand">
+                            HorizontalOptions="FillAndExpand"
+                            Margin="0, 5, 0, 10">
                         <Frame Margin="3"
                                 Padding="0"
                                 BackgroundColor="White"
@@ -71,19 +75,17 @@
                         </Frame>
                     </Frame>
                 </StackLayout>
-            </StackLayout>
             <StackLayout Margin="0, 15, 0, 0"
                             IsVisible="{Binding IsVisibleNoSymptomsLayout}">
                 <Label AutomationProperties.IsInAccessibleTree="{Binding IsVisibleNoSymptomsLayout}"
                         Style="{StaticResource DefaultLabel}"
                         Text="{x:Static resources:AppResources.NotifyOtherPageNoSymptomsDescription1}" />
-                <StackLayout Spacing="0"
-                                Margin="0, 5, 0, 10">
                     <Frame Padding="0"
                             BackgroundColor="#CECECE"
                             CornerRadius="7"
                             HasShadow="False"
-                            HorizontalOptions="FillAndExpand">
+                            HorizontalOptions="FillAndExpand"
+                            Margin="0, 5, 0, 10">
                         <Frame Margin="3"
                                 Padding="0"
                                 BackgroundColor="White"
@@ -96,7 +98,6 @@
                                                         Date="{Binding DiagnosisDate}"/>
                         </Frame>
                     </Frame>
-                </StackLayout>
             </StackLayout>
             <Label
                 AutomationProperties.IsInAccessibleTree="True"
@@ -241,4 +242,5 @@
             </Frame>
         </StackLayout>
     </ScrollView>
+    </ContentView>
 </ContentPage>

--- a/Covid19Radar/Covid19Radar/Views/HomePage/SubmitConsentPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/SubmitConsentPage.xaml
@@ -24,6 +24,11 @@
         </DataTrigger>
     </ContentPage.Triggers>
 
+    <!--
+        Workaround for fixing ScrollView truncates items issue.
+        https://github.com/xamarin/Xamarin.Forms/issues/13597
+    -->
+    <ContentView>
     <ScrollView>
         <Grid Style="{StaticResource DefaultGridLayout}">
             <Grid.RowDefinitions>
@@ -130,4 +135,5 @@
             </Grid>
         </Grid>
     </ScrollView>
+    </ContentView>
 </ContentPage>

--- a/Covid19Radar/Covid19Radar/Views/HomePage/ThankYouNotifyOtherPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/ThankYouNotifyOtherPage.xaml
@@ -16,6 +16,11 @@
     prism:ViewModelLocator.AutowireViewModel="True"
     Style="{StaticResource DefaultPageStyle}"
     Visual="Material">
+    <!--
+        Workaround for fixing ScrollView truncates items issue.
+        https://github.com/xamarin/Xamarin.Forms/issues/13597
+    -->
+    <ContentView>
     <ScrollView>
         <Grid Style="{StaticResource DefaultGridLayout}">
             <Grid.RowDefinitions>
@@ -51,4 +56,5 @@
             </Grid>
         </Grid>
     </ScrollView>
+    </ContentView>
 </ContentPage>

--- a/Covid19Radar/Covid19Radar/Views/HomePage/TroubleshootingPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/TroubleshootingPage.xaml
@@ -16,6 +16,11 @@
     prism:ViewModelLocator.AutowireViewModel="True"
     Style="{StaticResource DefaultPageStyle}"
     Visual="Material">
+    <!--
+        Workaround for fixing ScrollView truncates items issue.
+        https://github.com/xamarin/Xamarin.Forms/issues/13597
+    -->
+    <ContentView>
     <ScrollView>
         <StackLayout
             Padding="20"
@@ -55,5 +60,6 @@
                 AutomationProperties.IsInAccessibleTree="True" />
         </StackLayout>
     </ScrollView>
+    </ContentView>
 </ContentPage>
 

--- a/Covid19Radar/Covid19Radar/Views/Settings/DebugPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Settings/DebugPage.xaml
@@ -15,6 +15,11 @@
     prism:ViewModelLocator.AutowireViewModel="True"
     Style="{StaticResource DefaultPageStyle}"
     Visual="Material">
+    <!--
+        Workaround for fixing ScrollView truncates items issue.
+        https://github.com/xamarin/Xamarin.Forms/issues/13597
+    -->
+    <ContentView>
     <ScrollView>
         <StackLayout
             Padding="15"
@@ -227,4 +232,5 @@
             </Frame>
         </StackLayout>
     </ScrollView>
+    </ContentView>
 </ContentPage>

--- a/Covid19Radar/Covid19Radar/Views/Settings/EditServerConfigurationPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Settings/EditServerConfigurationPage.xaml
@@ -16,6 +16,11 @@
     prism:ViewModelLocator.AutowireViewModel="True"
     Style="{StaticResource DefaultPageStyle}"
     Visual="Material">
+    <!--
+        Workaround for fixing ScrollView truncates items issue.
+        https://github.com/xamarin/Xamarin.Forms/issues/13597
+    -->
+    <ContentView>
     <ScrollView>
         <StackLayout
             Padding="0"
@@ -145,4 +150,5 @@
                 VerticalOptions="Start" />
         </StackLayout>
     </ScrollView>
+    </ContentView>
 </ContentPage>

--- a/Covid19Radar/Covid19Radar/Views/Settings/SettingsPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Settings/SettingsPage.xaml
@@ -16,6 +16,11 @@
     prism:ViewModelLocator.AutowireViewModel="True"
     Style="{StaticResource DefaultPageStyle}"
     Visual="Material">
+    <!--
+        Workaround for fixing ScrollView truncates items issue.
+        https://github.com/xamarin/Xamarin.Forms/issues/13597
+    -->
+    <ContentView>
     <ScrollView>
         <StackLayout
             Padding="0"
@@ -108,4 +113,5 @@
             </Frame>
         </StackLayout>
     </ScrollView>
+    </ContentView>
 </ContentPage>

--- a/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage6.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Tutorial/TutorialPage6.xaml
@@ -16,6 +16,11 @@
     prism:ViewModelLocator.AutowireViewModel="True"
     Style="{StaticResource DefaultPageStyle}"
     Visual="Material">
+    <!--
+        Workaround for fixing ScrollView truncates items issue.
+        https://github.com/xamarin/Xamarin.Forms/issues/13597
+    -->
+    <ContentView>
     <ScrollView>
         <Grid Margin="20" Style="{StaticResource DefaultGridLayout}">
             <Grid.RowDefinitions>
@@ -69,4 +74,5 @@
             </StackLayout>
         </Grid>
     </ScrollView>
+    </ContentView>
 </ContentPage>


### PR DESCRIPTION
レビュー用の #573 に向けたPull Request。

## Issue 番号 / Issue ID

- #574 

## 目的 / Purpose

- Xamarin.Forms 5系の不具合。画面が見きれるIssueの修正

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

- ScrollViewの上位にContentViewを置くのはあくまでワークアラウンド（ https://github.com/xamarin/Xamarin.Forms/issues/13597 ）
    - 恒久的な解決策ではないため、インデントは変えていない（元に戻すときの差分を最小限にするため）。

## その他 / Other information

