### PR TITLE
[App] ClearText generating logic that App and Server must be equal.

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/Services/DeviceCheckService.cs
+++ b/Covid19Radar/Covid19Radar.Android/Services/DeviceCheckService.cs
@@ -14,7 +14,7 @@ namespace Covid19Radar.Droid.Services
     {
         public Task<string> VerifyAsync(DiagnosisSubmissionParameter submission)
         {
-            var nonce = DeviceVerifierUtils.CreateAndroidNonceV2(submission);
+            var nonce = DeviceVerifierUtils.CreateAndroidNonceV3(submission);
             return GetSafetyNetAttestationAsync(nonce);
         }
 

--- a/Covid19Radar/Covid19Radar/Model/DiagnosisSubmissionParameter.cs
+++ b/Covid19Radar/Covid19Radar/Model/DiagnosisSubmissionParameter.cs
@@ -40,6 +40,8 @@ namespace Covid19Radar.Model
             public uint RollingStartNumber { get; set; }
             [JsonProperty("rollingPeriod")]
             public uint RollingPeriod { get; set; }
+            [JsonProperty("reportType")]
+            public uint ReportType { get; set; }
         }
     }
 }

--- a/Covid19Radar/Covid19Radar/Services/DiagnosisKeyRegisterServer.cs
+++ b/Covid19Radar/Covid19Radar/Services/DiagnosisKeyRegisterServer.cs
@@ -95,6 +95,7 @@ namespace Covid19Radar.Services
                 KeyData = Convert.ToBase64String(k.KeyData),
                 RollingStartNumber = (uint)k.RollingStartIntervalNumber,
                 RollingPeriod = (uint)k.RollingPeriod,
+                ReportType = (uint)k.ReportType,
             });
 
             // Generate Padding

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
@@ -23,6 +23,8 @@ namespace Covid19Radar.ViewModels
 {
     public class NotifyOtherPageViewModel : ViewModelBase, IExposureNotificationEventCallback
     {
+        private const ReportType DEFAULT_REPORT_TYPE = ReportType.ConfirmedTest;
+
         public string HowToReceiveProcessingNumberReadText => $"{AppResources.NotifyOtherPageLabel} {AppResources.Button}";
 
         private readonly ILoggerService loggerService;
@@ -326,6 +328,12 @@ namespace Covid19Radar.ViewModels
                         );
 
                 loggerService.Info($"FilteredTemporaryExposureKeys-count: {filteredTemporaryExposureKeyList.Count()}");
+
+                // Set reportType
+                foreach (var tek in filteredTemporaryExposureKeyList)
+                {
+                    tek.ReportType = DEFAULT_REPORT_TYPE;
+                }
 
                 // TODO: Save and use revoke operation.
                 string idempotencyKey = Guid.NewGuid().ToString();

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Common/DeviceVerifierUtilsTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Common/DeviceVerifierUtilsTests.cs
@@ -13,11 +13,13 @@ namespace Covid19Radar.UnitTests.Common
     public class DeviceVerifierUtilsTests
     {
         private const string EXPECTED_CLEAR_TEXT_V2 = "jp.go.mhlw.cocoa.unit_test|S2V5RGF0YTE=.10000.140,S2V5RGF0YTI=.20000.141,S2V5RGF0YTM=.30000.142,S2V5RGF0YTQ=.40000.143,S2V5RGF0YTU=.50000.70|440,441|VerificationPayload THIS STRING IS MEANINGLESS";
+        private const string EXPECTED_CLEAR_TEXT_V3 = "2021-12-19T19:02:00.000+09:00|jp.go.mhlw.cocoa.unit_test|S2V5RGF0YTE=.10000.140.1,S2V5RGF0YTI=.20000.141.1,S2V5RGF0YTM=.30000.142.1,S2V5RGF0YTQ=.40000.143.1,S2V5RGF0YTU=.50000.70.1|440,441|VerificationPayload THIS STRING IS MEANINGLESS";
 
         private static DiagnosisSubmissionParameter.Key CreateDiagnosisKey(
             string keyData,
             int rollingStartNumber,
-            int rollingPeriod
+            int rollingPeriod,
+            int reportType
             )
         {
             var keyDataBytes = Encoding.UTF8.GetBytes(keyData);
@@ -28,6 +30,7 @@ namespace Covid19Radar.UnitTests.Common
                 KeyData = keyDataBase64,
                 RollingStartNumber = (uint)rollingStartNumber,
                 RollingPeriod = (uint)rollingPeriod,
+                ReportType = (uint)reportType
             };
         }
 
@@ -36,11 +39,11 @@ namespace Covid19Radar.UnitTests.Common
         {
             var platform = "Android";
             var dummyDiagnosisKeyDataList = new[] {
-                CreateDiagnosisKey("KeyData1", 10000, 140),
-                CreateDiagnosisKey("KeyData2", 20000, 141),
-                CreateDiagnosisKey("KeyData3", 30000, 142),
-                CreateDiagnosisKey("KeyData4", 40000, 143),
-                CreateDiagnosisKey("KeyData5", 50000, 70),
+                CreateDiagnosisKey("KeyData1", 10000, 140, 1),
+                CreateDiagnosisKey("KeyData2", 20000, 141, 1),
+                CreateDiagnosisKey("KeyData3", 30000, 142, 1),
+                CreateDiagnosisKey("KeyData4", 40000, 143, 1),
+                CreateDiagnosisKey("KeyData5", 50000, 70, 1),
             };
 
             var dummyRegions = new string[]
@@ -70,6 +73,51 @@ namespace Covid19Radar.UnitTests.Common
             string clearText = DeviceVerifierUtils.GetNonceClearTextV2(submissionParameter);
             Assert.Equal(
                 EXPECTED_CLEAR_TEXT_V2,
+                clearText
+                );
+        }
+
+        [Fact]
+        public void AndroidClearTextTestV3()
+        {
+            var platform = "Android";
+            var dummyDiagnosisKeyDataList = new[] {
+                CreateDiagnosisKey("KeyData1", 10000, 140, 1),
+                CreateDiagnosisKey("KeyData2", 20000, 141, 1),
+                CreateDiagnosisKey("KeyData3", 30000, 142, 1),
+                CreateDiagnosisKey("KeyData4", 40000, 143, 1),
+                CreateDiagnosisKey("KeyData5", 50000, 70, 1),
+            };
+
+            var dummyRegions = new string[]
+            {
+                "440",
+                "441",
+            };
+
+            var dummySymptomOnsetDate = "2021-12-19T19:02:00.000+09:00";
+            var dummyDeviceVerificationPayload = "DeviceVerificationPayload THIS STRING IS MEANINGLESS";
+            var dummyAppPackageName = "jp.go.mhlw.cocoa.unit_test";
+            var dummyVerificationPayload = "VerificationPayload THIS STRING IS MEANINGLESS";
+
+            // This value will not affect any result.
+            var dummyPadding = new Random().Next().ToString();
+
+            var submissionParameter = new DiagnosisSubmissionParameter()
+            {
+                Platform = platform,
+                Regions = dummyRegions,
+                SymptomOnsetDate = dummySymptomOnsetDate,
+                Keys = dummyDiagnosisKeyDataList,
+                DeviceVerificationPayload = dummyDeviceVerificationPayload,
+                AppPackageName = dummyAppPackageName,
+                VerificationPayload = dummyVerificationPayload,
+                Padding = dummyPadding,
+            };
+
+            string clearText = DeviceVerifierUtils.GetNonceClearTextV3(submissionParameter);
+            Assert.Equal(
+                EXPECTED_CLEAR_TEXT_V3,
                 clearText
                 );
         }


### PR DESCRIPTION
## Issue 番号 / Issue ID
~~#634 に依存した変更~~

- Close #623
- #621

## 目的 / Purpose

- DeviceVerificationを有効にするとAndroidのV3DiagnosisApiが失敗する不具合を修正する
- ClearTextの生成をServerとAppで同じロジックにする

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

-

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
