### PR TITLE
Handle exception(or ApiResult) that getTekHistory was unauthorized.

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/MainActivity.cs
+++ b/Covid19Radar/Covid19Radar.Android/MainActivity.cs
@@ -160,7 +160,7 @@ namespace Covid19Radar.Droid
                 ExposureNotificationApiService.REQUEST_EN_START
                     => new Action<IExposureNotificationEventCallback>(callback =>
                     {
-                        if(isOk)
+                        if (isOk)
                         {
                             callback.OnEnabled();
                         }
@@ -170,7 +170,17 @@ namespace Covid19Radar.Droid
                         }
                     }),
                 ExposureNotificationApiService.REQUEST_GET_TEK_HISTORY
-                    => new Action<IExposureNotificationEventCallback>(callback => { callback.OnGetTekHistoryAllowed(); }),
+                    => new Action<IExposureNotificationEventCallback>(callback =>
+                    {
+                        if (isOk)
+                        {
+                            callback.OnGetTekHistoryAllowed();
+                        }
+                        else
+                        {
+                            callback.OnGetTekHistoryDecline();
+                        }
+                    }),
                 ExposureNotificationApiService.REQUEST_PREAUTHORIZE_KEYS
                     => new Action<IExposureNotificationEventCallback>(callback => { callback.OnPreauthorizeAllowed(); }),
                 _ => new Action<IExposureNotificationEventCallback>(callback => { /* do nothing */ }),

--- a/Covid19Radar/Covid19Radar/IExposureNotificationEventCallback.cs
+++ b/Covid19Radar/Covid19Radar/IExposureNotificationEventCallback.cs
@@ -8,7 +8,10 @@ namespace Covid19Radar
     {
         public void OnEnabled() { }
         public void OnDeclined() { }
+
         public void OnGetTekHistoryAllowed() { }
+        public void OnGetTekHistoryDecline() { }
+
         public void OnPreauthorizeAllowed() { }
     }
 }

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
@@ -323,11 +323,12 @@ namespace Covid19Radar.ViewModels
 
                 UserDialogs.Instance.HideLoading();
 
-                UserDialogs.Instance.Alert(
-                    AppResources.NotifyOtherPageDialogExceptionText,
+                await UserDialogs.Instance.AlertAsync(
+                    AppResources.NotifyOther_Dialog_NoConnection,
                     AppResources.NotifyOtherPageDialogExceptionTitle,
                     AppResources.ButtonOk
-                );
+                    );
+
                 loggerService.Exception("Failed to submit DiagnosisKeys.", ex);
             }
             finally

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
@@ -283,14 +283,43 @@ namespace Covid19Radar.ViewModels
                 }
 
                 // UserDialogs.Instance.Loading must be executed in MainThread.
-                using (UserDialogs.Instance.Loading(AppResources.LoadingTextRegistering))
+                UserDialogs.Instance.ShowLoading(AppResources.LoadingTextRegistering);
+
+                await SubmitDiagnosisKeys();
+
+                UserDialogs.Instance.HideLoading();
+            }
+            catch (ENException exception)
+            {
+                loggerService.Exception("GetTemporaryExposureKeyHistoryAsync", exception);
+
+                if (exception.Code == ENException.Code_iOS.NotAuthorized)
                 {
-                    await SubmitDiagnosisKeys();
+                    loggerService.Info("GetTekHistory request is declined by user.");
+
+                    // Workarround for that HideLoading conflicts with AlertAsync on iOS.
+                    await Task.Delay(_delayForErrorMillis);
+
+                    UserDialogs.Instance.HideLoading();
+
+                    await UserDialogs.Instance.AlertAsync(
+                        null,
+                        AppResources.NotifyOtherPageDiag2Title,
+                        AppResources.ButtonOk
+                        );
                 }
+                else
+                {
+                    UserDialogs.Instance.HideLoading();
+                }
+
             }
             catch (Exception ex)
             {
+                UserDialogs.Instance.HideLoading();
+
                 errorCount++;
+
                 UserDialogs.Instance.Alert(
                     AppResources.NotifyOtherPageDialogExceptionText,
                     AppResources.NotifyOtherPageDialogExceptionTitle,
@@ -308,50 +337,39 @@ namespace Covid19Radar.ViewModels
         {
             loggerService.Info($"Submit DiagnosisKeys.");
 
-            try
-            {
-                List<TemporaryExposureKey> temporaryExposureKeyList
-                    = await exposureNotificationApiService.GetTemporaryExposureKeyHistoryAsync();
+            List<TemporaryExposureKey> temporaryExposureKeyList
+                = await exposureNotificationApiService.GetTemporaryExposureKeyHistoryAsync();
 
-                loggerService.Info($"TemporaryExposureKeys-count: {temporaryExposureKeyList.Count()}");
+            loggerService.Info($"TemporaryExposureKeys-count: {temporaryExposureKeyList.Count()}");
 
-                IList<TemporaryExposureKey> filteredTemporaryExposureKeyList
-                    = TemporaryExposureKeyUtils.FiilterTemporaryExposureKeys(
-                        temporaryExposureKeyList,
-                        _diagnosisDate,
-                        AppConstants.DaysToSendTek,
-                        loggerService
-                        );
-
-                loggerService.Info($"FilteredTemporaryExposureKeys-count: {filteredTemporaryExposureKeyList.Count()}");
-
-                // Set reportType
-                foreach (var tek in filteredTemporaryExposureKeyList)
-                {
-                    tek.ReportType = DEFAULT_REPORT_TYPE;
-                }
-
-                HttpStatusCode httpStatusCode = await diagnosisKeyRegisterServer.SubmitDiagnosisKeysAsync(
+            IList<TemporaryExposureKey> filteredTemporaryExposureKeyList
+                = TemporaryExposureKeyUtils.FiilterTemporaryExposureKeys(
+                    temporaryExposureKeyList,
                     _diagnosisDate,
-                    filteredTemporaryExposureKeyList,
-                    ProcessingNumber,
-                    idempotencyKey
+                    AppConstants.DaysToSendTek,
+                    loggerService
                     );
 
-                ShowResult(httpStatusCode);
+            loggerService.Info($"FilteredTemporaryExposureKeys-count: {filteredTemporaryExposureKeyList.Count()}");
 
-                if (httpStatusCode != HttpStatusCode.OK)
-                {
-                    errorCount++;
-                }
-            }
-            catch (ENException exception)
+            // Set reportType
+            foreach (var tek in filteredTemporaryExposureKeyList)
             {
-                loggerService.Exception("GetTemporaryExposureKeyHistoryAsync", exception);
+                tek.ReportType = DEFAULT_REPORT_TYPE;
             }
-            catch (Exception exception)
+
+            HttpStatusCode httpStatusCode = await diagnosisKeyRegisterServer.SubmitDiagnosisKeysAsync(
+                _diagnosisDate,
+                filteredTemporaryExposureKeyList,
+                ProcessingNumber,
+                idempotencyKey
+                );
+
+            ShowResult(httpStatusCode);
+
+            if (httpStatusCode != HttpStatusCode.OK)
             {
-                loggerService.Exception("SubmitDiagnosisKeys", exception);
+                errorCount++;
             }
         }
 
@@ -438,13 +456,47 @@ namespace Covid19Radar.ViewModels
         {
             loggerService.StartMethod();
 
-            // UserDialogs.Instance.Loading must be executde in MainThread.
-            using (UserDialogs.Instance.Loading(AppResources.LoadingTextRegistering))
+            try
             {
-                await SubmitDiagnosisKeys();
+                // UserDialogs.Instance.Loading must be executde in MainThread.
+                using (UserDialogs.Instance.Loading(AppResources.LoadingTextRegistering))
+                {
+                    await SubmitDiagnosisKeys();
+                }
             }
+            catch (ENException exception)
+            {
+                loggerService.Exception("GetTemporaryExposureKeyHistoryAsync", exception);
+            }
+            catch (Exception ex)
+            {
+                errorCount++;
+                UserDialogs.Instance.Alert(
+                    AppResources.NotifyOtherPageDialogExceptionText,
+                    AppResources.NotifyOtherPageDialogExceptionTitle,
+                    AppResources.ButtonOk
+                );
+                loggerService.Exception("Failed to submit DiagnosisKeys.", ex);
+            }
+            finally
+            {
+                loggerService.EndMethod();
+            }
+        }
+
+        public async void OnGetTekHistoryDecline()
+        {
+            loggerService.StartMethod();
+
+            loggerService.Info("GetTekHistory request is declined by user.");
+            await UserDialogs.Instance.AlertAsync(
+                null,
+                AppResources.NotifyOtherPageDiag2Title,
+                AppResources.ButtonOk
+                );
 
             loggerService.EndMethod();
         }
+
     }
 }

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
@@ -230,6 +230,9 @@ namespace Covid19Radar.ViewModels
 
                 loggerService.Info($"Number of attempts to submit diagnostic number. ({errorCount + 1} of {AppConstants.MaxErrorCount})");
 
+                // UserDialogs.Instance.Loading must be executed in MainThread.
+                UserDialogs.Instance.ShowLoading(AppResources.LoadingTextRegistering);
+
                 if (errorCount > 0)
                 {
                     await UserDialogs.Instance.AlertAsync(AppResources.NotifyOtherPageDiag3Message,
@@ -281,9 +284,6 @@ namespace Covid19Radar.ViewModels
                     loggerService.Warning($"Exposure notification is disable.");
                     return;
                 }
-
-                // UserDialogs.Instance.Loading must be executed in MainThread.
-                UserDialogs.Instance.ShowLoading(AppResources.LoadingTextRegistering);
 
                 await SubmitDiagnosisKeys();
 

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
@@ -316,9 +316,12 @@ namespace Covid19Radar.ViewModels
             }
             catch (Exception ex)
             {
-                UserDialogs.Instance.HideLoading();
-
                 errorCount++;
+
+                // Workarround for that HideLoading conflicts with AlertAsync on iOS.
+                await Task.Delay(_delayForErrorMillis);
+
+                UserDialogs.Instance.HideLoading();
 
                 UserDialogs.Instance.Alert(
                     AppResources.NotifyOtherPageDialogExceptionText,


### PR DESCRIPTION
## Issue 番号 / Issue ID
#776 に依存した変更

- Close #782 

## 目的 / Purpose

- 陽性情報登録時にTEKの共有を拒否したときに「登録を中止します」ダイアログを表示する

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[x] Yes
[ ] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

- ダイアログを表示しているライブラリの特性か、iOSでのみ、HideLoadingの直後にAlertAsyncを実行すると、一瞬アラートが表示されてすぐ消えてしまう現象が起きている
- 同種の問題としては、#776 でもShowLoadingが一瞬表示されてすぐ消えてしまう挙動を確認しているが、このケースではメインスレッドから実行すれば解決した（しかし、今回の場合は解決しなかった）。
- 検討の結果、HideLoading **前** にDelayの時間を設けるとAlertAsyncが消えないことが分かった
- 時間は1秒程度でいいが、マジックナンバーは使いたくないので `delayForErrorMillis` を適用している
- あまり気持ちのいい解決策ではないものの「陽性登録時にTEKの取得を拒否する」という、あまり発生頻度が高くない操作への対応なので、これで調整することにする（後々解決法が分かれば適応する

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
