### PR TITLE
基準値未満の接触画面リファインメント

### DIFF
--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
@@ -290,10 +290,6 @@
     <comment>スコアは、受信した信号の強さと時間から算出しています。一般的な条件では1m以内・15分以上の接触で100以上になるように設定しています。</comment>
   </data>
   <data name="LowRiskContactPageAnnotationDecription2" xml:space="preserve">
-    <value>日時については、協定世界時（UTC）を設定されているタイムゾーンに変換して、期間として表示しています。</value>
-    <comment>TODO:日時については、協定世界時（UTC）をを設定されているタイムゾーンに変換して、期間として表示しています。</comment>
-  </data>
-  <data name="LowRiskContactPageAnnotationDecription2" xml:space="preserve">
     <value>※日時については、協定世界時（UTC）を設定されているタイムゾーンに変換して、期間として表示しています。</value>
     <comment>TODO:※日時については、協定世界時（UTC）をを設定されているタイムゾーンに変換して、期間として表示しています。</comment>
   </data>

--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
@@ -286,8 +286,12 @@
     <comment>受信した信号</comment>
   </data>
   <data name="LowRiskContactPageAnnotationDecription" xml:space="preserve">
-    <value>※スコアは、受信した信号の強さと時間から算出しています。一般的な条件では1m以内・15分以上の接触で100以上になるように設定しています。</value>
-    <comment>※スコアは、受信した信号の強さと時間から算出しています。一般的な条件では1m以内・15分以上の接触で100以上になるように設定しています。</comment>
+    <value>スコアは、受信した信号の強さと時間から算出しています。一般的な条件では1m以内・15分以上の接触で100以上になるように設定しています。</value>
+    <comment>スコアは、受信した信号の強さと時間から算出しています。一般的な条件では1m以内・15分以上の接触で100以上になるように設定しています。</comment>
+  </data>
+  <data name="LowRiskContactPageAnnotationDecription2" xml:space="preserve">
+    <value>日時については、協定世界時（UTC）を設定されているタイムゾーンに変換して、期間として表示しています。</value>
+    <comment>TODO:日時については、協定世界時（UTC）をを設定されているタイムゾーンに変換して、期間として表示しています。</comment>
   </data>
   <data name="LowRiskContactPageAnnotationDecription2" xml:space="preserve">
     <value>※日時については、協定世界時（UTC）を設定されているタイムゾーンに変換して、期間として表示しています。</value>

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposureCheckPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposureCheckPageViewModel.cs
@@ -144,13 +144,13 @@ namespace Covid19Radar.ViewModels
         {
             var dayOfUse = _userDataRepository.GetDaysOfUse();
 
-            var latestExposureDateMillisSinceEpoch = dailySummaryList.Max(x => x.DateMillisSinceEpoch);
-            var latestExposureDate = DateTimeOffset.UnixEpoch.AddMilliseconds(latestExposureDateMillisSinceEpoch).UtcDateTime;
-            var latestExposureDateOffset = (DateTime.UtcNow.Date - latestExposureDate).Days;
+            var oldestExposureDateMillisSinceEpoch = dailySummaryList.Min(x => x.DateMillisSinceEpoch);
+            var oldestExposureDate = DateTimeOffset.UnixEpoch.AddMilliseconds(oldestExposureDateMillisSinceEpoch).UtcDateTime;
+            var oldestExposureDateOffset = (DateTime.UtcNow.Date - oldestExposureDate).Days;
 
             var daysOffset = Math.Max(
                 dayOfUse,
-                latestExposureDateOffset
+                oldestExposureDateOffset
                 );
 
             daysOffset = Math.Min(

--- a/Covid19Radar/Covid19Radar/Views/HomePage/ExposureCheckPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/ExposureCheckPage.xaml
@@ -128,11 +128,27 @@
                     IsVisible="{Binding IsExposureDetected}"
                     >
                     <Label
-                        Style="{StaticResource DefaultLabelCaptionStartAlignment}"
-                        Text="{Binding LowRiskContactPageAnnotationDecription}" />
+                        Style="{StaticResource AnnotationLabel}"
+                        TextColor="{StaticResource PrimaryText}">
+                        <Label.FormattedText>
+                            <FormattedString>
+                                <Span Text="{x:Static resources:AppResources.AnnotationSymbol}"/>
+                                <Span Text="{Binding LowRiskContactPageAnnotationDecription}"/>
+                            </FormattedString>
+                        </Label.FormattedText>
+                    </Label>
+
                     <Label
-                        Style="{StaticResource DefaultLabelCaptionStartAlignment}"
-                        Text="{x:Static resources:AppResources.LowRiskContactPageAnnotationDecription2}" />
+                        Margin="0, 10, 0, 0"
+                        Style="{StaticResource AnnotationLabel}"
+                        TextColor="{StaticResource PrimaryText}">
+                        <Label.FormattedText>
+                            <FormattedString>
+                                <Span Text="{x:Static resources:AppResources.AnnotationSymbol}"/>
+                                <Span Text="{x:Static resources:AppResources.LowRiskContactPageAnnotationDecription2}"/>
+                            </FormattedString>
+                        </Label.FormattedText>
+                    </Label>
                 </StackLayout>
             </CollectionView.Footer>
         </CollectionView>


### PR DESCRIPTION
## Issue 番号 / Issue ID

- #823

## 目的 / Purpose

- 日時がUTC基準であることを明記した（接触一覧の画面に表示しているものと同様）
- （デバッグ用途のみ）利用開始期間より過去に基準値未満の接触が存在する場合に表示する始期の計算が誤っていた不具合を修正した

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 検証方法 / How to test

### コードの入手 / Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
dotnet restore
```

### コードの検証 / Test the code

<!--
  テスト環境やマニュアルテストの実行手順をお書きください。
  Add steps to run the tests suite and/or manually test
-->

```

```

## 確認事項 / What to check

![Screen Shot 2022-02-22 at 0 05 05](https://user-images.githubusercontent.com/932136/154981623-04ec7d36-7b2e-4871-911b-2edd9f1c6a38.png)

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->
