### PR TITLE
HomePageViewModel内のEN関連のテストを追加

### DIFF
--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/HomePageViewModelTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/HomePageViewModelTests.cs
@@ -80,6 +80,14 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
                 );
         }
 
+        private DailySummary CreateDailySummaryWithDayOffset(DateTime date, int dayOffset)
+        {
+            return new DailySummary()
+            {
+                DateMillisSinceEpoch = date.AddDays(dayOffset).ToUnixEpoch() * 1000 // seconds -> milliseconds
+            };
+        }
+
         [Fact]
         public void Initialize_CheckExposureNotificationSettings()
         {
@@ -353,23 +361,14 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
         [InlineData(-12)]
         [InlineData(-13)]
         [InlineData(-14)]
-        public void OnClickExposuresTest_NavigateContactedNotifyPage(int offset)
+        public void OnClickExposuresTest_NavigateContactedNotifyPage(int dayOffset)
         {
             var utcNow = DateTime.UtcNow;
             var dailySummaries = new List<DailySummary>()
             {
-                new DailySummary()
-                {
-                    DateMillisSinceEpoch = utcNow.AddDays(-30).ToUnixEpoch() * 1000 // Seconds -> milliseconds
-                },
-                new DailySummary()
-                {
-                    DateMillisSinceEpoch = utcNow.AddDays(-20).ToUnixEpoch() * 1000 // Seconds -> milliseconds
-                },
-                new DailySummary()
-                {
-                    DateMillisSinceEpoch = utcNow.AddDays(offset).ToUnixEpoch() * 1000 // Seconds -> milliseconds
-                }
+                CreateDailySummaryWithDayOffset(utcNow, -30),
+                CreateDailySummaryWithDayOffset(utcNow, -20),
+                CreateDailySummaryWithDayOffset(utcNow, dayOffset)
             };
 
             var serializeDailySummaries = JsonConvert.SerializeObject(dailySummaries);
@@ -395,23 +394,14 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
         [InlineData(-17)]
         [InlineData(-18)]
         [InlineData(-19)]
-        public void OnClickExposuresTest_NavigateNotContactPage(int offset)
+        public void OnClickExposuresTest_NavigateNotContactPage(int dayOffset)
         {
             var utcNow = DateTime.UtcNow;
             var dailySummaries = new List<DailySummary>()
             {
-                new DailySummary()
-                {
-                    DateMillisSinceEpoch = utcNow.AddDays(-30).ToUnixEpoch() * 1000 // Seconds -> milliseconds
-                },
-                new DailySummary()
-                {
-                    DateMillisSinceEpoch = utcNow.AddDays(-20).ToUnixEpoch() * 1000 // Seconds -> milliseconds
-                },
-                new DailySummary()
-                {
-                    DateMillisSinceEpoch = utcNow.AddDays(offset).ToUnixEpoch() * 1000 // Seconds -> milliseconds
-                }
+                CreateDailySummaryWithDayOffset(utcNow, -30),
+                CreateDailySummaryWithDayOffset(utcNow, -20),
+                CreateDailySummaryWithDayOffset(utcNow, dayOffset),
             };
 
             var serializeDailySummaries = JsonConvert.SerializeObject(dailySummaries);

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/HomePageViewModelTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/HomePageViewModelTests.cs
@@ -112,7 +112,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
                .Returns(Task.FromResult(new List<int>() as IList<int>));
 
             mockPreferenceService
-                .Setup(x => x.GetValue(PreferenceKey.CanConfirmExposure, true))
+                .Setup(x => x.GetValue("CanConfirmExposure", true))
                 .Returns(true);
 
             var homePageViewModel = CreateViewModel();
@@ -132,7 +132,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
                .Returns(Task.FromResult(new List<int>() as IList<int>));
 
             mockPreferenceService
-                .Setup(x => x.GetValue(PreferenceKey.CanConfirmExposure, true))
+                .Setup(x => x.GetValue("CanConfirmExposure", true))
                 .Returns(true);
 
             var homePageViewModel = CreateViewModel();
@@ -152,7 +152,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
                .Returns(Task.FromResult(new List<int>() as IList<int>));
 
             mockPreferenceService
-                .Setup(x => x.GetValue(PreferenceKey.CanConfirmExposure, true))
+                .Setup(x => x.GetValue("CanConfirmExposure", true))
                 .Returns(true);
 
             var homePageViewModel = CreateViewModel();
@@ -176,9 +176,12 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
             var homePageViewModel = CreateViewModel();
 
             mockExposureNotificationApiService
-                .Setup(x => x.GetStatusCodesAsync()).Returns(Task.FromResult(new List<int>() { status } as IList<int>));
+                .Setup(x => x.GetStatusCodesAsync())
+                .Returns(Task.FromResult(new List<int>() { status } as IList<int>));
 
-            mockPreferenceService.Setup(x => x.GetValue(PreferenceKey.CanConfirmExposure, true)).Returns(isCanConfirmExposure);
+            mockPreferenceService
+                .Setup(x => x.GetValue("CanConfirmExposure", true))
+                .Returns(isCanConfirmExposure);
 
             homePageViewModel.OnAppearing();
 
@@ -193,8 +196,11 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
             var homePageViewModel = CreateViewModel();
 
             mockExposureNotificationApiService
-                .Setup(x => x.GetStatusCodesAsync()).Returns(Task.FromResult(new List<int>() { ExposureNotificationStatus.Code_Android.ACTIVATED } as IList<int>));
-            mockPreferenceService.Setup(x => x.GetValue(PreferenceKey.CanConfirmExposure, true)).Returns(true);
+                .Setup(x => x.GetStatusCodesAsync())
+                .Returns(Task.FromResult(new List<int>() { ExposureNotificationStatus.Code_Android.ACTIVATED } as IList<int>));
+            mockPreferenceService
+                .Setup(x => x.GetValue("CanConfirmExposure", true))
+                .Returns(true);
 
             homePageViewModel.OnAppearing();
 
@@ -213,13 +219,13 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
             mockExposureNotificationApiService
                 .Setup(x => x.GetStatusCodesAsync()).Returns(Task.FromResult(new List<int>() { ExposureNotificationStatus.Code_Android.ACTIVATED } as IList<int>));
             mockPreferenceService
-                .Setup(x => x.ContainsKey(PreferenceKey.LastConfirmedDateTimeEpoch))
+                .Setup(x => x.ContainsKey("LastConfirmedDateTimeEpoch"))
                 .Returns(true);
             mockPreferenceService
-                .Setup(x => x.GetValue(PreferenceKey.LastConfirmedDateTimeEpoch, 0L))
+                .Setup(x => x.GetValue("LastConfirmedDateTimeEpoch", 0L))
                 .Returns(mockLastConfirmedUtcDateTime.ToUnixEpoch());
             mockPreferenceService
-                .Setup(x => x.GetValue(PreferenceKey.CanConfirmExposure, true))
+                .Setup(x => x.GetValue("CanConfirmExposure", true))
                 .Returns(true);
 
             homePageViewModel.OnAppearing();
@@ -378,7 +384,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
                 .Returns(utcNow);
 
             mockPreferenceService
-                .Setup(x => x.GetValue(PreferenceKey.DailySummaries, It.IsAny<string>()))
+                .Setup(x => x.GetValue("DailySummaries", It.IsAny<string>()))
                 .Returns(serializeDailySummaries);
 
             var homePageViewModel = CreateViewModel();
@@ -411,7 +417,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
                 .Returns(utcNow);
 
             mockPreferenceService
-                .Setup(x => x.GetValue(PreferenceKey.DailySummaries, It.IsAny<string>()))
+                .Setup(x => x.GetValue("DailySummaries", It.IsAny<string>()))
                 .Returns(serializeDailySummaries);
 
             var homePageViewModel = CreateViewModel();


### PR DESCRIPTION
## Issue 番号 / Issue ID

<!--
  Issue 番号なき PR は受け付けません。
  PRs without the issue IDs are never accepted.
-->

- Close #576 

## 目的 / Purpose

<!--
  その変更を提案する意図をご説明ください。どの問題が解決したり、機能的な追加がなされたりしますか。
  Describe the intention of the changes being proposed. What problem does it solve or functionality does it add?
-->

- HomePageViewModel内にはEN関連の処理が存在しますが、テストが実装されていないので追加しました

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

<!--
  当てはまるもの 1 つに「x」とマークしてください。
  Mark one with an "x".
-->

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: テストのみの変更
```

## 検証方法 / How to test
テスト実行:
```
dotnet test Covid19Radar.sln
```

また、テストのカバレッジ計測には↓のpluginを使用しています
https://github.com/ademanuele/VSMac-CodeCoverage

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

- 特に問題はないと思うので手をつけていないですが、現状の実装だとOnResume()やOnEnabled()で繰り返しUpdateView()が呼ばれるようになっているのが気になりました
- ViewModelから呼んでいるUserDataRepositoryのロジックは一緒にテストしたほうがいいと思ったので、Mockを使わず実体をDIして、大元のPreferenceServiceのデータ取得のところをMock化する形でまとめてテストしています。
- OnResumeなどもメソッド呼び出しだけですが、EN API関連のものなので一応テストを書いています。

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
