### PR TITLE
Fix ReAgree*Page are not launched from DebugPage.

### DIFF
--- a/Covid19Radar/Covid19Radar/Destination.cs
+++ b/Covid19Radar/Covid19Radar/Destination.cs
@@ -13,6 +13,7 @@ namespace Covid19Radar
         HomePage,
         ContactedNotifyPage,
         NotifyOtherPage,
+        DebugPage,
     }
 
     public static class DestinationExtensions
@@ -21,6 +22,7 @@ namespace Covid19Radar
         private static string HomePagePath => "/" + nameof(MenuPage) + "/" + nameof(NavigationPage) + "/" + nameof(HomePage);
         private static string ContactedNotifyPagePath => HomePagePath + "/" + nameof(ContactedNotifyPage);
         private static string NotifyOtherPagePath => HomePagePath + "/" + nameof(NotifyOtherPage);
+        private static string DebugPagePath => "/" + nameof(MenuPage) + "/" + nameof(NavigationPage) + "/" + nameof(DebugPage);
 
         public static string ToPath(this Destination destination)
         {
@@ -30,6 +32,7 @@ namespace Covid19Radar
                 Destination.HomePage => HomePagePath,
                 Destination.ContactedNotifyPage => ContactedNotifyPagePath,
                 Destination.NotifyOtherPage => NotifyOtherPagePath,
+                Destination.DebugPage => DebugPagePath,
                 _ => throw new System.NotImplementedException()
             };
         }

--- a/Covid19Radar/Covid19Radar/Destination.cs
+++ b/Covid19Radar/Covid19Radar/Destination.cs
@@ -13,7 +13,6 @@ namespace Covid19Radar
         HomePage,
         ContactedNotifyPage,
         NotifyOtherPage,
-        DebugPage,
     }
 
     public static class DestinationExtensions
@@ -22,7 +21,6 @@ namespace Covid19Radar
         private static string HomePagePath => "/" + nameof(MenuPage) + "/" + nameof(NavigationPage) + "/" + nameof(HomePage);
         private static string ContactedNotifyPagePath => HomePagePath + "/" + nameof(ContactedNotifyPage);
         private static string NotifyOtherPagePath => HomePagePath + "/" + nameof(NotifyOtherPage);
-        private static string DebugPagePath => "/" + nameof(MenuPage) + "/" + nameof(NavigationPage) + "/" + nameof(DebugPage);
 
         public static string ToPath(this Destination destination)
         {
@@ -32,7 +30,6 @@ namespace Covid19Radar
                 Destination.HomePage => HomePagePath,
                 Destination.ContactedNotifyPage => ContactedNotifyPagePath,
                 Destination.NotifyOtherPage => NotifyOtherPagePath,
-                Destination.DebugPage => DebugPagePath,
                 _ => throw new System.NotImplementedException()
             };
         }

--- a/Covid19Radar/Covid19Radar/ViewModels/Settings/DebugPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/Settings/DebugPageViewModel.cs
@@ -302,14 +302,14 @@ namespace Covid19Radar.ViewModels
                 TermsOfService = new TermsUpdateInfoModel.Detail { Text = "DEBUG  利用規約の変更", UpdateDateTimeJst = new DateTime(2022, 03, 14) },
                 PrivacyPolicy = new TermsUpdateInfoModel.Detail { Text = "DEBUG プライバシーポリシーの変更", UpdateDateTimeJst = new DateTime(2022, 03, 14) }
             };
-            var navigationParams = ReAgreeTermsOfServicePage.BuildNavigationParams(termsUpdateInfoModel, Destination.DebugPage);
+            var navigationParams = ReAgreeTermsOfServicePage.BuildNavigationParams(termsUpdateInfoModel, Destination.HomePage);
             _ = await NavigationService.NavigateAsync("/" + nameof(ReAgreeTermsOfServicePage), navigationParams);
         });
 
         public Command OnClickReAgreePrivacyPolicyPage => new Command(async () =>
         {
             var privacyPolicyUpdated = new TermsUpdateInfoModel.Detail { Text = "DEBUG プライバシーポリシーの変更", UpdateDateTimeJst = new DateTime(2022, 03, 14) };
-            var navigationParams = ReAgreePrivacyPolicyPage.BuildNavigationParams(privacyPolicyUpdated, Destination.DebugPage);
+            var navigationParams = ReAgreePrivacyPolicyPage.BuildNavigationParams(privacyPolicyUpdated, Destination.HomePage);
             _ = await NavigationService.NavigateAsync("/" + nameof(ReAgreePrivacyPolicyPage), navigationParams);
         });
 

--- a/Covid19Radar/Covid19Radar/ViewModels/Settings/DebugPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/Settings/DebugPageViewModel.cs
@@ -13,8 +13,10 @@ using System.Threading.Tasks;
 using Acr.UserDialogs;
 using Chino;
 using Covid19Radar.Common;
+using Covid19Radar.Model;
 using Covid19Radar.Repository;
 using Covid19Radar.Services;
+using Covid19Radar.Views;
 using Prism.Navigation;
 using Xamarin.Essentials;
 using Xamarin.Forms;
@@ -291,6 +293,24 @@ namespace Covid19Radar.ViewModels
         {
             _userDataRepository.RemoveAllUpdateDate();
             await UpdateInfo("RemoveAllUpdateDate");
+        });
+
+        public Command OnClickReAgreeTermsOfServicePage => new Command(async () =>
+        {
+            var termsUpdateInfoModel = new TermsUpdateInfoModel
+            {
+                TermsOfService = new TermsUpdateInfoModel.Detail { Text = "DEBUG  利用規約の変更", UpdateDateTimeJst = new DateTime(2022, 03, 14) },
+                PrivacyPolicy = new TermsUpdateInfoModel.Detail { Text = "DEBUG プライバシーポリシーの変更", UpdateDateTimeJst = new DateTime(2022, 03, 14) }
+            };
+            var navigationParams = ReAgreeTermsOfServicePage.BuildNavigationParams(termsUpdateInfoModel, Destination.DebugPage);
+            _ = await NavigationService.NavigateAsync("/" + nameof(ReAgreeTermsOfServicePage), navigationParams);
+        });
+
+        public Command OnClickReAgreePrivacyPolicyPage => new Command(async () =>
+        {
+            var privacyPolicyUpdated = new TermsUpdateInfoModel.Detail { Text = "DEBUG プライバシーポリシーの変更", UpdateDateTimeJst = new DateTime(2022, 03, 14) };
+            var navigationParams = ReAgreePrivacyPolicyPage.BuildNavigationParams(privacyPolicyUpdated, Destination.DebugPage);
+            _ = await NavigationService.NavigateAsync("/" + nameof(ReAgreePrivacyPolicyPage), navigationParams);
         });
 
         public Command OnClickQuit => new Command(() =>

--- a/Covid19Radar/Covid19Radar/Views/Settings/DebugPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Settings/DebugPage.xaml
@@ -217,11 +217,11 @@
                     Style="{StaticResource DefaultButton}"
                     Text="ExposuresPage" />
                 <Button
-                    Command="{prism:NavigateTo 'ReAgreePrivacyPolicyPage'}"
+                    Command="{Binding OnClickReAgreePrivacyPolicyPage}"
                     Style="{StaticResource DefaultButton}"
                     Text="ReAgreePrivacyPolicyPage" />
                 <Button
-                    Command="{prism:NavigateTo 'ReAgreeTermsOfServicePage'}"
+                    Command="{Binding OnClickReAgreeTermsOfServicePage}"
                     Style="{StaticResource DefaultButton}"
                     Text="ReAgreeTermsOfServicePage" />
                 <Button


### PR DESCRIPTION
## Issue 番号 / Issue ID

- Close #911

## 目的 / Purpose

- デバッグページからプライバシーポリシー・利用規約の更新画面を表示できない不具合を解消する

## 変更内容 / Changes

- ReAgree*Pageを表示する際に更新内容（TermsUpdateInfoModel）のオブジェクトをNavigationParametersに含めて渡す。

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 確認事項 / What to check

- [ ] 

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->

- 

---

Internal IDs:

<!--
  関係者のみ: 内部向けの ID があれば紐付けてください。
  For parties only: Please link to internal IDs, if any.
-->

- 
