### PR TITLE
Task.Delayを入れてENのモーダルが閉じるのを待つ

### DIFF
--- a/Covid19Radar/Covid19Radar.iOS/Services/ExposureNotificationApiService.cs
+++ b/Covid19Radar/Covid19Radar.iOS/Services/ExposureNotificationApiService.cs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,8 +15,9 @@ namespace Covid19Radar.iOS.Services
 {
     public class ExposureNotificationApiService : AbsExposureNotificationApiService
     {
-        private ExposureNotificationClient _exposureNotificationClient = new ExposureNotificationClient();
+        private const int MILLISECONDS_TO_WAIT_DISMISSING_ANIMATION = 1000;
 
+        private ExposureNotificationClient _exposureNotificationClient = new ExposureNotificationClient();
         public string UserExplanation
         {
             set => _exposureNotificationClient.UserExplanation = value;
@@ -30,8 +32,22 @@ namespace Covid19Radar.iOS.Services
         public override Task<IList<ExposureNotificationStatus>> GetStatusesAsync()
             => _exposureNotificationClient.GetStatusesAsync();
 
-        public override Task<List<TemporaryExposureKey>> GetTemporaryExposureKeyHistoryAsync()
-            => _exposureNotificationClient.GetTemporaryExposureKeyHistoryAsync();
+        public override async Task<List<TemporaryExposureKey>> GetTemporaryExposureKeyHistoryAsync()
+        {
+            try
+            {
+                return await _exposureNotificationClient.GetTemporaryExposureKeyHistoryAsync();
+            }
+            catch(Exception)
+            {
+                throw;
+            }
+            finally
+            {
+                // [workaround] wait for dismissing en permission modal
+                await Task.Delay(MILLISECONDS_TO_WAIT_DISMISSING_ANIMATION);
+            }
+        }
 
         public override Task<long> GetVersionAsync()
             => _exposureNotificationClient.GetVersionAsync();

--- a/Covid19Radar/Covid19Radar.iOS/Services/ExposureNotificationApiService.cs
+++ b/Covid19Radar/Covid19Radar.iOS/Services/ExposureNotificationApiService.cs
@@ -38,10 +38,6 @@ namespace Covid19Radar.iOS.Services
             {
                 return await _exposureNotificationClient.GetTemporaryExposureKeyHistoryAsync();
             }
-            catch(Exception)
-            {
-                throw;
-            }
             finally
             {
                 // [workaround] wait for dismissing en permission modal

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/NotifyOtherPageViewModel.cs
@@ -306,9 +306,6 @@ namespace Covid19Radar.ViewModels
                 {
                     loggerService.Info("GetTekHistory request is declined by user.");
 
-                    // Workarround for that HideLoading conflicts with AlertAsync on iOS.
-                    await Task.Delay(_delayForErrorMillis);
-
                     UserDialogs.Instance.HideLoading();
 
                     await UserDialogs.Instance.AlertAsync(
@@ -326,9 +323,6 @@ namespace Covid19Radar.ViewModels
             catch (Exception ex)
             {
                 errorCount++;
-
-                // Workarround for that HideLoading conflicts with AlertAsync on iOS.
-                await Task.Delay(_delayForErrorMillis);
 
                 UserDialogs.Instance.HideLoading();
 


### PR DESCRIPTION
## Issue 番号 / Issue ID

<!--
  Issue 番号なき PR は受け付けません。
  PRs without the issue IDs are never accepted.
-->

- Close #821

## 目的 / Purpose

<!--
  その変更を提案する意図をご説明ください。どの問題が解決したり、機能的な追加がなされたりしますか。
  Describe the intention of the changes being proposed. What problem does it solve or functionality does it add?
-->

- iOSでENモーダルが閉じ切る前に結果が返ってきており、その後続処理がすぐに完了してしまうと同じくモーダルで表示されるはずのアラートのpresent処理と被ってアラートの表示が一瞬で消える
- 根本的な解決は難しそうなので、モーダルアニメーションが終わっているだろう時間まで待ってから後続の処理が走るようにワークアラウンドを入れる
  - iOSの画面遷移のシステムアニメーションは大体0.3-0.5秒ぐらいで設定されている
  - あたりをつけて1秒待つようにする 


## 破壊的変更をもたらしますか / Does this introduce a breaking change?

<!--
  当てはまるもの 1 つに「x」とマークしてください。
  Mark one with an "x".
-->

```
[x] Yes
[ ] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

- 以下の観点でExposureNotificationApiService.csに実装を入れています
  - Android側に影響を与えない
  - Exceptionが発生しても必ず待つようにする

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
