### PR TITLE
ClearText generating logic that App and Server must be equal.

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/Services/DeviceCheckService.cs
+++ b/Covid19Radar/Covid19Radar.Android/Services/DeviceCheckService.cs
@@ -8,10 +8,8 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using Android.Gms.SafetyNet;
-using Covid19Radar.Droid.Services;
 using Covid19Radar.Model;
 using Covid19Radar.Services;
-using Xamarin.Forms;
 
 namespace Covid19Radar.Droid.Services
 {
@@ -47,7 +45,7 @@ namespace Covid19Radar.Droid.Services
                 string.Join(",", keys.OrderBy(k => k.KeyData).Select(k => GetKeyStringCore(k)));
 
             static string GetKeyStringCore(DiagnosisSubmissionParameter.Key k) =>
-                string.Join(".", k.KeyData, k.RollingStartNumber, k.RollingPeriod);
+                string.Join(".", k.KeyData, k.RollingStartNumber, k.RollingPeriod, k.ReportType);
 
             static string GetRegionString(IEnumerable<string> regions) =>
                 string.Join(",", regions.Select(r => r.ToUpperInvariant()).OrderBy(r => r));

--- a/Covid19Radar/Covid19Radar/Model/DiagnosisSubmissionParameter.cs
+++ b/Covid19Radar/Covid19Radar/Model/DiagnosisSubmissionParameter.cs
@@ -40,6 +40,8 @@ namespace Covid19Radar.Model
             public uint RollingStartNumber { get; set; }
             [JsonProperty("rollingPeriod")]
             public uint RollingPeriod { get; set; }
+            [JsonProperty("reportType")]
+            public uint ReportType { get; set; }
         }
     }
 }

--- a/Covid19Radar/Covid19Radar/Services/DiagnosisKeyRegisterServer.cs
+++ b/Covid19Radar/Covid19Radar/Services/DiagnosisKeyRegisterServer.cs
@@ -95,6 +95,7 @@ namespace Covid19Radar.Services
                 KeyData = Convert.ToBase64String(k.KeyData),
                 RollingStartNumber = (uint)k.RollingStartIntervalNumber,
                 RollingPeriod = (uint)k.RollingPeriod,
+                ReportType = (uint)k.ReportType,
             });
 
             // Generate Padding

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
@@ -23,6 +23,8 @@ namespace Covid19Radar.ViewModels
 {
     public class NotifyOtherPageViewModel : ViewModelBase, IExposureNotificationEventCallback
     {
+        private const ReportType DEFAULT_REPORT_TYPE = ReportType.ConfirmedTest;
+
         public string HowToReceiveProcessingNumberReadText => $"{AppResources.NotifyOtherPageLabel} {AppResources.Button}";
 
         private readonly ILoggerService loggerService;
@@ -338,6 +340,12 @@ namespace Covid19Radar.ViewModels
                         );
 
                 loggerService.Info($"FilteredTemporaryExposureKeys-count: {filteredTemporaryExposureKeyList.Count()}");
+
+                // Set reportType
+                foreach (var tek in filteredTemporaryExposureKeyList)
+                {
+                    tek.ReportType = DEFAULT_REPORT_TYPE;
+                }
 
                 // TODO: Save and use revoke operation.
                 string idempotencyKey = Guid.NewGuid().ToString();

--- a/src/Covid19Radar.Api/Models/V3DiagnosisSubmissionParameter.cs
+++ b/src/Covid19Radar.Api/Models/V3DiagnosisSubmissionParameter.cs
@@ -105,7 +105,7 @@ namespace Covid19Radar.Api.Models
                 return true;
             }
 
-            public string GetKeyString() => string.Join(".", KeyData, RollingStartNumber, RollingPeriod, ReportType, DaysSinceOnsetOfSymptoms);
+            public string GetKeyString() => string.Join(".", KeyData, RollingStartNumber, RollingPeriod, ReportType);
         }
 
         /// <summary>


### PR DESCRIPTION
## Issue 番号 / Issue ID

- Close #623

## 目的 / Purpose

- DeviceVerificationを有効にするとAndroidのV3DiagnosisApiが失敗する不具合を修正する
- ClearTextの生成をServerとAppで同じロジックにする

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

-

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
