### PR TITLE
Fix an issue that DatePicker hard to see.

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/Resources/values/styles.xml
+++ b/Covid19Radar/Covid19Radar.Android/Resources/values/styles.xml
@@ -44,5 +44,7 @@
   </style>
   <style name="AppCompatDialogStyle" parent="Theme.AppCompat.Light.Dialog">
     <item name="colorAccent">@color/colorAccent</item>
+    <item name="android:colorAccent">@color/colorAccent</item>
+    <item name="android:colorControlActivated">@color/colorAccent</item>
   </style>
 </resources>

--- a/Covid19Radar/Covid19Radar/Views/HomePage/NotifyOtherPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/NotifyOtherPage.xaml
@@ -16,7 +16,7 @@
     ios:Page.UseSafeArea="true"
     prism:ViewModelLocator.AutowireViewModel="True"
     Style="{StaticResource DefaultPageStyle}"
-    Visual="Material">
+    >
     <!--
         Workaround for fixing ScrollView truncates items issue.
         https://github.com/xamarin/Xamarin.Forms/issues/13597
@@ -37,7 +37,11 @@
                 Margin="0, 0, 0, 10"
                 Style="{StaticResource DefaultLabelSmall}"
                 Text="{x:Static resources:AppResources.NotifyOtherPageDescription2}" />
-            <StackLayout Orientation="Horizontal" Spacing="30">
+            <StackLayout
+                Orientation="Horizontal"
+                Spacing="30"
+                Visual="Material"
+                >
                 <RadioButton
                     AutomationProperties.IsInAccessibleTree="True"
                     TabIndex="3"
@@ -72,7 +76,7 @@
                         HorizontalOptions="FillAndExpand">
                         <Frame
                             Margin="3"
-                            Padding="0"
+                            Padding="5"
                             BackgroundColor="White"
                             CornerRadius="5"
                             HasShadow="False">
@@ -104,7 +108,7 @@
                         HorizontalOptions="FillAndExpand">
                         <Frame
                             Margin="3"
-                            Padding="0"
+                            Padding="5"
                             BackgroundColor="White"
                             CornerRadius="5"
                             HasShadow="False">
@@ -158,7 +162,11 @@
                     </FormattedString>
                 </Label.FormattedText>
             </Label>
-            <StackLayout Spacing="0" Margin="0, 5, 0, 0">
+            <StackLayout
+                Spacing="0"
+                Margin="0, 5, 0, 0"
+                Visual="Material"
+                >
                 <Frame
                     Margin="3"
                     Padding="0"


### PR DESCRIPTION
## Issue 番号 / Issue ID

- Close #803

## 目的 / Purpose

- DatePickerの色が見にくい不具合を修正した

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

 - v1.4.1まではDatePickerの色は黒色だったが、Styleの指定は濃い青色だった。ここでは本来のStyle指定を優先した。

![Screen Shot 2022-01-23 at 22 58 25](https://user-images.githubusercontent.com/932136/150682311-f07c5daf-cec7-4c36-ab75-04964294c873.png)

![Screen Shot 2022-01-23 at 22 58 21](https://user-images.githubusercontent.com/932136/150682317-67f97bad-ecf9-4a26-ad6f-0fcdeb251d97.png)



## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
