### PR TITLE
Fix an issue that V1DiagnosisApi doesn't work.

### DIFF
--- a/Covid19Radar/Covid19Radar/Common/DeviceVerifierUtils.cs
+++ b/Covid19Radar/Covid19Radar/Common/DeviceVerifierUtils.cs
@@ -12,7 +12,7 @@ namespace Covid19Radar.Common
 {
     public static class DeviceVerifierUtils
     {
-        #region V3DiagnosisApi
+        #region V3DiagnosisApi v2.0.0 -
         public static byte[] CreateAndroidNonceV3(DiagnosisSubmissionParameter submission)
         {
             var cleartext = GetNonceClearTextV3(submission);
@@ -54,7 +54,7 @@ namespace Covid19Radar.Common
 
         #endregion
 
-        #region V1/V2DiagnosisApi
+        #region V2DiagnosisApi v1.2.2 - v1.4.1
 
         // For checking compatibility with server API, do not remove this method.
         public static byte[] CreateAndroidNonceV2(DiagnosisSubmissionParameter submission)
@@ -73,6 +73,31 @@ namespace Covid19Radar.Common
 
             static string GetKeyStringCore(DiagnosisSubmissionParameter.Key k) =>
                 string.Join(".", k.KeyData, k.RollingStartNumber, k.RollingPeriod);
+
+            static string GetRegionString(IEnumerable<string> regions) =>
+                string.Join(",", regions.Select(r => r.ToUpperInvariant()).OrderBy(r => r));
+        }
+        #endregion
+
+        #region V1DiagnosisApi version v1.0.0 - v1.2.1
+
+        // For checking compatibility with server API, do not remove this method.
+        public static byte[] CreateAndroidNonceV1(DiagnosisSubmissionParameter submission)
+        {
+            var cleartext = GetNonceClearTextV1(submission);
+            var nonce = GetSha256(cleartext);
+            return nonce;
+        }
+
+        public static string GetNonceClearTextV1(DiagnosisSubmissionParameter submission)
+        {
+            return string.Join("|", submission.AppPackageName, GetKeyString(submission.Keys), GetRegionString(submission.Regions), submission.VerificationPayload);
+
+            static string GetKeyString(IEnumerable<DiagnosisSubmissionParameter.Key> keys) =>
+                string.Join(",", keys.OrderBy(k => k.KeyData).Select(k => GetKeyStringCore(k)));
+
+            static string GetKeyStringCore(DiagnosisSubmissionParameter.Key k) =>
+                string.Join(".", k.KeyData, k.RollingStartNumber, 0 /* TransmissionRisk was always 0. */);
 
             static string GetRegionString(IEnumerable<string> regions) =>
                 string.Join(",", regions.Select(r => r.ToUpperInvariant()).OrderBy(r => r));

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Common/DeviceVerifierUtilsTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Common/DeviceVerifierUtilsTests.cs
@@ -14,6 +14,7 @@ namespace Covid19Radar.UnitTests.Common
 {
     public class DeviceVerifierUtilsDiagnosisSubmissionParametersTests
     {
+        private const string EXPECTED_CLEAR_TEXT_V1 = "jp.go.mhlw.cocoa.unit_test|S2V5RGF0YTE=.10000.0,S2V5RGF0YTI=.20000.0,S2V5RGF0YTM=.30000.0,S2V5RGF0YTQ=.40000.0,S2V5RGF0YTU=.50000.0|440,441|VerificationPayload THIS STRING IS MEANINGLESS";
         private const string EXPECTED_CLEAR_TEXT_V2 = "jp.go.mhlw.cocoa.unit_test|S2V5RGF0YTE=.10000.140,S2V5RGF0YTI=.20000.141,S2V5RGF0YTM=.30000.142,S2V5RGF0YTQ=.40000.143,S2V5RGF0YTU=.50000.70|440,441|VerificationPayload THIS STRING IS MEANINGLESS";
         private const string EXPECTED_CLEAR_TEXT_V3 = "2021-12-19T19:02:00.000+09:00|jp.go.mhlw.cocoa.unit_test|S2V5RGF0YTE=.10000.140.1,S2V5RGF0YTI=.20000.141.1,S2V5RGF0YTM=.30000.142.1,S2V5RGF0YTQ=.40000.143.1,S2V5RGF0YTU=.50000.70.1|440,441|VerificationPayload THIS STRING IS MEANINGLESS";
 
@@ -34,6 +35,49 @@ namespace Covid19Radar.UnitTests.Common
                 RollingPeriod = (uint)rollingPeriod,
                 ReportType = (uint)reportType
             };
+        }
+
+        [Fact]
+        public void AndroidClearTextTestV1()
+        {
+            var platform = "Android";
+            var dummyDiagnosisKeyDataList = new[] {
+                CreateDiagnosisKey("KeyData1", 10000, 140, 1),
+                CreateDiagnosisKey("KeyData2", 20000, 141, 1),
+                CreateDiagnosisKey("KeyData3", 30000, 142, 1),
+                CreateDiagnosisKey("KeyData4", 40000, 143, 1),
+                CreateDiagnosisKey("KeyData5", 50000, 70, 1),
+            };
+
+            var dummyRegions = new string[]
+            {
+                "440",
+                "441",
+            };
+
+            var dummyDeviceVerificationPayload = "DeviceVerificationPayload THIS STRING IS MEANINGLESS";
+            var dummyAppPackageName = "jp.go.mhlw.cocoa.unit_test";
+            var dummyVerificationPayload = "VerificationPayload THIS STRING IS MEANINGLESS";
+
+            // This value will not affect any result.
+            var dummyPadding = new Random().Next().ToString();
+
+            var submissionParameter = new DiagnosisSubmissionParameter()
+            {
+                Platform = platform,
+                Regions = dummyRegions,
+                Keys = dummyDiagnosisKeyDataList,
+                DeviceVerificationPayload = dummyDeviceVerificationPayload,
+                AppPackageName = dummyAppPackageName,
+                VerificationPayload = dummyVerificationPayload,
+                Padding = dummyPadding,
+            };
+
+            string clearText = DeviceVerifierUtils.GetNonceClearTextV1(submissionParameter);
+            Assert.Equal(
+                EXPECTED_CLEAR_TEXT_V1,
+                clearText
+                );
         }
 
         [Fact]

--- a/src/Covid19Radar.Api.Tests/Models/V1DiagnosisSubmissionParameterTest.cs
+++ b/src/Covid19Radar.Api.Tests/Models/V1DiagnosisSubmissionParameterTest.cs
@@ -14,8 +14,8 @@ namespace Covid19Radar.Api.Tests.Models
     [TestCategory("Models")]
     public class V1DiagnosisSubmissionParameterTest
     {
-        private const string EXPECTED_CLEAR_TEXT_V1 = "jp.go.mhlw.cocoa.unit_test|S2V5RGF0YTE=.10000.4,S2V5RGF0YTI=.20000.4,S2V5RGF0YTM=.30000.4,S2V5RGF0YTQ=.40000.4,S2V5RGF0YTU=.50000.4|440,441|VerificationPayload THIS STRING IS MEANINGLESS";
-        private const string EXPECTED_TRANSACTION_ID_SEED_V1 = "jp.go.mhlw.cocoa.unit_testS2V5RGF0YTE=.10000.4,S2V5RGF0YTI=.20000.4,S2V5RGF0YTM=.30000.4,S2V5RGF0YTQ=.40000.4,S2V5RGF0YTU=.50000.4440,441";
+        private const string EXPECTED_CLEAR_TEXT_V1 = "jp.go.mhlw.cocoa.unit_test|S2V5RGF0YTE=.10000.0,S2V5RGF0YTI=.20000.0,S2V5RGF0YTM=.30000.0,S2V5RGF0YTQ=.40000.0,S2V5RGF0YTU=.50000.0|440,441|VerificationPayload THIS STRING IS MEANINGLESS";
+        private const string EXPECTED_TRANSACTION_ID_SEED_V1 = "jp.go.mhlw.cocoa.unit_testS2V5RGF0YTE=.10000.0,S2V5RGF0YTI=.20000.0,S2V5RGF0YTM=.30000.0,S2V5RGF0YTQ=.40000.0,S2V5RGF0YTU=.50000.0440,441";
 
         private const string EXPECTED_CLEAR_TEXT_V1_NO_KEY = "jp.go.mhlw.cocoa.unit_test||440,441|VerificationPayload THIS STRING IS MEANINGLESS";
         private const string EXPECTED_TRANSACTION_ID_SEED_V1_NO_KEY = "jp.go.mhlw.cocoa.unit_test440,441";
@@ -69,7 +69,7 @@ namespace Covid19Radar.Api.Tests.Models
                 KeyData = keyDataBase64,
                 RollingStartNumber = (uint)rollingStartNumber,
                 RollingPeriod = (uint)rollingPeriod,
-                TransmissionRisk = 4,
+                TransmissionRisk = 0,
             };
         }
 

--- a/src/Covid19Radar.Api.Tests/Models/V1DiagnosisSubmissionParameterTest.cs
+++ b/src/Covid19Radar.Api.Tests/Models/V1DiagnosisSubmissionParameterTest.cs
@@ -14,6 +14,12 @@ namespace Covid19Radar.Api.Tests.Models
     [TestCategory("Models")]
     public class V1DiagnosisSubmissionParameterTest
     {
+        private const string EXPECTED_CLEAR_TEXT_V1 = "jp.go.mhlw.cocoa.unit_test|S2V5RGF0YTE=.10000.4,S2V5RGF0YTI=.20000.4,S2V5RGF0YTM=.30000.4,S2V5RGF0YTQ=.40000.4,S2V5RGF0YTU=.50000.4|440,441|VerificationPayload THIS STRING IS MEANINGLESS";
+        private const string EXPECTED_TRANSACTION_ID_SEED_V1 = "jp.go.mhlw.cocoa.unit_testS2V5RGF0YTE=.10000.4,S2V5RGF0YTI=.20000.4,S2V5RGF0YTM=.30000.4,S2V5RGF0YTQ=.40000.4,S2V5RGF0YTU=.50000.4440,441";
+
+        private const string EXPECTED_CLEAR_TEXT_V1_NO_KEY = "jp.go.mhlw.cocoa.unit_test||440,441|VerificationPayload THIS STRING IS MEANINGLESS";
+        private const string EXPECTED_TRANSACTION_ID_SEED_V1_NO_KEY = "jp.go.mhlw.cocoa.unit_test440,441";
+
         [TestMethod]
         public void CreateMethod()
         {
@@ -53,5 +59,149 @@ namespace Covid19Radar.Api.Tests.Models
             Assert.AreEqual(start, item.RollingStartIntervalNumber);
         }
 
+        private static V1DiagnosisSubmissionParameter.Key CreateDiagnosisKey(string keyData, int rollingStartNumber, int rollingPeriod)
+        {
+            var keyDataBytes = Encoding.UTF8.GetBytes(keyData);
+            var keyDataBase64 = Convert.ToBase64String(keyDataBytes);
+
+            return new V1DiagnosisSubmissionParameter.Key()
+            {
+                KeyData = keyDataBase64,
+                RollingStartNumber = (uint)rollingStartNumber,
+                RollingPeriod = (uint)rollingPeriod,
+                TransmissionRisk = 4,
+            };
+        }
+
+        [TestMethod]
+        public void DeviceVerificationTest2()
+        {
+            var platform = "Android";
+            V1DiagnosisSubmissionParameter.Key[] dummyDiagnosisKeyDataList = new V1DiagnosisSubmissionParameter.Key[] {
+                CreateDiagnosisKey("KeyData1", 10000, 140 ),
+                CreateDiagnosisKey("KeyData2", 20000, 141 ),
+                CreateDiagnosisKey("KeyData3", 30000, 142 ),
+                CreateDiagnosisKey("KeyData4", 40000, 143 ),
+                CreateDiagnosisKey("KeyData5", 50000, 70 ),
+            };
+
+            var dummyRegions = new string[]
+            {
+                "440",
+                "441",
+            };
+
+            var dummyDeviceVerificationPayload = "DeviceVerificationPayload THIS STRING IS MEANINGLESS";
+            var dummyAppPackageName = "jp.go.mhlw.cocoa.unit_test";
+            var dummyVerificationPayload = "VerificationPayload THIS STRING IS MEANINGLESS";
+
+            // This value will not affect any result.
+            var dummyPadding = new Random().Next().ToString();
+
+            // preparation
+            var model = new V1DiagnosisSubmissionParameter()
+            {
+                Platform = platform,
+                Regions = dummyRegions,
+                Keys = dummyDiagnosisKeyDataList,
+                DeviceVerificationPayload = dummyDeviceVerificationPayload,
+                AppPackageName = dummyAppPackageName,
+                VerificationPayload = dummyVerificationPayload,
+                Padding = dummyPadding,
+            };
+
+            Assert.AreEqual(dummyDeviceVerificationPayload, model.JwsPayload);
+            Assert.AreEqual(
+                EXPECTED_CLEAR_TEXT_V1,
+                model.ClearText
+                );
+
+            Assert.AreEqual(dummyDeviceVerificationPayload, model.DeviceToken);
+            Assert.AreEqual(
+                EXPECTED_TRANSACTION_ID_SEED_V1,
+                model.TransactionIdSeed
+                );
+        }
+
+        [TestMethod]
+        public void DeviceVerificationTest_NoKey()
+        {
+            var platform = "Android";
+            V1DiagnosisSubmissionParameter.Key[] dummyDiagnosisKeyDataList = new V1DiagnosisSubmissionParameter.Key[] {
+            };
+            var dummyRegions = new string[]
+            {
+                "440",
+                "441",
+            };
+            var dummyDeviceVerificationPayload = "DeviceVerificationPayload THIS STRING IS MEANINGLESS";
+            var dummyAppPackageName = "jp.go.mhlw.cocoa.unit_test";
+            var dummyVerificationPayload = "VerificationPayload THIS STRING IS MEANINGLESS";
+
+            // This value will not affect any result.
+            var dummyPadding = new Random().Next().ToString();
+
+            // preparation
+            var model = new V1DiagnosisSubmissionParameter()
+            {
+                Platform = platform,
+                Regions = dummyRegions,
+                Keys = dummyDiagnosisKeyDataList,
+                DeviceVerificationPayload = dummyDeviceVerificationPayload,
+                AppPackageName = dummyAppPackageName,
+                VerificationPayload = dummyVerificationPayload,
+                Padding = dummyPadding,
+            };
+
+            Assert.AreEqual(dummyDeviceVerificationPayload, model.JwsPayload);
+            Assert.AreEqual(
+                EXPECTED_CLEAR_TEXT_V1_NO_KEY,
+                model.ClearText);
+
+            Assert.AreEqual(dummyDeviceVerificationPayload, model.DeviceToken);
+            Assert.AreEqual(
+                EXPECTED_TRANSACTION_ID_SEED_V1_NO_KEY,
+                model.TransactionIdSeed);
+        }
+
+        [TestMethod]
+        public void DeviceVerificationTest_NullKey()
+        {
+            var platform = "Android";
+            V1DiagnosisSubmissionParameter.Key[] dummyDiagnosisKeyDataList = null;
+            var dummyRegions = new string[]
+            {
+                "440",
+                "441",
+            };
+            var dummyDeviceVerificationPayload = "DeviceVerificationPayload THIS STRING IS MEANINGLESS";
+            var dummyAppPackageName = "jp.go.mhlw.cocoa.unit_test";
+            var dummyVerificationPayload = "VerificationPayload THIS STRING IS MEANINGLESS";
+
+            // This value will not affect any result.
+            var dummyPadding = new Random().Next().ToString();
+
+            // preparation
+            var model = new V1DiagnosisSubmissionParameter()
+            {
+                Platform = platform,
+                Regions = dummyRegions,
+                Keys = dummyDiagnosisKeyDataList,
+                DeviceVerificationPayload = dummyDeviceVerificationPayload,
+                AppPackageName = dummyAppPackageName,
+                VerificationPayload = dummyVerificationPayload,
+                Padding = dummyPadding,
+            };
+
+            Assert.AreEqual(dummyDeviceVerificationPayload, model.JwsPayload);
+            Assert.AreEqual(
+                EXPECTED_CLEAR_TEXT_V1_NO_KEY,
+                model.ClearText);
+
+            Assert.AreEqual(dummyDeviceVerificationPayload, model.DeviceToken);
+            Assert.AreEqual(
+                EXPECTED_TRANSACTION_ID_SEED_V1_NO_KEY,
+                model.TransactionIdSeed);
+        }
     }
 }

--- a/src/Covid19Radar.Api.Tests/Models/V2DiagnosisSubmissionParameterTest.cs
+++ b/src/Covid19Radar.Api.Tests/Models/V2DiagnosisSubmissionParameterTest.cs
@@ -17,6 +17,9 @@ namespace Covid19Radar.Api.Tests.Models
         private const string EXPECTED_CLEAR_TEXT_V2 = "jp.go.mhlw.cocoa.unit_test|S2V5RGF0YTE=.10000.140,S2V5RGF0YTI=.20000.141,S2V5RGF0YTM=.30000.142,S2V5RGF0YTQ=.40000.143,S2V5RGF0YTU=.50000.70|440,441|VerificationPayload THIS STRING IS MEANINGLESS";
         private const string EXPECTED_TRANSACTION_ID_SEED_V2 = "jp.go.mhlw.cocoa.unit_testS2V5RGF0YTE=.10000.140,S2V5RGF0YTI=.20000.141,S2V5RGF0YTM=.30000.142,S2V5RGF0YTQ=.40000.143,S2V5RGF0YTU=.50000.70440,441";
 
+        private const string EXPECTED_CLEAR_TEXT_V2_NO_KEY = "jp.go.mhlw.cocoa.unit_test||440,441|VerificationPayload THIS STRING IS MEANINGLESS";
+        private const string EXPECTED_TRANSACTION_ID_SEED_V2_NO_KEY = "jp.go.mhlw.cocoa.unit_test440,441";
+
         [TestMethod]
         public void CreateMethod()
         {
@@ -108,6 +111,87 @@ namespace Covid19Radar.Api.Tests.Models
             Assert.AreEqual(dummyDeviceVerificationPayload, model.DeviceToken);
             Assert.AreEqual(
                 EXPECTED_TRANSACTION_ID_SEED_V2,
+                model.TransactionIdSeed);
+        }
+
+        [TestMethod]
+        public void DeviceVerificationTest_NoKey()
+        {
+            var platform = "Android";
+            V2DiagnosisSubmissionParameter.Key[] dummyDiagnosisKeyDataList = new V2DiagnosisSubmissionParameter.Key[] {
+            };
+            var dummyRegions = new string[]
+            {
+                "440",
+                "441",
+            };
+            var dummyDeviceVerificationPayload = "DeviceVerificationPayload THIS STRING IS MEANINGLESS";
+            var dummyAppPackageName = "jp.go.mhlw.cocoa.unit_test";
+            var dummyVerificationPayload = "VerificationPayload THIS STRING IS MEANINGLESS";
+
+            // This value will not affect any result.
+            var dummyPadding = new Random().Next().ToString();
+
+            // preparation
+            var model = new V2DiagnosisSubmissionParameter()
+            {
+                Platform = platform,
+                Regions = dummyRegions,
+                Keys = dummyDiagnosisKeyDataList,
+                DeviceVerificationPayload = dummyDeviceVerificationPayload,
+                AppPackageName = dummyAppPackageName,
+                VerificationPayload = dummyVerificationPayload,
+                Padding = dummyPadding,
+            };
+
+            Assert.AreEqual(dummyDeviceVerificationPayload, model.JwsPayload);
+            Assert.AreEqual(
+                EXPECTED_CLEAR_TEXT_V2_NO_KEY,
+                model.ClearText);
+
+            Assert.AreEqual(dummyDeviceVerificationPayload, model.DeviceToken);
+            Assert.AreEqual(
+                EXPECTED_TRANSACTION_ID_SEED_V2_NO_KEY,
+                model.TransactionIdSeed);
+        }
+
+        [TestMethod]
+        public void DeviceVerificationTest_NullKey()
+        {
+            var platform = "Android";
+            V2DiagnosisSubmissionParameter.Key[] dummyDiagnosisKeyDataList = null;
+            var dummyRegions = new string[]
+            {
+                "440",
+                "441",
+            };
+            var dummyDeviceVerificationPayload = "DeviceVerificationPayload THIS STRING IS MEANINGLESS";
+            var dummyAppPackageName = "jp.go.mhlw.cocoa.unit_test";
+            var dummyVerificationPayload = "VerificationPayload THIS STRING IS MEANINGLESS";
+
+            // This value will not affect any result.
+            var dummyPadding = new Random().Next().ToString();
+
+            // preparation
+            var model = new V2DiagnosisSubmissionParameter()
+            {
+                Platform = platform,
+                Regions = dummyRegions,
+                Keys = dummyDiagnosisKeyDataList,
+                DeviceVerificationPayload = dummyDeviceVerificationPayload,
+                AppPackageName = dummyAppPackageName,
+                VerificationPayload = dummyVerificationPayload,
+                Padding = dummyPadding,
+            };
+
+            Assert.AreEqual(dummyDeviceVerificationPayload, model.JwsPayload);
+            Assert.AreEqual(
+                EXPECTED_CLEAR_TEXT_V2_NO_KEY,
+                model.ClearText);
+
+            Assert.AreEqual(dummyDeviceVerificationPayload, model.DeviceToken);
+            Assert.AreEqual(
+                EXPECTED_TRANSACTION_ID_SEED_V2_NO_KEY,
                 model.TransactionIdSeed);
         }
     }

--- a/src/Covid19Radar.Api.Tests/Models/V3DiagnosisSubmissionParameterTest.cs
+++ b/src/Covid19Radar.Api.Tests/Models/V3DiagnosisSubmissionParameterTest.cs
@@ -17,6 +17,9 @@ namespace Covid19Radar.Api.Tests.Models
         private const string EXPECTED_CLEAR_TEXT_V3 = "2021-12-19T19:02:00.000+09:00|jp.go.mhlw.cocoa.unit_test|S2V5RGF0YTE=.10000.140.1,S2V5RGF0YTI=.20000.141.1,S2V5RGF0YTM=.30000.142.1,S2V5RGF0YTQ=.40000.143.1,S2V5RGF0YTU=.50000.70.1|440,441|VerificationPayload THIS STRING IS MEANINGLESS";
         private const string EXPECTED_TRANSACTION_ID_SEED_V3 = "2021-12-19T19:02:00.000+09:00jp.go.mhlw.cocoa.unit_testS2V5RGF0YTE=.10000.140.1,S2V5RGF0YTI=.20000.141.1,S2V5RGF0YTM=.30000.142.1,S2V5RGF0YTQ=.40000.143.1,S2V5RGF0YTU=.50000.70.1440,441";
 
+        private const string EXPECTED_CLEAR_TEXT_V3_NO_KEY = "2021-12-19T19:02:00.000+09:00|jp.go.mhlw.cocoa.unit_test||440,441|VerificationPayload THIS STRING IS MEANINGLESS";
+        private const string EXPECTED_TRANSACTION_ID_SEED_V3_NO_KEY = "2021-12-19T19:02:00.000+09:00jp.go.mhlw.cocoa.unit_test440,441";
+
         [TestMethod]
         public void CreateMethod()
         {
@@ -133,6 +136,99 @@ namespace Covid19Radar.Api.Tests.Models
             Assert.AreEqual(dummyDeviceVerificationPayload, model.DeviceToken);
             Assert.AreEqual(
                 EXPECTED_TRANSACTION_ID_SEED_V3,
+                model.TransactionIdSeed
+                );
+        }
+
+        [TestMethod]
+        public void DeviceVerificationTest_NoKey()
+        {
+            var platform = "Android";
+            V3DiagnosisSubmissionParameter.Key[] dummyDiagnosisKeyDataList = new V3DiagnosisSubmissionParameter.Key[]{
+            };
+
+            var dummyRegions = new string[]
+            {
+                "440",
+                "441",
+            };
+            var dummySymptomOnsetDate = "2021-12-19T19:02:00.000+09:00";
+
+            var dummyDeviceVerificationPayload = "DeviceVerificationPayload THIS STRING IS MEANINGLESS";
+            var dummyAppPackageName = "jp.go.mhlw.cocoa.unit_test";
+            var dummyVerificationPayload = "VerificationPayload THIS STRING IS MEANINGLESS";
+
+            // This value will not affect any result.
+            var dummyPadding = new Random().Next().ToString();
+
+            // preparation
+            var model = new V3DiagnosisSubmissionParameter()
+            {
+                Platform = platform,
+                Regions = dummyRegions,
+                SymptomOnsetDate = dummySymptomOnsetDate,
+                Keys = dummyDiagnosisKeyDataList,
+                DeviceVerificationPayload = dummyDeviceVerificationPayload,
+                AppPackageName = dummyAppPackageName,
+                VerificationPayload = dummyVerificationPayload,
+                Padding = dummyPadding,
+            };
+
+            Assert.AreEqual(dummyDeviceVerificationPayload, model.JwsPayload);
+            Assert.AreEqual(
+                EXPECTED_CLEAR_TEXT_V3_NO_KEY,
+                model.ClearText
+                );
+
+            Assert.AreEqual(dummyDeviceVerificationPayload, model.DeviceToken);
+            Assert.AreEqual(
+                EXPECTED_TRANSACTION_ID_SEED_V3_NO_KEY,
+                model.TransactionIdSeed
+                );
+        }
+
+        [TestMethod]
+        public void DeviceVerificationTestKeysNull()
+        {
+            var platform = "Android";
+            V3DiagnosisSubmissionParameter.Key[] dummyDiagnosisKeyDataList = null;
+
+            var dummyRegions = new string[]
+            {
+                "440",
+                "441",
+            };
+            var dummySymptomOnsetDate = "2021-12-19T19:02:00.000+09:00";
+
+            var dummyDeviceVerificationPayload = "DeviceVerificationPayload THIS STRING IS MEANINGLESS";
+            var dummyAppPackageName = "jp.go.mhlw.cocoa.unit_test";
+            var dummyVerificationPayload = "VerificationPayload THIS STRING IS MEANINGLESS";
+
+            // This value will not affect any result.
+            var dummyPadding = new Random().Next().ToString();
+
+            // preparation
+            var model = new V3DiagnosisSubmissionParameter()
+            {
+                Platform = platform,
+                Regions = dummyRegions,
+                SymptomOnsetDate = dummySymptomOnsetDate,
+                Keys = dummyDiagnosisKeyDataList,
+                DeviceVerificationPayload = dummyDeviceVerificationPayload,
+                AppPackageName = dummyAppPackageName,
+                VerificationPayload = dummyVerificationPayload,
+                Padding = dummyPadding,
+            };
+
+            Assert.AreEqual(dummyDeviceVerificationPayload, model.JwsPayload);
+            Assert.AreEqual(
+                EXPECTED_CLEAR_TEXT_V3_NO_KEY,
+                model.ClearText
+                );
+
+            Assert.AreEqual(dummyDeviceVerificationPayload, model.DeviceToken);
+            Assert.AreEqual(
+                EXPECTED_TRANSACTION_ID_SEED_V3_NO_KEY,
                 model.TransactionIdSeed
                 );
         }

--- a/src/Covid19Radar.Api/Models/V1DiagnosisSubmissionParameter.cs
+++ b/src/Covid19Radar.Api/Models/V1DiagnosisSubmissionParameter.cs
@@ -9,92 +9,92 @@ using System.Linq;
 
 namespace Covid19Radar.Api.Models
 {
-	public class V1DiagnosisSubmissionParameter : V2DiagnosisSubmissionParameter, IUser
-	{
-		[JsonProperty("userUuid")]
-		public string UserUuid { get; set; }
+    public class V1DiagnosisSubmissionParameter : V2DiagnosisSubmissionParameter, IUser
+    {
+        [JsonProperty("userUuid")]
+        public string UserUuid { get; set; }
 
-		[JsonProperty("keys")]
-		public new Key[] Keys { get; set; }
+        [JsonProperty("keys")]
+        public new Key[] Keys { get; set; }
 
-		[JsonIgnore]
-		public override string KeysTextForDeviceVerification
+        [JsonIgnore]
+        public override string KeysTextForDeviceVerification
         {
-			get
-			{
-				if (Keys is null)
-				{
-					return string.Empty;
-				}
-				return string.Join(",", Keys.OrderBy(k => k.KeyData).Select(k => k.GetKeyString()));
-			}
-		}
+            get
+            {
+                if (Keys is null)
+                {
+                    return string.Empty;
+                }
+                return string.Join(",", Keys.OrderBy(k => k.KeyData).Select(k => k.GetKeyString()));
+            }
+        }
 
-		#region Apple Device Check
+        #region Apple Device Check
 
-		[JsonIgnore]
-		public override string DeviceToken
-			=> DeviceVerificationPayload;
+        [JsonIgnore]
+        public override string DeviceToken
+            => DeviceVerificationPayload;
 
-		[JsonIgnore]
-		public override string TransactionIdSeed
-			=> AppPackageName
-				+ KeysTextForDeviceVerification
-				+ IAndroidDeviceVerification.GetRegionString(Regions);
+        [JsonIgnore]
+        public override string TransactionIdSeed
+            => AppPackageName
+                + KeysTextForDeviceVerification
+                + IAndroidDeviceVerification.GetRegionString(Regions);
 
-		#endregion
+        #endregion
 
-		public new class Key
-		{
-			[JsonProperty("keyData")]
-			public string KeyData { get; set; }
-			[JsonProperty("rollingStartNumber")]
-			public uint RollingStartNumber { get; set; }
-			[JsonProperty("rollingPeriod")]
-			public uint RollingPeriod { get; set; }
-			[JsonProperty("transmissionRisk")]
-			public int TransmissionRisk { get; set; }
-			public TemporaryExposureKeyModel ToModel(V1DiagnosisSubmissionParameter _, ulong timestamp)
-			{
-				return new TemporaryExposureKeyModel()
-				{
-					KeyData = Convert.FromBase64String(this.KeyData),
-					RollingPeriod = ((int)this.RollingPeriod == 0 ? (int)Constants.ActiveRollingPeriod : (int)this.RollingPeriod),
-					RollingStartIntervalNumber = (int)this.RollingStartNumber,
-					TransmissionRiskLevel = TRANSMISSION_RISK_LEVEL,
-					ReportType = Constants.ReportTypeMissingValue,
-					DaysSinceOnsetOfSymptoms = Constants.DaysSinceOnsetOfSymptomsMissingValue,
-					Timestamp = timestamp,
-					Exported = false
-				};
-			}
-			/// <summary>
-			/// Validation
-			/// </summary>
-			/// <returns>true if valid</returns>
-			public bool IsValid()
-			{
-				if (string.IsNullOrWhiteSpace(KeyData)) return false;
-				if (RollingPeriod != 0 && RollingPeriod > Constants.ActiveRollingPeriod) return false;
-				var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds() / 600;
-				var oldest = new DateTimeOffset(DateTime.UtcNow.AddDays(Constants.OutOfDateDays).Date.Ticks, TimeSpan.Zero).ToUnixTimeSeconds() / 600;
-				if (RollingStartNumber != 0 && (RollingStartNumber < oldest || RollingStartNumber > now)) return false;
-				return true;
-			}
+        public new class Key
+        {
+            [JsonProperty("keyData")]
+            public string KeyData { get; set; }
+            [JsonProperty("rollingStartNumber")]
+            public uint RollingStartNumber { get; set; }
+            [JsonProperty("rollingPeriod")]
+            public uint RollingPeriod { get; set; }
+            [JsonProperty("transmissionRisk")]
+            public int TransmissionRisk { get; set; }
+            public TemporaryExposureKeyModel ToModel(V1DiagnosisSubmissionParameter _, ulong timestamp)
+            {
+                return new TemporaryExposureKeyModel()
+                {
+                    KeyData = Convert.FromBase64String(this.KeyData),
+                    RollingPeriod = ((int)this.RollingPeriod == 0 ? (int)Constants.ActiveRollingPeriod : (int)this.RollingPeriod),
+                    RollingStartIntervalNumber = (int)this.RollingStartNumber,
+                    TransmissionRiskLevel = TRANSMISSION_RISK_LEVEL,
+                    ReportType = Constants.ReportTypeMissingValue,
+                    DaysSinceOnsetOfSymptoms = Constants.DaysSinceOnsetOfSymptomsMissingValue,
+                    Timestamp = timestamp,
+                    Exported = false
+                };
+            }
+            /// <summary>
+            /// Validation
+            /// </summary>
+            /// <returns>true if valid</returns>
+            public bool IsValid()
+            {
+                if (string.IsNullOrWhiteSpace(KeyData)) return false;
+                if (RollingPeriod != 0 && RollingPeriod > Constants.ActiveRollingPeriod) return false;
+                var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds() / 600;
+                var oldest = new DateTimeOffset(DateTime.UtcNow.AddDays(Constants.OutOfDateDays).Date.Ticks, TimeSpan.Zero).ToUnixTimeSeconds() / 600;
+                if (RollingStartNumber != 0 && (RollingStartNumber < oldest || RollingStartNumber > now)) return false;
+                return true;
+            }
 
-			internal string GetKeyString() => string.Join(".", KeyData, RollingStartNumber, TransmissionRisk);
-		}
+            internal string GetKeyString() => string.Join(".", KeyData, RollingStartNumber, TransmissionRisk);
+        }
 
-		public override bool IsValid()
-		{
-			if (string.IsNullOrWhiteSpace(VerificationPayload)) return false;
-			if ((Regions?.Length ?? 0) == 0) return false;
-			if (string.IsNullOrWhiteSpace(Platform)) return false;
-			if (string.IsNullOrWhiteSpace(DeviceVerificationPayload)) return false;
-			if (string.IsNullOrWhiteSpace(AppPackageName)) return false;
-			if (Keys.Any(_ => !_.IsValid())) return false;
-			return true;
-		}
+        public override bool IsValid()
+        {
+            if (string.IsNullOrWhiteSpace(VerificationPayload)) return false;
+            if ((Regions?.Length ?? 0) == 0) return false;
+            if (string.IsNullOrWhiteSpace(Platform)) return false;
+            if (string.IsNullOrWhiteSpace(DeviceVerificationPayload)) return false;
+            if (string.IsNullOrWhiteSpace(AppPackageName)) return false;
+            if (Keys.Any(_ => !_.IsValid())) return false;
+            return true;
+        }
 
-	}
+    }
 }

--- a/src/Covid19Radar.Api/Models/V1DiagnosisSubmissionParameter.cs
+++ b/src/Covid19Radar.Api/Models/V1DiagnosisSubmissionParameter.cs
@@ -17,6 +17,33 @@ namespace Covid19Radar.Api.Models
 		[JsonProperty("keys")]
 		public new Key[] Keys { get; set; }
 
+		[JsonIgnore]
+		public override string KeysTextForDeviceVerification
+        {
+			get
+			{
+				if (Keys is null)
+				{
+					return string.Empty;
+				}
+				return string.Join(",", Keys.OrderBy(k => k.KeyData).Select(k => k.GetKeyString()));
+			}
+		}
+
+		#region Apple Device Check
+
+		[JsonIgnore]
+		public override string DeviceToken
+			=> DeviceVerificationPayload;
+
+		[JsonIgnore]
+		public override string TransactionIdSeed
+			=> AppPackageName
+				+ KeysTextForDeviceVerification
+				+ IAndroidDeviceVerification.GetRegionString(Regions);
+
+		#endregion
+
 		public new class Key
 		{
 			[JsonProperty("keyData")]
@@ -55,7 +82,7 @@ namespace Covid19Radar.Api.Models
 				return true;
 			}
 
-			internal string GetKeyString() => string.Join(".", KeyData, RollingStartNumber, RollingPeriod, TransmissionRisk);
+			internal string GetKeyString() => string.Join(".", KeyData, RollingStartNumber, TransmissionRisk);
 		}
 
 		public override bool IsValid()

--- a/src/Covid19Radar.Api/Models/V2DiagnosisSubmissionParameter.cs
+++ b/src/Covid19Radar.Api/Models/V2DiagnosisSubmissionParameter.cs
@@ -32,17 +32,25 @@ namespace Covid19Radar.Api.Models
 		public string Padding { get; set; }
 
 		[JsonIgnore]
-		public string KeysTextForDeviceVerification
-			=> string.Join(",", Keys.OrderBy(k => k.KeyData).Select(k => k.GetKeyString()));
+		public virtual string KeysTextForDeviceVerification
+        {
+			get {
+				if (Keys is null)
+                {
+					return string.Empty;
+                }
+				return string.Join(",", Keys.OrderBy(k => k.KeyData).Select(k => k.GetKeyString()));
+			}
+		}
 
 		#region Apple Device Check
 
 		[JsonIgnore]
-		public string DeviceToken
+		public virtual string DeviceToken
 			=> DeviceVerificationPayload;
 
 		[JsonIgnore]
-		public string TransactionIdSeed
+		public virtual string TransactionIdSeed
 			=> AppPackageName
 				+ KeysTextForDeviceVerification
 				+ IAndroidDeviceVerification.GetRegionString(Regions);
@@ -52,11 +60,11 @@ namespace Covid19Radar.Api.Models
 		#region Android SafetyNet Attestation API
 
 		[JsonIgnore]
-		public string JwsPayload
+		public virtual string JwsPayload
 			=> DeviceVerificationPayload;
 
 		[JsonIgnore]
-		public string ClearText
+		public virtual string ClearText
 			=> string.Join("|", AppPackageName, KeysTextForDeviceVerification, IAndroidDeviceVerification.GetRegionString(Regions), VerificationPayload);
 
 		#endregion

--- a/src/Covid19Radar.Api/Models/V2DiagnosisSubmissionParameter.cs
+++ b/src/Covid19Radar.Api/Models/V2DiagnosisSubmissionParameter.cs
@@ -12,115 +12,116 @@ namespace Covid19Radar.Api.Models
 
     public class V2DiagnosisSubmissionParameter : IPayload, IDeviceVerification
     {
-		public const int TRANSMISSION_RISK_LEVEL = 4;
+        public const int TRANSMISSION_RISK_LEVEL = 4;
 
-		[JsonProperty("keys")]
-		public Key[] Keys { get; set; }
-		[JsonProperty("regions")]
-		public string[] Regions { get; set; }
-		[JsonProperty("platform")]
-		public string Platform { get; set; }
-		[JsonProperty("deviceVerificationPayload")]
-		public string DeviceVerificationPayload { get; set; }
-		[JsonProperty("appPackageName")]
-		public string AppPackageName { get; set; }
-		// Some signature / code confirming authorization by the verification authority.
-		[JsonProperty("verificationPayload")]
-		public string VerificationPayload { get; set; }
-		// Random data to obscure the size of the request network packet sniffers.
-		[JsonProperty("padding")]
-		public string Padding { get; set; }
+        [JsonProperty("keys")]
+        public Key[] Keys { get; set; }
+        [JsonProperty("regions")]
+        public string[] Regions { get; set; }
+        [JsonProperty("platform")]
+        public string Platform { get; set; }
+        [JsonProperty("deviceVerificationPayload")]
+        public string DeviceVerificationPayload { get; set; }
+        [JsonProperty("appPackageName")]
+        public string AppPackageName { get; set; }
+        // Some signature / code confirming authorization by the verification authority.
+        [JsonProperty("verificationPayload")]
+        public string VerificationPayload { get; set; }
+        // Random data to obscure the size of the request network packet sniffers.
+        [JsonProperty("padding")]
+        public string Padding { get; set; }
 
-		[JsonIgnore]
-		public virtual string KeysTextForDeviceVerification
+        [JsonIgnore]
+        public virtual string KeysTextForDeviceVerification
         {
-			get {
-				if (Keys is null)
+            get
+            {
+                if (Keys is null)
                 {
-					return string.Empty;
+                    return string.Empty;
                 }
-				return string.Join(",", Keys.OrderBy(k => k.KeyData).Select(k => k.GetKeyString()));
-			}
-		}
+                return string.Join(",", Keys.OrderBy(k => k.KeyData).Select(k => k.GetKeyString()));
+            }
+        }
 
-		#region Apple Device Check
+        #region Apple Device Check
 
-		[JsonIgnore]
-		public virtual string DeviceToken
-			=> DeviceVerificationPayload;
+        [JsonIgnore]
+        public virtual string DeviceToken
+            => DeviceVerificationPayload;
 
-		[JsonIgnore]
-		public virtual string TransactionIdSeed
-			=> AppPackageName
-				+ KeysTextForDeviceVerification
-				+ IAndroidDeviceVerification.GetRegionString(Regions);
+        [JsonIgnore]
+        public virtual string TransactionIdSeed
+            => AppPackageName
+                + KeysTextForDeviceVerification
+                + IAndroidDeviceVerification.GetRegionString(Regions);
 
-		#endregion
+        #endregion
 
-		#region Android SafetyNet Attestation API
+        #region Android SafetyNet Attestation API
 
-		[JsonIgnore]
-		public virtual string JwsPayload
-			=> DeviceVerificationPayload;
+        [JsonIgnore]
+        public virtual string JwsPayload
+            => DeviceVerificationPayload;
 
-		[JsonIgnore]
-		public virtual string ClearText
-			=> string.Join("|", AppPackageName, KeysTextForDeviceVerification, IAndroidDeviceVerification.GetRegionString(Regions), VerificationPayload);
+        [JsonIgnore]
+        public virtual string ClearText
+            => string.Join("|", AppPackageName, KeysTextForDeviceVerification, IAndroidDeviceVerification.GetRegionString(Regions), VerificationPayload);
 
-		#endregion
-		public class Key
-		{
-			[JsonProperty("keyData")]
-			public string KeyData { get; set; }
-			[JsonProperty("rollingStartNumber")]
-			public uint RollingStartNumber { get; set; }
-			[JsonProperty("rollingPeriod")]
-			public uint RollingPeriod { get; set; }
+        #endregion
+        public class Key
+        {
+            [JsonProperty("keyData")]
+            public string KeyData { get; set; }
+            [JsonProperty("rollingStartNumber")]
+            public uint RollingStartNumber { get; set; }
+            [JsonProperty("rollingPeriod")]
+            public uint RollingPeriod { get; set; }
 
-			public TemporaryExposureKeyModel ToModel(V2DiagnosisSubmissionParameter _, ulong timestamp)
-			{
-				return new TemporaryExposureKeyModel()
-				{
-					KeyData = Convert.FromBase64String(this.KeyData),
-					RollingPeriod = ((int)this.RollingPeriod == 0 ? (int)Constants.ActiveRollingPeriod : (int)this.RollingPeriod),
-					RollingStartIntervalNumber = (int)this.RollingStartNumber,
-					TransmissionRiskLevel = TRANSMISSION_RISK_LEVEL,
-					ReportType = Constants.ReportTypeMissingValue,
-					DaysSinceOnsetOfSymptoms = Constants.DaysSinceOnsetOfSymptomsMissingValue,
-					Timestamp = timestamp,
-					Exported = false
-				};
-			}
-			/// <summary>
-			/// Validation
-			/// </summary>
-			/// <returns>true if valid</returns>
-			public bool IsValid()
-			{
-				if (string.IsNullOrWhiteSpace(KeyData)) return false;
-				if (RollingPeriod != 0 && RollingPeriod > Constants.ActiveRollingPeriod) return false;
-				var nowRollingStartNumber = DateTimeOffset.UtcNow.ToUnixTimeSeconds() / TemporaryExposureKeyModel.TIME_WINDOW_IN_SEC;
-				var oldestRollingStartNumber = new DateTimeOffset(DateTime.UtcNow.AddDays(Constants.OutOfDateDays).Date.Ticks, TimeSpan.Zero).ToUnixTimeSeconds() / TemporaryExposureKeyModel.TIME_WINDOW_IN_SEC;
-				if (RollingStartNumber != 0 && (RollingStartNumber < oldestRollingStartNumber || RollingStartNumber > nowRollingStartNumber)) return false;
-				return true;
-			}
+            public TemporaryExposureKeyModel ToModel(V2DiagnosisSubmissionParameter _, ulong timestamp)
+            {
+                return new TemporaryExposureKeyModel()
+                {
+                    KeyData = Convert.FromBase64String(this.KeyData),
+                    RollingPeriod = ((int)this.RollingPeriod == 0 ? (int)Constants.ActiveRollingPeriod : (int)this.RollingPeriod),
+                    RollingStartIntervalNumber = (int)this.RollingStartNumber,
+                    TransmissionRiskLevel = TRANSMISSION_RISK_LEVEL,
+                    ReportType = Constants.ReportTypeMissingValue,
+                    DaysSinceOnsetOfSymptoms = Constants.DaysSinceOnsetOfSymptomsMissingValue,
+                    Timestamp = timestamp,
+                    Exported = false
+                };
+            }
+            /// <summary>
+            /// Validation
+            /// </summary>
+            /// <returns>true if valid</returns>
+            public bool IsValid()
+            {
+                if (string.IsNullOrWhiteSpace(KeyData)) return false;
+                if (RollingPeriod != 0 && RollingPeriod > Constants.ActiveRollingPeriod) return false;
+                var nowRollingStartNumber = DateTimeOffset.UtcNow.ToUnixTimeSeconds() / TemporaryExposureKeyModel.TIME_WINDOW_IN_SEC;
+                var oldestRollingStartNumber = new DateTimeOffset(DateTime.UtcNow.AddDays(Constants.OutOfDateDays).Date.Ticks, TimeSpan.Zero).ToUnixTimeSeconds() / TemporaryExposureKeyModel.TIME_WINDOW_IN_SEC;
+                if (RollingStartNumber != 0 && (RollingStartNumber < oldestRollingStartNumber || RollingStartNumber > nowRollingStartNumber)) return false;
+                return true;
+            }
 
-			public string GetKeyString() => string.Join(".", KeyData, RollingStartNumber, RollingPeriod);
-		}
+            public string GetKeyString() => string.Join(".", KeyData, RollingStartNumber, RollingPeriod);
+        }
 
-		/// <summary>
-		/// Validation
-		/// </summary>
-		/// <returns>true if valid</returns>
-		public virtual bool IsValid()
-		{
-			if (string.IsNullOrWhiteSpace(VerificationPayload)) return false;
-			if ((Regions?.Length ?? 0) == 0) return false;
-			if (string.IsNullOrWhiteSpace(Platform)) return false;
-			if (string.IsNullOrWhiteSpace(DeviceVerificationPayload)) return false;
-			if (string.IsNullOrWhiteSpace(AppPackageName)) return false;
-			if (Keys.Any(_ => !_.IsValid())) return false;
-			return true;
-		}
-	}
+        /// <summary>
+        /// Validation
+        /// </summary>
+        /// <returns>true if valid</returns>
+        public virtual bool IsValid()
+        {
+            if (string.IsNullOrWhiteSpace(VerificationPayload)) return false;
+            if ((Regions?.Length ?? 0) == 0) return false;
+            if (string.IsNullOrWhiteSpace(Platform)) return false;
+            if (string.IsNullOrWhiteSpace(DeviceVerificationPayload)) return false;
+            if (string.IsNullOrWhiteSpace(AppPackageName)) return false;
+            if (Keys.Any(_ => !_.IsValid())) return false;
+            return true;
+        }
+    }
 }

--- a/src/Covid19Radar.Api/Models/V3DiagnosisSubmissionParameter.cs
+++ b/src/Covid19Radar.Api/Models/V3DiagnosisSubmissionParameter.cs
@@ -7,7 +7,6 @@ using Covid19Radar.Api.Extensions;
 using Newtonsoft.Json;
 using System;
 using System.Linq;
-using System.Text;
 
 namespace Covid19Radar.Api.Models
 {
@@ -55,8 +54,17 @@ namespace Covid19Radar.Api.Models
         public string Padding { get; set; }
 
         [JsonIgnore]
-        public string KeysTextForDeviceVerification
-            => string.Join(",", Keys.OrderBy(k => k.KeyData).Select(k => k.GetKeyString()));
+        public virtual string KeysTextForDeviceVerification
+        {
+            get
+            {
+                if (Keys is null)
+                {
+                    return string.Empty;
+                }
+                return string.Join(",", Keys.OrderBy(k => k.KeyData).Select(k => k.GetKeyString()));
+            }
+        }
 
         #region Apple Device Check
 


### PR DESCRIPTION
## Issue 番号 / Issue ID

- Close #827

## 目的 / Purpose

- V1DiagnosisSubmissionParameterのKeyDataを使用するようにした

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[x] Yes
[ ] No
```

## Pull Request の種類 / Pull Request type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

- `V1DiagnosisSubmissionParameter`は`V2DiagnosisSubmissionParameter`を継承している（ `V1` extends `V2` ）
- V1とV2でそえれぞれに診断キーのリスト（`Keys`）を持つ
- `KeysTextForDeviceVerification`系のメソッドは`V2DiagnosisSubmissionParameter`にしかないので、呼び出したときに`V1`の`Keys`ではなく、`V2`の`Keys`を参照する
- `V2`のKeysはnullなのでエラーが発生する

## その他 / Other information

AttestationApiのnonce生成で、`V1DiagnosisApi`と`V2DiagnosisApi`で違いを見つけたので、アプリ側のテストに反映した。