### PR TITLE
Update default AppleExposureConfigV2.

### DIFF
--- a/Covid19Radar/Covid19Radar/Repository/ExposureConfigurationRepository.cs
+++ b/Covid19Radar/Covid19Radar/Repository/ExposureConfigurationRepository.cs
@@ -282,6 +282,16 @@ namespace Covid19Radar.Repository
                 {
                     InfectiousnessWhenDaysSinceOnsetMissing = Infectiousness.High,
                     ReportTypeNoneMap = ReportType.ConfirmedTest,
+                    AttenuationDurationThresholds = new int[] {
+                        50,
+                        54,
+                        65
+                    },
+                    ImmediateDurationWeight = 250.0,
+                    NearDurationWeight = 130.0,
+                    MediumDurationWeight = 60.0,
+                    OtherDurationWeight = 1.0,
+                    DaysSinceLastExposureThreshold = 0,
                     InfectiousnessForDaysSinceOnsetOfSymptoms = new Dictionary<long, Infectiousness>()
                     {
                         { -14, Infectiousness.None },


### PR DESCRIPTION
## Issue 番号 / Issue ID

- #646

## 目的 / Purpose

JSONで定義している接触確認のConfigurationをダウンロードできなかった場合に、フォールバックとして用いる設定をデフォルト値として定義する。

JSONファイルのこの部分、

https://github.com/keiji/cocoa/blob/78c17d9f00ee141464ff9d4f4c5090c94f6fc573/documents/static/exposure_configuration/configuration.json#L159-L168

`AppleExposureConfigV2`の辺りを書いているときに Missing の設定をどうするかが気になって Issue #705 作りに行って、戻ってきたら、このあたりの設定の反映を忘れていました。

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

-

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
