### PR TITLE
Show AlertDialog when connection failed to diagnosis-register server.

### DIFF
--- a/Covid19Radar/Covid19Radar/Resources/AppResources.Designer.cs
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.Designer.cs
@@ -959,6 +959,12 @@ namespace Covid19Radar.Resources {
             }
         }
         
+        public static string NotifyOther_Dialog_NoConnection {
+            get {
+                return ResourceManager.GetString("NotifyOther_Dialog_NoConnection", resourceCulture);
+            }
+        }
+        
         public static string NotifyOtherPageDiag1Message {
             get {
                 return ResourceManager.GetString("NotifyOtherPageDiag1Message", resourceCulture);

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
@@ -595,6 +595,10 @@
     <value>センターに接続できません</value>
     <comment>センターに接続できません</comment>
   </data>
+  <data name="NotifyOther_Dialog_NoConnection" xml:space="preserve">
+    <value>ご不便おかけして申し訳ありません。ネットワークが不安定か、サーバーが混み合っている可能性があります。時間をおいて再度お試しください。</value>
+    <comment>ご不便おかけして申し訳ありません。ネットワークが不安定か、サーバーが混み合っている可能性があります。時間をおいて再度お試しください。</comment>
+  </data>
   <data name="NotifyOtherPageDiag1Message" xml:space="preserve">
     <value>よろしいですか？</value>
     <comment>よろしいですか？</comment>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.resx
@@ -713,6 +713,10 @@
     <value>Cannot connect to registration center</value>
     <comment>センターに接続できません</comment>
   </data>
+  <data name="NotifyOther_Dialog_NoConnection" xml:space="preserve">
+    <value>We apologize for the inconvinience. The network may be unstable or the server may be busy. Please try again later.</value>
+    <comment>ご不便おかけして申し訳ありません。ネットワークが不安定か、サーバーが混み合っている可能性があります。時間をおいて再度お試しください。</comment>
+  </data>
   <data name="NotifyOtherPageDiag1Message" xml:space="preserve">
     <value>Do you want to register it?</value>
     <comment>よろしいですか？</comment>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.zh-Hans.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.zh-Hans.resx
@@ -589,6 +589,10 @@
     <value>无法连接到登记服务中心</value>
     <comment>センターに接続できません</comment>
   </data>
+  <data name="NotifyOther_Dialog_NoConnection" xml:space="preserve">
+    <value>We apologize for the inconvinience. The network may be unstable or the server may be busy. Please try again later.</value>
+    <comment>ご不便おかけして申し訳ありません。ネットワークが不安定か、サーバーが混み合っている可能性があります。時間をおいて再度お試しください。</comment>
+  </data>
   <data name="NotifyOtherPageDiag1Message" xml:space="preserve">
     <value>是否登记？</value>
     <comment>よろしいですか？</comment>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.zh-Hans.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.zh-Hans.resx
@@ -590,7 +590,7 @@
     <comment>センターに接続できません</comment>
   </data>
   <data name="NotifyOther_Dialog_NoConnection" xml:space="preserve">
-    <value>We apologize for the inconvinience. The network may be unstable or the server may be busy. Please try again later.</value>
+    <value>TODO: We apologize for the inconvinience. The network may be unstable or the server may be busy. Please try again later.</value>
     <comment>ご不便おかけして申し訳ありません。ネットワークが不安定か、サーバーが混み合っている可能性があります。時間をおいて再度お試しください。</comment>
   </data>
   <data name="NotifyOtherPageDiag1Message" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/Services/DiagnosisKeyRegisterServer.cs
+++ b/Covid19Radar/Covid19Radar/Services/DiagnosisKeyRegisterServer.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -33,7 +32,7 @@ namespace Covid19Radar.Services
             _deviceVerifier = deviceVerifier;
         }
 
-        public async Task<IList<HttpStatusCode>> SubmitDiagnosisKeysAsync(
+        public async Task<HttpStatusCode> SubmitDiagnosisKeysAsync(
             DateTime symptomOnsetDate,
             IList<TemporaryExposureKey> temporaryExposureKeys,
             string processNumber,
@@ -62,9 +61,7 @@ namespace Covid19Radar.Services
                 }
 
                 var diagnosisInfo = await CreateSubmissionAsync(symptomOnsetDate, temporaryExposureKeys, processNumber, idempotencyKey);
-                IList<HttpStatusCode> httpStatusCode = await _httpDataService.PutSelfExposureKeysAsync(diagnosisInfo);
-
-                return httpStatusCode;
+                return await _httpDataService.PutSelfExposureKeysAsync(diagnosisInfo);
             }
             finally
             {

--- a/Covid19Radar/Covid19Radar/Services/HttpDataService.cs
+++ b/Covid19Radar/Covid19Radar/Services/HttpDataService.cs
@@ -85,7 +85,7 @@ namespace Covid19Radar.Services
             return false;
         }
 
-        public async Task<IList<HttpStatusCode>> PutSelfExposureKeysAsync(DiagnosisSubmissionParameter request)
+        public async Task<HttpStatusCode> PutSelfExposureKeysAsync(DiagnosisSubmissionParameter request)
         {
             loggerService.StartMethod();
 
@@ -94,13 +94,20 @@ namespace Covid19Radar.Services
                 await serverConfigurationRepository.LoadAsync();
 
                 var diagnosisKeyRegisterApiUrls = serverConfigurationRepository.DiagnosisKeyRegisterApiUrls;
-                var tasks = diagnosisKeyRegisterApiUrls.Select(async url =>
+                if (diagnosisKeyRegisterApiUrls.Count() == 0)
                 {
-                    var content = new StringContent(JsonConvert.SerializeObject(request), Encoding.UTF8, "application/json");
-                    return await PutAsync(url, content);
-                });
+                    loggerService.Error("DiagnosisKeyRegisterApiUrls count 0");
+                    throw new InvalidOperationException("DiagnosisKeyRegisterApiUrls count 0");
+                }
+                else if (diagnosisKeyRegisterApiUrls.Count() > 1)
+                {
+                    loggerService.Warning("Multi DiagnosisKeyRegisterApiUrl are detected.");
+                }
 
-                return await Task.WhenAll(tasks);
+                var url = diagnosisKeyRegisterApiUrls.First();
+                var content = new StringContent(JsonConvert.SerializeObject(request), Encoding.UTF8, "application/json");
+
+                return await PutAsync(url, content);
             }
             finally
             {

--- a/Covid19Radar/Covid19Radar/Services/HttpDataServiceMock.cs
+++ b/Covid19Radar/Covid19Radar/Services/HttpDataServiceMock.cs
@@ -105,7 +105,7 @@ namespace Covid19Radar.Services
             return await Task.FromResult(result);
         }
 
-        Task<IList<HttpStatusCode>> IHttpDataService.PutSelfExposureKeysAsync(DiagnosisSubmissionParameter request)
+        Task<HttpStatusCode> IHttpDataService.PutSelfExposureKeysAsync(DiagnosisSubmissionParameter request)
         {
             var code = HttpStatusCode.OK; // default. for PutSelfExposureKeys NG
             var dataType = mockCommonUtils.GetDiagnosisDataType();
@@ -122,11 +122,9 @@ namespace Covid19Radar.Services
                         break;
                 }
             }
-            return Task.Factory.StartNew<IList<HttpStatusCode>>(() =>
-            {
-                Debug.WriteLine("HttpDataServiceMock::PutSelfExposureKeysAsync called");
-                return new List<HttpStatusCode>() { code };
-            });
+
+            Debug.WriteLine("HttpDataServiceMock::PutSelfExposureKeysAsync called");
+            return Task.FromResult(code);
         }
 
         public Task<ApiResponse<LogStorageSas>> GetLogStorageSas()

--- a/Covid19Radar/Covid19Radar/Services/IDiagnosisKeyRegisterServer.cs
+++ b/Covid19Radar/Covid19Radar/Services/IDiagnosisKeyRegisterServer.cs
@@ -12,7 +12,7 @@ namespace Covid19Radar.Services
 {
     public interface IDiagnosisKeyRegisterServer
     {
-        public Task<IList<HttpStatusCode>> SubmitDiagnosisKeysAsync(
+        public Task<HttpStatusCode> SubmitDiagnosisKeysAsync(
             DateTime symptomOnsetDate,
             IList<TemporaryExposureKey> temporaryExposureKeys,
             string processNumber,

--- a/Covid19Radar/Covid19Radar/Services/IHttpDataService.cs
+++ b/Covid19Radar/Covid19Radar/Services/IHttpDataService.cs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 using Covid19Radar.Model;
-using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -13,7 +12,7 @@ namespace Covid19Radar.Services
     {
         Task<bool> PostRegisterUserAsync();
 
-        Task<IList<HttpStatusCode>> PutSelfExposureKeysAsync(DiagnosisSubmissionParameter request);
+        Task<HttpStatusCode> PutSelfExposureKeysAsync(DiagnosisSubmissionParameter request);
 
         Task<ApiResponse<LogStorageSas>> GetLogStorageSas();
     }

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
@@ -355,7 +355,7 @@ namespace Covid19Radar.ViewModels
 
                 await UserDialogs.Instance.AlertAsync(
                     AppResources.NotifyOther_Dialog_NoConnection,
-                    AppResources.ExposureNotificationHandler2ErrorMessage,
+                    AppResources.NotifyOtherPageDialogExceptionTitle,
                     AppResources.ButtonOk);
             }
         }

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
@@ -13,7 +13,6 @@ using System.Text.RegularExpressions;
 using Covid19Radar.Common;
 using Covid19Radar.Resources;
 using System.Threading.Tasks;
-using System.IO;
 using System.Collections.Generic;
 using Chino;
 using System.Net;
@@ -121,6 +120,9 @@ namespace Covid19Radar.ViewModels
 
         private int errorCount { get; set; }
 
+        // TODO: Save and use for revoke operation.
+        private string idempotencyKey = Guid.NewGuid().ToString();
+
         public NotifyOtherPageViewModel(
             INavigationService navigationService,
             ILoggerService loggerService,
@@ -219,7 +221,6 @@ namespace Covid19Radar.ViewModels
                         AppResources.NotifyOtherPageDiagReturnHomeTitle,
                         AppResources.ButtonOk
                     );
-                    UserDialogs.Instance.HideLoading();
                     await NavigationService.NavigateAsync(Destination.HomePage.ToPath());
 
                     loggerService.Error($"Exceeded the number of trials.");
@@ -275,19 +276,20 @@ namespace Covid19Radar.ViewModels
                        AppResources.NotifyOtherPageDiag6Title,
                        AppResources.ButtonOk
                     );
-                    UserDialogs.Instance.HideLoading();
                     await NavigationService.NavigateAsync("/" + nameof(MenuPage) + "/" + nameof(NavigationPage) + "/" + nameof(HomePage));
 
                     loggerService.Warning($"Exposure notification is disable.");
                     return;
                 }
 
-                await SubmitDiagnosisKeys();
+                // UserDialogs.Instance.Loading must be executed in MainThread.
+                using (UserDialogs.Instance.Loading(AppResources.LoadingTextRegistering))
+                {
+                    await SubmitDiagnosisKeys();
+                }
             }
             catch (Exception ex)
             {
-                UserDialogs.Instance.HideLoading();
-
                 errorCount++;
                 UserDialogs.Instance.Alert(
                     AppResources.NotifyOtherPageDialogExceptionText,
@@ -329,28 +331,16 @@ namespace Covid19Radar.ViewModels
                     tek.ReportType = DEFAULT_REPORT_TYPE;
                 }
 
-                UserDialogs.Instance.ShowLoading(AppResources.LoadingTextRegistering);
-
-                // TODO: Save and use revoke operation.
-                string idempotencyKey = Guid.NewGuid().ToString();
-
-                IList<HttpStatusCode> httpStatusCodes = await diagnosisKeyRegisterServer.SubmitDiagnosisKeysAsync(
+                HttpStatusCode httpStatusCode = await diagnosisKeyRegisterServer.SubmitDiagnosisKeysAsync(
                     _diagnosisDate,
                     filteredTemporaryExposureKeyList,
                     ProcessingNumber,
                     idempotencyKey
                     );
 
-                foreach(var statusCode in httpStatusCodes)
-                {
-                    loggerService.Info($"HTTP status is {httpStatusCodes}({(int)statusCode}).");
+                ShowResult(httpStatusCode);
 
-                    // Mainly, we expect that SubmitDiagnosisKeysAsync returns one result.
-                    // Multiple-results is for debug use only.
-                    ShowResult(statusCode);
-                }
-
-                if (httpStatusCodes.Any(statusCode => statusCode != HttpStatusCode.OK))
+                if (httpStatusCode != HttpStatusCode.OK)
                 {
                     errorCount++;
                 }
@@ -363,14 +353,12 @@ namespace Covid19Radar.ViewModels
             {
                 loggerService.Exception("SubmitDiagnosisKeys", exception);
             }
-            finally
-            {
-                UserDialogs.Instance.HideLoading();
-            }
         }
 
         private async void ShowResult(HttpStatusCode httpStatusCode)
         {
+            loggerService.Info($"HTTP status is {httpStatusCode}({(int)httpStatusCode}).");
+
             switch (httpStatusCode)
             {
                 case HttpStatusCode.OK:
@@ -450,7 +438,11 @@ namespace Covid19Radar.ViewModels
         {
             loggerService.StartMethod();
 
-            await SubmitDiagnosisKeys();
+            // UserDialogs.Instance.Loading must be executde in MainThread.
+            using (UserDialogs.Instance.Loading(AppResources.LoadingTextRegistering))
+            {
+                await SubmitDiagnosisKeys();
+            }
 
             loggerService.EndMethod();
         }

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
@@ -352,6 +352,11 @@ namespace Covid19Radar.ViewModels
             catch (Exception exception)
             {
                 loggerService.Exception("SubmitDiagnosisKeys", exception);
+
+                await UserDialogs.Instance.AlertAsync(
+                    AppResources.NotifyOther_Dialog_NoConnection,
+                    AppResources.ExposureNotificationHandler2ErrorMessage,
+                    AppResources.ButtonOk);
             }
         }
 

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/HttpDataServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/HttpDataServiceTests.cs
@@ -192,14 +192,13 @@ namespace Covid19Radar.UnitTests.Services
                 Padding = "padding"
             };
 
-            var results = await unitUnderTest.PutSelfExposureKeysAsync(request);
+            var result = await unitUnderTest.PutSelfExposureKeysAsync(request);
 
             mockLoggerService.Verify(x => x.StartMethod("PutSelfExposureKeysAsync", It.IsAny<string>(), It.IsAny<int>()), Times.Once());
             mockLoggerService.Verify(x => x.EndMethod("PutSelfExposureKeysAsync", It.IsAny<string>(), It.IsAny<int>()), Times.Once());
             mockLoggerService.Verify(x => x.Exception(It.IsAny<string>(), It.IsAny<Exception>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()), Times.Never());
 
-            Assert.Equal(1, results.Count);
-            Assert.Equal(HttpStatusCode.NoContent, results[0]);
+            Assert.Equal(HttpStatusCode.NoContent, result);
             Assert.NotNull(requestContent);
 
             var stringContent = await requestContent.ReadAsStringAsync();


### PR DESCRIPTION
## Issue 番号 / Issue ID
#776 に依存した変更

- Close #775

## 目的 / Purpose

- 陽性情報登録でサーバーにアクセスできないときにダイアログを表示する

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

ちょっと画面が詰まり過ぎな感がある

![Screen Shot 2022-01-19 at 19 45 20](https://user-images.githubusercontent.com/932136/150115260-4e936470-9412-4984-8483-7edf7e42740a.png)




## その他 / Other information
