### PR TITLE
Add debug-feature manage UserData.

### DIFF
--- a/Covid19Radar/Covid19Radar/App.xaml.cs
+++ b/Covid19Radar/Covid19Radar/App.xaml.cs
@@ -135,6 +135,7 @@ namespace Covid19Radar
 #if DEBUG
             containerRegistry.RegisterForNavigation<DebugPage>();
             containerRegistry.RegisterForNavigation<EditServerConfigurationPage>();
+            containerRegistry.RegisterForNavigation<ManageUserDataPage>();
 #endif
 
             // Settings

--- a/Covid19Radar/Covid19Radar/ViewModels/Settings/ManageUserDataPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/Settings/ManageUserDataPageViewModel.cs
@@ -1,0 +1,46 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+using System;
+using System.Windows.Input;
+using Covid19Radar.Repository;
+using Prism.Navigation;
+using Xamarin.Forms;
+
+namespace Covid19Radar.ViewModels
+{
+    public class ManageUserDataPageViewModel : ViewModelBase
+    {
+        private string _state;
+        public string State
+        {
+            get { return _state; }
+            set { SetProperty(ref _state, value); }
+        }
+
+        private readonly IUserDataRepository _userDataRepository;
+
+        public ManageUserDataPageViewModel(
+            INavigationService navigationService,
+            IUserDataRepository userDataRepository
+            ) : base(navigationService)
+        {
+            Title = "Manage UserData";
+            _userDataRepository = userDataRepository;
+        }
+
+        public ICommand OnClickResetDayOfUse => new Command(() => SetDayOfUsec(0));
+        public ICommand OnClickSetDayOfUse1 => new Command(() => SetDayOfUsec(1));
+        public ICommand OnClickSetDayOfUse14 => new Command(() => SetDayOfUsec(14));
+        public ICommand OnClickSetDayOfUse15 => new Command(() => SetDayOfUsec(15));
+
+        private void SetDayOfUsec(int dayOfUse)
+        {
+            DateTime startDateTime = DateTime.UtcNow - TimeSpan.FromDays(dayOfUse);
+
+            _userDataRepository.SetStartDate(startDateTime);
+
+            State = $"利用開始から{dayOfUse}日に設定しました";
+        }
+    }
+}

--- a/Covid19Radar/Covid19Radar/Views/Settings/DebugPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Settings/DebugPage.xaml
@@ -77,6 +77,10 @@
                         Style="{StaticResource DefaultButton}"
                         Text="ShowExposureNotification" />
                     <Button
+                        Command="{prism:NavigateTo 'ManageUserDataPage'}"
+                        Style="{StaticResource DefaultButton}"
+                        Text="Manage UserData" />
+                    <Button
                         Command="{Binding Path=OnClickExportExposureWindow}"
                         Style="{StaticResource DefaultButton}"
                         Text="ExportExposureWindow" />

--- a/Covid19Radar/Covid19Radar/Views/Settings/ManageUserDataPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/Settings/ManageUserDataPage.xaml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<ContentPage
+    x:Class="Covid19Radar.Views.ManageUserDataPage"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+    xmlns:prism="http://prismlibrary.com"
+    Title="{Binding Title}"
+    ios:Page.UseSafeArea="true"
+    prism:ViewModelLocator.AutowireViewModel="True"
+    Style="{StaticResource DefaultPageStyle}"
+    Visual="Material">
+    <!--
+        Workaround for fixing ScrollView truncates items issue.
+        https://github.com/xamarin/Xamarin.Forms/issues/13597
+    -->
+    <ContentView>
+    <ScrollView>
+        <StackLayout
+            Padding="0"
+            BackgroundColor="{StaticResource Background}"
+            Spacing="0"
+            Margin="10, 10, 0, 10">
+
+            <Label
+                Style="{StaticResource DefaultLabel}"
+                Text="DayOfUse"
+                Margin="0, 0, 0, 10"
+                />
+
+            <Button
+                Command="{Binding OnClickResetDayOfUse}"
+                HorizontalOptions="Center"
+                Style="{StaticResource DefaultButton}"
+                Text="Reset"
+                VerticalOptions="Start" />
+
+            <Button
+                Command="{Binding OnClickSetDayOfUse1}"
+                HorizontalOptions="Center"
+                Style="{StaticResource DefaultButton}"
+                Text="1 day"
+                VerticalOptions="Start" />
+
+            <Button
+                Command="{Binding OnClickSetDayOfUse14}"
+                HorizontalOptions="Center"
+                Style="{StaticResource DefaultButton}"
+                Text="14 days"
+                VerticalOptions="Start" />
+
+            <Button
+                Command="{Binding OnClickSetDayOfUse15}"
+                HorizontalOptions="Center"
+                Style="{StaticResource DefaultButton}"
+                Text="15 days"
+                VerticalOptions="Start" />
+
+            <Label
+                Style="{StaticResource DefaultLabel}"
+                Text="{Binding State}"
+                Margin="10, 20, 0, 10"
+                />
+
+        </StackLayout>
+    </ScrollView>
+    </ContentView>
+</ContentPage>

--- a/Covid19Radar/Covid19Radar/Views/Settings/ManageUserDataPage.xaml.cs
+++ b/Covid19Radar/Covid19Radar/Views/Settings/ManageUserDataPage.xaml.cs
@@ -1,0 +1,16 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using Xamarin.Forms;
+
+namespace Covid19Radar.Views
+{
+    public partial class ManageUserDataPage : ContentPage
+    {
+        public ManageUserDataPage()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Issue 番号 / Issue ID

- Close #975

## 目的 / Purpose

- 画面テストのため使用開始日（使用日数）をデバッグページから設定できるようにする

## 変更内容 / Changes

- デバッグ画面から遷移する `ManageUserDataPage` を追加
- ManageUserDataPageで、使用日数の設定を行えるようにする

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 確認事項 / What to check

![Screen Shot 2022-04-16 at 13 34 12](https://user-images.githubusercontent.com/932136/163661699-bc573a55-36de-4bdb-ae75-b3827894d20d.png)

![Screen Shot 2022-04-16 at 13 34 43](https://user-images.githubusercontent.com/932136/163661711-3f674cea-a432-433f-9817-4a678b39e76e.png)

## その他 / Other information

---

Internal IDs:

<!--
  関係者のみ: 内部向けの ID があれば紐付けてください。
  For parties only: Please link to internal IDs, if any.
-->

- 
