### PR TITLE
[クローズドベータ向け]「過去14日間の接触」画面の表示を改善する

### DIFF
--- a/Covid19Radar/Covid19Radar/Repository/IExposureDataRepository.cs
+++ b/Covid19Radar/Covid19Radar/Repository/IExposureDataRepository.cs
@@ -70,7 +70,7 @@ namespace Covid19Radar.Repository
             string fromStr = from.ToString(fromFormat, CultureInfo.CurrentCulture);
             string toStr = to.ToString(toFormat, CultureInfo.CurrentCulture);
 
-            return string.Format("{0} {1} {2}", fromStr, AppResources.ExposuresPageTo, toStr);
+            return string.Format("{0}{1} {2} {3}", AppResources.ExposuresPageFrom, fromStr, AppResources.ExposuresPageTo, toStr);
         }
     }
 }

--- a/Covid19Radar/Covid19Radar/Repository/IExposureDataRepository.cs
+++ b/Covid19Radar/Covid19Radar/Repository/IExposureDataRepository.cs
@@ -67,8 +67,8 @@ namespace Covid19Radar.Repository
                 toFormat = AppResources.ExposureDateFormatYear;
             }
 
-            string fromStr = string.Format(fromFormat, from.Year, from.Month, from.Day, from.Hour);
-            string toStr = string.Format(toFormat, to.Year, to.Month, to.Day, to.Hour);
+            string fromStr = from.ToString(fromFormat, CultureInfo.CurrentCulture);
+            string toStr = to.ToString(toFormat, CultureInfo.CurrentCulture);
 
             return string.Format("{0} {1} {2}", fromStr, AppResources.ExposuresPageTo, toStr);
         }

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.Designer.cs
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.Designer.cs
@@ -1061,12 +1061,6 @@ namespace Covid19Radar.Resources {
             }
         }
         
-        public static string ContactedNotifyPageDescription0 {
-            get {
-                return ResourceManager.GetString("ContactedNotifyPageDescription0", resourceCulture);
-            }
-        }
-        
         public static string ContactedNotifyPageDescription1 {
             get {
                 return ResourceManager.GetString("ContactedNotifyPageDescription1", resourceCulture);

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.Designer.cs
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.Designer.cs
@@ -1901,6 +1901,12 @@ namespace Covid19Radar.Resources {
             }
         }
         
+        public static string ExposuresPageFrom {
+            get {
+                return ResourceManager.GetString("ExposuresPageFrom", resourceCulture);
+            }
+        }
+        
         public static string ExposuresPageTo {
             get {
                 return ResourceManager.GetString("ExposuresPageTo", resourceCulture);

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
@@ -665,10 +665,6 @@
     <value>検査等の相談先を探す</value>
     <comment>検査等の相談先を探す</comment>
   </data>
-  <data name="ContactedNotifyPageDescription0" xml:space="preserve">
-    <value>受診の際に必要となる場合があるため、「陽性登録者との接触一覧」のスクリーンショットを保存してください。</value>
-    <comment>TODO:受診の際に必要となる場合があるため、「陽性登録者との接触一覧」のスクリーンショットを保存してください。</comment>
-  </data>
   <data name="ContactedNotifyPageDescription1" xml:space="preserve">
     <value>症状がない場合、
 陽性者と接触した心当たりがない場合は、

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
@@ -291,7 +291,7 @@
   </data>
   <data name="LowRiskContactPageAnnotationDecription2" xml:space="preserve">
     <value>※日時については、協定世界時（UTC）を設定されているタイムゾーンに変換して、期間として表示しています。</value>
-    <comment>TODO:※日時については、協定世界時（UTC）をを設定されているタイムゾーンに変換して、期間として表示しています。</comment>
+    <comment>※日時については、協定世界時（UTC）をを設定されているタイムゾーンに変換して、期間として表示しています。</comment>
   </data>
   <data name="NoRiskContactPageLabel" xml:space="preserve">
     <value>陽性登録者のスマートフォンからの信号を受信していません</value>
@@ -327,11 +327,11 @@
   </data>
   <data name="ContactedNotifyPageButton1" xml:space="preserve">
     <value>陽性登録者との接触一覧</value>
-    <comment>TODO:陽性登録者との接触一覧</comment>
+    <comment>陽性登録者との接触一覧</comment>
   </data>
   <data name="ContactedNotifyPageMainText" xml:space="preserve">
     <value>陽性登録者との接触確認</value>
-    <comment>TODO:陽性登録者との接触確認</comment>
+    <comment>陽性登録者との接触確認</comment>
   </data>
   <data name="ContactedNotifyPageTitle" xml:space="preserve">
     <value>過去14日間の接触</value>
@@ -539,7 +539,7 @@
   </data>
   <data name="ExposuresPageLabel1" xml:space="preserve">
     <value>次の期間に陽性登録者との接触が確認されました。</value>
-    <comment>TODO:次の期間に陽性登録者との接触が確認されました。</comment>
+    <comment>次の期間に陽性登録者との接触が確認されました。</comment>
   </data>
   <data name="UrlContactedPhone" xml:space="preserve">
     <value>https://covid19radarjpnprod.z11.web.core.windows.net/phone.json</value>
@@ -670,23 +670,23 @@
 陽性者と接触した心当たりがない場合は、
 感染対策に留意しつつ普段通りの生活をお送りください。
 ただし、体調に変化があった場合は、受診を検討ください。</value>
-    <comment>TODO:症状がない場合、陽性者と接触した心当たりがない場合は、感染対策に留意しつつ普段通りの生活をお送りください。ただし、体調に変化があった場合は、受診を検討ください。</comment>
+    <comment>症状がない場合、陽性者と接触した心当たりがない場合は、感染対策に留意しつつ普段通りの生活をお送りください。ただし、体調に変化があった場合は、受診を検討ください。</comment>
   </data>
   <data name="ContactedNotifyPageDescription2" xml:space="preserve">
     <value>次のいずれかに当てはまる方は、アプリの案内に従い、診療・検査医療機関等への受診を検討ください。</value>
-    <comment>TODO:次のいずれかに当てはまる方は、アプリの案内に従い、診療・検査医療機関等への受診を検討ください。</comment>
+    <comment>次のいずれかに当てはまる方は、アプリの案内に従い、診療・検査医療機関等への受診を検討ください。</comment>
   </data>
   <data name="ContactedNotifyPageDescription3" xml:space="preserve">
     <value>・発熱等の症状や基礎疾患がある</value>
-    <comment>TODO:・発熱等の症状や基礎疾患がある</comment>
+    <comment>・発熱等の症状や基礎疾患がある</comment>
   </data>
   <data name="ContactedNotifyPageDescription4" xml:space="preserve">
     <value>・陽性者と接触した心当たりがある</value>
-    <comment>TODO:・陽性者と接触した心当たりがある</comment>
+    <comment>・陽性者と接触した心当たりがある</comment>
   </data>
   <data name="ContactedNotifyPageDescription5" xml:space="preserve">
     <value>・その他、受診を希望する</value>
-    <comment>TODO:・その他、受診を希望する</comment>
+    <comment>・その他、受診を希望する</comment>
   </data>
   <data name="ReAgreeCheckButton" xml:space="preserve">
     <value>確認しました</value>
@@ -1240,23 +1240,27 @@
 
   <data name="ExposuresPageToUtcDescription" xml:space="preserve">
     <value>日時については、協定世界時（UTC）を設定されているタイムゾーンに変換して、期間として表示しています。</value>
-    <comment>TODO:日時については、協定世界時（UTC）をを設定されているタイムゾーンに変換して、期間として表示しています。</comment>
+    <comment>日時については、協定世界時（UTC）をを設定されているタイムゾーンに変換して、期間として表示しています。</comment>
+  </data>
+  <data name="ExposuresPageFrom" xml:space="preserve">
+    <value></value>
+    <comment> </comment>
   </data>
   <data name="ExposuresPageTo" xml:space="preserve">
     <value>から</value>
-    <comment>TODO:から</comment>
+    <comment>から</comment>
   </data>
   <data name="ExposureDateFormatDate" xml:space="preserve">
     <value>d日 tth時mm分</value>
-    <comment>TODO:d日 tth時mm分</comment>
+    <comment>d日 tth時mm分</comment>
   </data>
   <data name="ExposureDateFormatMonth" xml:space="preserve">
     <value>M月d日 tth時mm分</value>
-    <comment>TODO:M月d日 tth時mm分</comment>
+    <comment>M月d日 tth時mm分</comment>
   </data>
   <data name="ExposureDateFormatYear" xml:space="preserve">
     <value>yyyy年M月d日 tth時mm分</value>
-    <comment>TODO:yyyy年M月d日 tth時mm分</comment>
+    <comment>yyyy年M月d日 tth時mm分</comment>
   </data>
 
   <data name="OpenSourceLicense" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
@@ -1247,16 +1247,16 @@
     <comment>TODO:から</comment>
   </data>
   <data name="ExposureDateFormatDate" xml:space="preserve">
-    <value>{2:#}日 午前{3:#}時</value>
-    <comment>TODO:{2:#}日 午前{3:#}時</comment>
+    <value>d日 tth時mm分</value>
+    <comment>TODO:d日 tth時mm分</comment>
   </data>
   <data name="ExposureDateFormatMonth" xml:space="preserve">
-    <value>{1:#}月 {2:#}日 午前{3:#}時</value>
-    <comment>TODO:{1:#}月{2:#}日 午前{3:#}時</comment>
+    <value>M月d日 tth時mm分</value>
+    <comment>TODO:M月d日 tth時mm分</comment>
   </data>
   <data name="ExposureDateFormatYear" xml:space="preserve">
-    <value>{0:#}年{1:#}月 {2:#}日 午前{3:#}時</value>
-    <comment>TODO:{0:#}年{1:#}月 午前{2:#}日{3:#}時</comment>
+    <value>yyyy年M月d日 tth時mm分</value>
+    <comment>TODO:yyyy年M月d日 tth時mm分</comment>
   </data>
 
   <data name="OpenSourceLicense" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.resx
@@ -1355,16 +1355,16 @@ Note: this app does not collect users’ location information.</value>
     <comment>TODO:から</comment>
   </data>
   <data name="ExposureDateFormatDate" xml:space="preserve">
-    <value>{2:#} {3:#}:00 AM</value>
-    <comment>TODO:{2:#}日 午前{3:#}時</comment>
+    <value>d h:mm tt</value>
+    <comment>TODO:d日 tth時mm分</comment>
   </data>
   <data name="ExposureDateFormatMonth" xml:space="preserve">
-    <value>{1:#}/{2:#}/ {3:#}:00 AM</value>
-    <comment>TODO:{1:#}月{2:#}日 午前{3:#}時</comment>
+    <value>d MMM h:mm tt</value>
+    <comment>TODO:M月d日 tth時mm分</comment>
   </data>
   <data name="ExposureDateFormatYear" xml:space="preserve">
-    <value>{0:#}/{1:#}/{2:#} {3:#}:00 AM</value>
-    <comment>TODO:{0:#}年{1:#}月{2:#}日 午前{3:#}時</comment>
+    <value>d MMM, yyyy h:mm tt</value>
+    <comment>TODO:yyyy年M月d日 tth時mm分</comment>
   </data>
 
   <data name="OpenSourceLicense" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.resx
@@ -780,10 +780,6 @@
     <value>Find COVID-19 Consultation Centers</value>
     <comment>検査等の相談先を探す</comment>
   </data>
-  <data name="ContactedNotifyPageDescription0" xml:space="preserve">
-    <value>Please take a screenshot of the Close Contacts List below, as it may be necessary during the medical examination.</value>
-    <comment>TODO:受診の際に必要となる場合があるため、「陽性登録者との接触一覧」のスクリーンショットを保存してください。</comment>
-  </data>
   <data name="ContactedNotifyPageDescription1" xml:space="preserve">
     <value>If you do not have any symptoms,
 or if you do not know anyone who has had contact with a person that has been tested positive for COVID-19,

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.resx
@@ -417,8 +417,8 @@
     <comment>※スコアは、受信した信号の強さと時間から算出しています。1m以内・15分以上の接触で100以上になるように設定しています。</comment>
   </data>
   <data name="LowRiskContactPageAnnotationDecription2" xml:space="preserve">
-    <value>For the date and time, Coordinated Universal Time (UTC) is converted to the time zone you set and displayed as a term.</value>
-    <comment>TODO:※日時については、協定世界時（UTC）をを設定されているタイムゾーンに変換して、期間として表示しています。</comment>
+    <value>* For the date and time, the Coordinated Universal Time (UTC) is converted to the set time zone of the device and displayed.​</value>
+    <comment>※日時については、協定世界時（UTC）をを設定されているタイムゾーンに変換して、期間として表示しています。</comment>
   </data>
   <data name="NoRiskContactPageLabel" xml:space="preserve">
     <value>No signal has being received from the smartphone of a person who has registered positive for COVID-19 </value>
@@ -1347,24 +1347,28 @@ Note: this app does not collect users’ location information.</value>
   </data>
 
   <data name="ExposuresPageToUtcDescription" xml:space="preserve">
-    <value>For the date and time, Coordinated Universal Time (UTC) is converted to the time zone you set and displayed as a term.</value>
-    <comment>TODO:日時については、協定世界時（UTC）をを設定されているタイムゾーンに変換して、期間として表示しています。</comment>
+    <value>* For the date and time, the Coordinated Universal Time (UTC) is converted to the set time zone of the device and displayed.​</value>
+    <comment>日時については、協定世界時（UTC）をを設定されているタイムゾーンに変換して、期間として表示しています。</comment>
+  </data>
+  <data name="ExposuresPageFrom" xml:space="preserve">
+    <value>From </value>
+    <comment> </comment>
   </data>
   <data name="ExposuresPageTo" xml:space="preserve">
     <value>to</value>
-    <comment>TODO:から</comment>
+    <comment>から</comment>
   </data>
   <data name="ExposureDateFormatDate" xml:space="preserve">
     <value>d h:mm tt</value>
-    <comment>TODO:d日 tth時mm分</comment>
+    <comment>d日 tth時mm分</comment>
   </data>
   <data name="ExposureDateFormatMonth" xml:space="preserve">
     <value>d MMM h:mm tt</value>
-    <comment>TODO:M月d日 tth時mm分</comment>
+    <comment>M月d日 tth時mm分</comment>
   </data>
   <data name="ExposureDateFormatYear" xml:space="preserve">
     <value>d MMM, yyyy h:mm tt</value>
-    <comment>TODO:yyyy年M月d日 tth時mm分</comment>
+    <comment>yyyy年M月d日 tth時mm分</comment>
   </data>
 
   <data name="OpenSourceLicense" xml:space="preserve">

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.zh-Hans.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.zh-Hans.resx
@@ -309,8 +309,8 @@
     <comment>※スコアは、受信した信号の強さと時間から算出しています。一般的な条件では1m以内・15分以上の接触で100以上になるように設定しています。</comment>
   </data>
   <data name="LowRiskContactPageAnnotationDecription2" xml:space="preserve">
-    <value>For the date and time, Coordinated Universal Time (UTC) is converted to the time zone you set and displayed as a term.</value>
-    <comment>TODO:※日時については、協定世界時（UTC）をを設定されているタイムゾーンに変換して、期間として表示しています。</comment>
+    <value>* 对于日期和时间，以协调世界时 (UTC) 转换成设置的时区来显示时间段。​</value>
+    <comment>※日時については、協定世界時（UTC）をを設定されているタイムゾーンに変換して、期間として表示しています。</comment>
   </data>
   <data name="NoRiskContactPageLabel" xml:space="preserve">
     <value>未收到来自阳性登记者所持智能手机的信号</value>
@@ -345,16 +345,16 @@
     <comment>端末の識別</comment>
   </data>
   <data name="ContactedNotifyPageButton1" xml:space="preserve">
-    <value>和阳性患者的密切接触一览</value>
-    <comment>TODO:陽性登録者との接触一覧</comment>
+    <value>与阳性登记者的接触一览​</value>
+    <comment>陽性登録者との接触一覧</comment>
   </data>
   <data name="ContactedNotifyPageCountText" xml:space="preserve">
     <value>times</value>
     <comment>件</comment>
   </data>
   <data name="ContactedNotifyPageMainText" xml:space="preserve">
-    <value>查询跟阳性患者的密切接触情况</value>
-    <comment>TODO:陽性登録者との接触確認</comment>
+    <value>确认与阳性登记者的接触​</value>
+    <comment>陽性登録者との接触確認</comment>
   </data>
   <data name="ContactedNotifyPageTitle" xml:space="preserve">
     <value>查询过去14天内里的接触情况</value>
@@ -369,8 +369,8 @@
     <comment>お問い合わせ（メニュー）</comment>
   </data>
   <data name="HomePageDescription2" xml:space="preserve">
-    <value>确认与阳性者接触的结果</value>
-    <comment>TODO:陽性登録者との接触結果を確認</comment>
+    <value>确认与阳性登记者接触的结果</value>
+    <comment>陽性登録者との接触結果を確認</comment>
   </data>
   <data name="HomePageDescription3" xml:space="preserve">
     <value>确诊新型冠状病毒呈阳性</value>
@@ -541,8 +541,8 @@
     <comment>過去14日間の接触一覧</comment>
   </data>
   <data name="ExposuresPageLabel1" xml:space="preserve">
-    <value>以下日期确认到您与阳性患者存在密切接触。</value>
-    <comment>TODO:次の日に陽性登録者との接触が確認されました。</comment>
+    <value>在下记时间段检测到与阳性登记者的接触。</value>
+    <comment>次の日に陽性登録者との接触が確認されました。</comment>
   </data>
   <data name="UrlContactedPhone" xml:space="preserve">
     <value>https://covid19radarjpnprod.z11.web.core.windows.net/phone.json</value>
@@ -1246,24 +1246,28 @@ However, if you have any symptoms, please consider receiving a consultation..
   </data>
 
   <data name="ExposuresPageToUtcDescription" xml:space="preserve">
-    <value>For the date and time, Coordinated Universal Time (UTC) is converted to the time zone you set and displayed as a term.</value>
-    <comment>TODO:日時については、協定世界時（UTC）をを設定されているタイムゾーンに変換して、期間として表示しています。</comment>
+    <value>* 对于日期和时间，以协调世界时 (UTC) 转换成设置的时区来显示时间段。​</value>
+    <comment>日時については、協定世界時（UTC）をを設定されているタイムゾーンに変換して、期間として表示しています。</comment>
+  </data>
+  <data name="ExposuresPageFrom" xml:space="preserve">
+    <value></value>
+    <comment></comment>
   </data>
   <data name="ExposuresPageTo" xml:space="preserve">
-    <value>to</value>
-    <comment>TODO:から</comment>
+    <value>到</value>
+    <comment>から</comment>
   </data>
   <data name="ExposureDateFormatDate" xml:space="preserve">
-    <value>d h:mm tt</value>
-    <comment>TODO:d日 tth時mm分</comment>
+    <value>d日 tth点mm分</value>
+    <comment>d日 tth時mm分</comment>
   </data>
   <data name="ExposureDateFormatMonth" xml:space="preserve">
-    <value>d MMM h:mm tt</value>
-    <comment>TODO:M月d日 tth時mm分</comment>
+    <value>M月d日 tth点mm分</value>
+    <comment>M月d日 tth時mm分</comment>
   </data>
   <data name="ExposureDateFormatYear" xml:space="preserve">
-    <value>d MMM, yyyy h:mm tt</value>
-    <comment>TODO:yyyy年M月d日 tth時mm分</comment>
+    <value>yyyy年M月d日 tth点mm分</value>
+    <comment>yyyy年M月d日 tth時mm分</comment>
   </data>
 
 </root>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.zh-Hans.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.zh-Hans.resx
@@ -668,10 +668,6 @@
     <value>寻找咨询中心</value>
     <comment>検査等の相談先を探す</comment>
   </data>
-  <data name="ContactedNotifyPageDescription0" xml:space="preserve">
-    <value>Please take a screenshot of the Close Contacts List below, as it may be necessary during the medical examination.</value>
-    <comment>TODO:受診の際に必要となる場合があるため、「陽性登録者との接触一覧」のスクリーンショットを保存してください。</comment>
-  </data>
   <data name="ContactedNotifyPageDescription1" xml:space="preserve">
     <value>If you do not have any symptoms,
 or if you do not know anyone who has had contact with a person that has been tested positive for COVID-19,

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.zh-Hans.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.zh-Hans.resx
@@ -1254,16 +1254,16 @@ However, if you have any symptoms, please consider receiving a consultation..
     <comment>TODO:から</comment>
   </data>
   <data name="ExposureDateFormatDate" xml:space="preserve">
-    <value>{2:#} {3:#}:00 AM</value>
-    <comment>TODO:{2:#}日 午前{3:#}時</comment>
+    <value>d h:mm tt</value>
+    <comment>TODO:d日 tth時mm分</comment>
   </data>
   <data name="ExposureDateFormatMonth" xml:space="preserve">
-    <value>{1:#}/{2:#}/ {3:#}:00 AM</value>
-    <comment>TODO:{1:#}月{2:#}日 午前{3:#}時</comment>
+    <value>d MMM h:mm tt</value>
+    <comment>TODO:M月d日 tth時mm分</comment>
   </data>
   <data name="ExposureDateFormatYear" xml:space="preserve">
-    <value>{0:#}/{1:#}/{2:#} {3:#}:00 AM</value>
-    <comment>TODO:{0:#}年{1:#}月{2:#}日 午前{3:#}時</comment>
+    <value>d MMM, yyyy h:mm tt</value>
+    <comment>TODO:yyyy年M月d日 tth時mm分</comment>
   </data>
 
 </root>

--- a/Covid19Radar/Covid19Radar/Views/HomePage/ContactedNotifyPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/ContactedNotifyPage.xaml
@@ -139,21 +139,6 @@
                         IsVisible="false"
                         />
 
-                    <Label
-                        AutomationProperties.IsInAccessibleTree="True"
-                        TabIndex="12"
-                        Margin="0, 10, 0, 0"
-                        Style="{StaticResource AnnotationLabel}"
-                        TextColor="{StaticResource PrimaryText}"
-                        IsVisible="false" >
-                        <Label.FormattedText>
-                            <FormattedString>
-                                <Span Text="{x:Static resources:AppResources.AnnotationSymbol}"/>
-                                <Span Text="{x:Static resources:AppResources.ContactedNotifyPageDescription0}"/>
-                            </FormattedString>
-                        </Label.FormattedText>
-                    </Label>
-
                 </StackLayout>
             </Frame>
         </StackLayout>


### PR DESCRIPTION
## Issue 番号 / Issue ID

- #815

## 目的 / Purpose

- 診察その他のケースでスクリーンショットを取る必要ないよね
- 時間表記を「午前」に固定していたけど、タイムゾーンによっては午前とは限らない。 https://github.com/cocoa-mhlw/cocoa/issues/877#issuecomment-1047573185 の指摘



## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

-

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
