### PR TITLE
Fix an issue that progressdialog never dismiss.

### DIFF
--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
@@ -224,7 +224,6 @@ namespace Covid19Radar.ViewModels
                     await NavigationService.NavigateAsync(Destination.HomePage.ToPath());
 
                     loggerService.Error($"Exceeded the number of trials.");
-                    loggerService.EndMethod();
                     return;
                 }
 
@@ -254,6 +253,7 @@ namespace Covid19Radar.ViewModels
                     );
                     errorCount++;
                     loggerService.Error($"No diagnostic number entered.");
+                    UserDialogs.Instance.HideLoading();
                     return;
                 }
 
@@ -266,6 +266,7 @@ namespace Covid19Radar.ViewModels
                     );
                     errorCount++;
                     loggerService.Error($"Incorrect process number format.");
+                    UserDialogs.Instance.HideLoading();
                     return;
                 }
 
@@ -282,6 +283,7 @@ namespace Covid19Radar.ViewModels
                     await NavigationService.NavigateAsync("/" + nameof(MenuPage) + "/" + nameof(NavigationPage) + "/" + nameof(HomePage));
 
                     loggerService.Warning($"Exposure notification is disable.");
+                    UserDialogs.Instance.HideLoading();
                     return;
                 }
 


### PR DESCRIPTION
## Issue 番号 / Issue ID

- Close #801

## 目的 / Purpose

- 陽性情報登録の時に書式チェックに引っかかるとプログレスダイアログが消えない不具合を修正

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

<!--
  当てはまるもの 1 つに「x」とマークしてください。
  Mark one with an "x".
-->

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

-

## その他 / Other information

iOS版で処理番号に無理矢理書式外の文字をコピペしないと発生しない不具合だけど、念のため。