### PR TITLE
Fix wrong state in HomePage when list.json obtained failed.

### DIFF
--- a/Covid19Radar/Covid19Radar/Services/AbsExposureDetectionBackgroundService.cs
+++ b/Covid19Radar/Covid19Radar/Services/AbsExposureDetectionBackgroundService.cs
@@ -81,8 +81,7 @@ namespace Covid19Radar.Services
                 return;
             }
 
-            IEnumerable<ExposureNotificationStatus> statuses = await _exposureNotificationApiService.GetStatusesAsync();
-            IEnumerable<int> statuseCodes = statuses.Select(status => status.Code);
+            IEnumerable<int> statuseCodes = await _exposureNotificationApiService.GetStatusCodesAsync();
 
             bool isActivated = statuseCodes.Contains(ExposureNotificationStatus.Code_Android.ACTIVATED)
                 | statuseCodes.Contains(ExposureNotificationStatus.Code_iOS.Active);

--- a/Covid19Radar/Covid19Radar/Services/AbsExposureDetectionBackgroundService.cs
+++ b/Covid19Radar/Covid19Radar/Services/AbsExposureDetectionBackgroundService.cs
@@ -92,8 +92,6 @@ namespace Covid19Radar.Services
                 return;
             }
 
-            _userDataRepository.SetCanConfirmExposure(true);
-
             var cancellationToken = cancellationTokenSource?.Token ?? default(CancellationToken);
 
             await _serverConfigurationRepository.LoadAsync();
@@ -166,17 +164,16 @@ namespace Covid19Radar.Services
                 }
                 catch (Exception exception)
                 {
+                    canConfirmExposure = false;
                     _loggerService.Exception($"Exception occurred: {region}", exception);
-                    _userDataRepository.SetCanConfirmExposure(false);
                     throw;
                 }
                 finally
                 {
                     RemoveFiles(downloadedFileNameList);
+                    _userDataRepository.SetCanConfirmExposure(canConfirmExposure);
                 }
             }
-
-            _userDataRepository.SetCanConfirmExposure(canConfirmExposure);
         }
 
         private static IList<DiagnosisKeyEntry> FilterDiagnosisKeysAfterLastProcessTimestamp(

--- a/Covid19Radar/Covid19Radar/Services/AbsExposureDetectionBackgroundService.cs
+++ b/Covid19Radar/Covid19Radar/Services/AbsExposureDetectionBackgroundService.cs
@@ -167,7 +167,7 @@ namespace Covid19Radar.Services
                 catch (Exception exception)
                 {
                     _loggerService.Exception($"Exception occurred: {region}", exception);
-                    canConfirmExposure = false;
+                    _userDataRepository.SetCanConfirmExposure(false);
                     throw;
                 }
                 finally

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Repository/DiagnosisKeyRepositoryTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Repository/DiagnosisKeyRepositoryTests.cs
@@ -49,7 +49,7 @@ namespace Covid19Radar.UnitTests.Repository
             mockClientService.Setup(x => x.Create()).Returns(client);
 
             var unitUnderTest = CreateRepository();
-            var result = await unitUnderTest.GetDiagnosisKeysListAsync("https://example.com", default);
+            var (_, result) = await unitUnderTest.GetDiagnosisKeysListAsync("https://example.com", default);
 
             Assert.Equal(2, result.Count);
 
@@ -74,7 +74,7 @@ namespace Covid19Radar.UnitTests.Repository
             mockClientService.Setup(x => x.Create()).Returns(client);
 
             var unitUnderTest = CreateRepository();
-            var result = await unitUnderTest.GetDiagnosisKeysListAsync("https://example.com", default);
+            var (_, result) = await unitUnderTest.GetDiagnosisKeysListAsync("https://example.com", default);
 
             Assert.Equal(0, result.Count);
         }

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/AbsExposureDetectionBackgroundServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/AbsExposureDetectionBackgroundServiceTests.cs
@@ -57,7 +57,11 @@ namespace Covid19Radar.UnitTests.Services
 
         public void Dispose()
         {
-            Directory.Delete($"{Path.GetTempPath()}/diagnosis_keys/", true);
+            var dir = $"{Path.GetTempPath()}/diagnosis_keys/";
+            if (Directory.Exists(dir))
+            {
+                Directory.Delete(dir, true);
+            }
         }
 
         #endregion
@@ -374,6 +378,14 @@ namespace Covid19Radar.UnitTests.Services
             mockLocalPathService
                 .Setup(x => x.CacheDirectory)
                 .Returns(Path.GetTempPath());
+
+            // Setup ExposureNotification API
+            mockExposureNotificationApiService.Setup(x => x.IsEnabledAsync())
+                .ReturnsAsync(true);
+            mockExposureNotificationApiService.Setup(x => x.GetStatusesAsync())
+                .ReturnsAsync(new List<ExposureNotificationStatus>() {
+                    new ExposureNotificationStatus(ExposureNotificationStatus.Code_Android.ACTIVATED)
+                });
 
             mockDiagnosisKeyRepository
                 .Setup(x => x.GetDiagnosisKeysListAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/AbsExposureDetectionBackgroundServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/AbsExposureDetectionBackgroundServiceTests.cs
@@ -382,9 +382,9 @@ namespace Covid19Radar.UnitTests.Services
             // Setup ExposureNotification API
             mockExposureNotificationApiService.Setup(x => x.IsEnabledAsync())
                 .ReturnsAsync(true);
-            mockExposureNotificationApiService.Setup(x => x.GetStatusesAsync())
-                .ReturnsAsync(new List<ExposureNotificationStatus>() {
-                    new ExposureNotificationStatus(ExposureNotificationStatus.Code_Android.ACTIVATED)
+            mockExposureNotificationApiService.Setup(x => x.GetStatusCodesAsync())
+                .ReturnsAsync(new List<int>() {
+                    ExposureNotificationStatus.Code_Android.ACTIVATED,
                 });
 
             mockDiagnosisKeyRepository


### PR DESCRIPTION
## Issue 番号 / Issue ID

- Close #780
- 関連 #772

## 目的 / Purpose

- 診断キー一覧（list.json）の取得に失敗したとき、動作状況が「接触有無が確認できません」にななる不具合を修正した

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

<!--
  当てはまるもの 1 つに「x」とマークしてください。
  Mark one with an "x".
-->

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

-

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
