### PR TITLE
Set transmission risk level LOWEST to outdated diagnosis-keys.

### DIFF
--- a/Covid19Radar/Covid19Radar/Repository/ExposureConfigurationRepository.cs
+++ b/Covid19Radar/Covid19Radar/Repository/ExposureConfigurationRepository.cs
@@ -426,8 +426,8 @@ namespace Covid19Radar.Repository
                     },
                     TransmissionRiskLevelValues = new int[]
                     {
-                        1,
-                        7,
+                        0,
+                        0,
                         7,
                         7,
                         7,

--- a/documents/static/exposure_configuration/Xamarin.ExposureNotification/Configration.json
+++ b/documents/static/exposure_configuration/Xamarin.ExposureNotification/Configration.json
@@ -5,8 +5,8 @@
     "DurationWeight": 50,
     "DaysSinceLastExposureWeight": 50,
     "TransmissionRiskScores": [
-        1,
-        7,
+        0,
+        0,
         7,
         7,
         7,

--- a/documents/static/exposure_configuration/configuration.json
+++ b/documents/static/exposure_configuration/configuration.json
@@ -142,8 +142,8 @@
       1
     ],
     "transmission_risk_level_values": [
-      1,
-      7,
+      0,
+      0,
       7,
       7,
       7,

--- a/src/Covid19Radar.Api/V3DiagnosisApi.cs
+++ b/src/Covid19Radar.Api/V3DiagnosisApi.cs
@@ -27,7 +27,7 @@ namespace Covid19Radar.Api
 {
     public class V3DiagnosisApi
     {
-        private const int TRANSMISSION_RISK_LEVEL_INVALID = 0;
+        private const int TRANSMISSION_RISK_LEVEL_LOWEST = 1;
         private const int TRANSMISSION_RISK_LEVEL_MEDIUM = 4;
 
         private const string CHAFF_HEADER = "X-Chaff";
@@ -79,7 +79,7 @@ namespace Covid19Radar.Api
             // Make compatible with Legacy-V1 mode.
             foreach (var key in submissionParameter.Keys)
             {
-                var transmissionRiskLevel = TRANSMISSION_RISK_LEVEL_INVALID;
+                var transmissionRiskLevel = TRANSMISSION_RISK_LEVEL_LOWEST;
                 if (key.DaysSinceOnsetOfSymptoms >= Constants.DaysHasInfectiousness)
                 {
                     transmissionRiskLevel = TRANSMISSION_RISK_LEVEL_MEDIUM;


### PR DESCRIPTION
## Issue 番号 / Issue ID

- #792

## 目的 / Purpose

- COCOA1で送信していなかった期間の診断キーのTransmissionRiskLevelにLower(`1`)を設定する。

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

<!--
  当てはまるもの 1 つに「x」とマークしてください。
  Mark one with an "x".
-->

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

サーバー側の変更は2行だけど、なんと言っても診断キーに関わることなので、TEKの登録からProtocolBuffersの生成（TransmissionLevelが期待通り設定されているか）まで試してみる。

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
