### PR TITLE
Fix an issue that background task unexpected behavior on iOS.

### DIFF
--- a/Covid19Radar/Covid19Radar.iOS/Info.plist
+++ b/Covid19Radar/Covid19Radar.iOS/Info.plist
@@ -54,7 +54,6 @@
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>APP_PACKAGE_NAME.exposure-notification</string>
-		<string>APP_PACKAGE_NAME.exposure-detection</string>
 		<string>APP_PACKAGE_NAME.delete-old-logs</string>
 	</array>
 	<key>UIAppFonts</key>

--- a/Covid19Radar/Covid19Radar.iOS/Services/ExposureDetectionBackgroundService.cs
+++ b/Covid19Radar/Covid19Radar.iOS/Services/ExposureDetectionBackgroundService.cs
@@ -3,12 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BackgroundTasks;
-using Chino;
 using Covid19Radar.Common;
 using Covid19Radar.Repository;
 using Covid19Radar.Services;
@@ -20,12 +17,16 @@ namespace Covid19Radar.iOS.Services
 {
     public class ExposureDetectionBackgroundService : AbsExposureDetectionBackgroundService
     {
-        private static string BGTASK_IDENTIFIER => AppInfo.PackageName + ".exposure-detection";
-
-        private const int TIMEOUT_IN_MILLIS = 60 * 60 * 1000;
+        /*
+         * [IMPORTANT]
+         * From README.md( https://developer.apple.com/documentation/exposurenotification/building_an_app_to_notify_users_of_covid-19_exposure )
+         *
+         * The Background Task framework automatically detects apps that contain the Exposure Notification entitlement and a background task that ends in `exposure-notification`.
+         * The operating system automatically launches these apps when they aren't running and guarantees them more background time to ensure that the app can test and report results promptly.
+         */
+        private static string BGTASK_IDENTIFIER => AppInfo.PackageName + ".exposure-notification";
 
         private readonly ILoggerService _loggerService;
-
 
         public ExposureDetectionBackgroundService(
             IDiagnosisKeyRepository diagnosisKeyRepository,


### PR DESCRIPTION
## Issue 番号 / Issue ID

- #807 
- #799 ? ← 連続してバックグラウンドタスク実行するから怒られて落ちてるとかだったら関係ありそう

## 目的 / Purpose

- `BGTASK_IDENTIFIER` を末尾 `.exposure-notification` のものに置き換え

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

https://developer.apple.com/documentation/exposurenotification/building_an_app_to_notify_users_of_covid-19_exposure
の README.md曰く

> The Background Task framework automatically detects apps that contain the Exposure Notification entitlement and a background task that ends in `exposure-notification`.
> The operating system automatically launches these apps when they aren't running and guarantees them more background time to ensure that the app can test and report results promptly.

接触確認を行うバックグルアンドタスクは `exposure-notification` で終わらなければならないとある。

しかし、ぼくがAndroidのWorkerIdに合わせておこうと変なオリジナリティを発揮して変更してしまったので、システムの管理下から外れてしまった。実行間隔が想定と変わったのは多分これが原因。

ちなみに、もともとのXamarin.ExposureNotificationにも特別な接尾辞であることが書いてある（重要なことならローカル変数に置かないでクラスの頭に書いておいて欲しい……！）

https://github.com/cocoa-mhlw/cocoa/blob/6453b8eb1939f6bd2c522b40e07e044edc873b3b/Covid19Radar/Xamarin.ExposureNotification/ExposureNotification.ios.cs#L87-L97

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
