### PR TITLE
Suppress notification if the exposure date time is expired.

### DIFF
--- a/Covid19Radar/Covid19Radar/Common/AppConstants.cs
+++ b/Covid19Radar/Covid19Radar/Common/AppConstants.cs
@@ -45,7 +45,7 @@ namespace Covid19Radar.Common
         /// <summary>
         /// Number of days of exposure information to display
         /// </summary>
-        public const int DaysOfExposureInformationToDisplay = -15;
+        public const int TermOfExposureRecordValidityInDays = -15;
 
         /// <summary>
         /// Message when `AppDelagate.OnActivated()` occurs on iOS.

--- a/Covid19Radar/Covid19Radar/Services/ExposureDetectionService.cs
+++ b/Covid19Radar/Covid19Radar/Services/ExposureDetectionService.cs
@@ -110,7 +110,13 @@ namespace Covid19Radar.Services
                 .GetExposureRiskCalculationConfigurationAsync(preferCache: false);
             _loggerService.Info(exposureRiskCalculationConfiguration.ToString());
 
+            long expectOldestDateMillisSinceEpoch
+                = _dateTimeUtility.UtcNow
+                .AddDays(AppConstants.DaysOfExposureInformationToDisplay)
+                .ToUnixEpochMillis();
+
             bool isHighRiskExposureDetected = newDailySummaries
+                .Where(ds => ds.DateMillisSinceEpoch >= expectOldestDateMillisSinceEpoch)
                 .Select(ds => _exposureRiskCalculationService.CalcRiskLevel(
                         ds,
                         newExposureWindows.Where(ew => ew.DateMillisSinceEpoch == ds.DateMillisSinceEpoch).ToList(),

--- a/Covid19Radar/Covid19Radar/Services/ExposureDetectionService.cs
+++ b/Covid19Radar/Covid19Radar/Services/ExposureDetectionService.cs
@@ -112,7 +112,7 @@ namespace Covid19Radar.Services
 
             long expectOldestDateMillisSinceEpoch
                 = _dateTimeUtility.UtcNow
-                .AddDays(AppConstants.DaysOfExposureInformationToDisplay)
+                .AddDays(AppConstants.TermOfExposureRecordValidityInDays)
                 .ToUnixEpochMillis();
 
             bool isHighRiskExposureDetected = newDailySummaries

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/ContactedNotifyPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/ContactedNotifyPageViewModel.cs
@@ -65,7 +65,7 @@ namespace Covid19Radar.ViewModels
                     = await _exposureRiskCalculationConfigurationRepository.GetExposureRiskCalculationConfigurationAsync(preferCache: true);
                 loggerService.Info(exposureRiskCalculationConfiguration.ToString());
 
-                var userExposureInformationList = _exposureDataRepository.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay);
+                var userExposureInformationList = _exposureDataRepository.GetExposureInformationList(AppConstants.TermOfExposureRecordValidityInDays);
 
                 string contactedNotifyPageCountFormat = AppResources.ContactedNotifyPageCountOneText;
                 if (userExposureInformationList.Count() > 1)
@@ -73,9 +73,9 @@ namespace Covid19Radar.ViewModels
                     contactedNotifyPageCountFormat = AppResources.ContactedNotifyPageCountText;
                 }
 
-                var dailySummaryList = await _exposureDataRepository.GetDailySummariesAsync(AppConstants.DaysOfExposureInformationToDisplay);
+                var dailySummaryList = await _exposureDataRepository.GetDailySummariesAsync(AppConstants.TermOfExposureRecordValidityInDays);
                 var dailySummaryMap = dailySummaryList.ToDictionary(ds => ds.GetDateTime());
-                var exposureWindowList = await _exposureDataRepository.GetExposureWindowsAsync(AppConstants.DaysOfExposureInformationToDisplay);
+                var exposureWindowList = await _exposureDataRepository.GetExposureWindowsAsync(AppConstants.TermOfExposureRecordValidityInDays);
 
                 int dayCount = 0;
                 long exposureDurationInSec = 0;

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposureCheckPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposureCheckPageViewModel.cs
@@ -169,7 +169,7 @@ namespace Covid19Radar.ViewModels
             _loggerService.StartMethod();
 
             List<DailySummary> dailySummaryList = await _exposureDataRepository
-                .GetDailySummariesAsync(AppConstants.DaysOfExposureInformationToDisplay);
+                .GetDailySummariesAsync(AppConstants.TermOfExposureRecordValidityInDays);
 
             if (dailySummaryList.Count() == 0)
             {
@@ -182,7 +182,7 @@ namespace Covid19Radar.ViewModels
             _loggerService.Debug($"dailySummaryMap {dailySummaryMap.Count}");
 
             var exposureWindowList
-                = await _exposureDataRepository.GetExposureWindowsAsync(AppConstants.DaysOfExposureInformationToDisplay);
+                = await _exposureDataRepository.GetExposureWindowsAsync(AppConstants.TermOfExposureRecordValidityInDays);
 
             _loggerService.Debug($"exposureWindowList {exposureWindowList.Count}");
 

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposuresPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposuresPageViewModel.cs
@@ -58,14 +58,14 @@ namespace Covid19Radar.ViewModels
             _loggerService.Info(exposureRiskCalculationConfiguration.ToString());
 
             var dailySummaryList
-                = await _exposureDataRepository.GetDailySummariesAsync(AppConstants.DaysOfExposureInformationToDisplay);
+                = await _exposureDataRepository.GetDailySummariesAsync(AppConstants.TermOfExposureRecordValidityInDays);
             var dailySummaryMap = dailySummaryList.ToDictionary(ds => ds.GetDateTime());
 
             var exposureWindowList
-                = await _exposureDataRepository.GetExposureWindowsAsync(AppConstants.DaysOfExposureInformationToDisplay);
+                = await _exposureDataRepository.GetExposureWindowsAsync(AppConstants.TermOfExposureRecordValidityInDays);
 
             var userExposureInformationList
-                = _exposureDataRepository.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay);
+                = _exposureDataRepository.GetExposureInformationList(AppConstants.TermOfExposureRecordValidityInDays);
 
             if (dailySummaryList.Count() > 0)
             {

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
@@ -217,11 +217,11 @@ namespace Covid19Radar.ViewModels
                     .GetExposureRiskCalculationConfigurationAsync(preferCache: true);
                 loggerService.Info(exposureRiskCalculationConfiguration.ToString());
 
-                var dailySummaryList = await _exposureDataRepository.GetDailySummariesAsync(AppConstants.DaysOfExposureInformationToDisplay);
+                var dailySummaryList = await _exposureDataRepository.GetDailySummariesAsync(AppConstants.TermOfExposureRecordValidityInDays);
                 var dailySummaryMap = dailySummaryList.ToDictionary(ds => ds.GetDateTime());
-                var exposureWindowList = await _exposureDataRepository.GetExposureWindowsAsync(AppConstants.DaysOfExposureInformationToDisplay);
+                var exposureWindowList = await _exposureDataRepository.GetExposureWindowsAsync(AppConstants.TermOfExposureRecordValidityInDays);
 
-                var userExposureInformationList = _exposureDataRepository.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay);
+                var userExposureInformationList = _exposureDataRepository.GetExposureInformationList(AppConstants.TermOfExposureRecordValidityInDays);
 
                 var hasExposure = dailySummaryList.Count() > 0 || userExposureInformationList.Count() > 0;
                 var hasHighRiskExposure = userExposureInformationList.Count() > 0;

--- a/Covid19Radar/Covid19Radar/ViewModels/Settings/DebugPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/Settings/DebugPageViewModel.cs
@@ -99,8 +99,8 @@ namespace Covid19Radar.ViewModels
 
             var exposureNotificationStatus = await _exposureNotificationApiService.IsEnabledAsync();
 
-            var dailySummaryCount = (await _exposureDataRepository.GetDailySummariesAsync(AppConstants.DaysOfExposureInformationToDisplay)).Count();
-            var exposureWindowCount = (await _exposureDataRepository.GetExposureWindowsAsync(AppConstants.DaysOfExposureInformationToDisplay)).Count();
+            var dailySummaryCount = (await _exposureDataRepository.GetDailySummariesAsync(AppConstants.TermOfExposureRecordValidityInDays)).Count();
+            var exposureWindowCount = (await _exposureDataRepository.GetExposureWindowsAsync(AppConstants.TermOfExposureRecordValidityInDays)).Count();
 
             // ../../settings.json
             var settings = new[] {
@@ -113,7 +113,7 @@ namespace Covid19Radar.ViewModels
                 $"PrivacyPolicyUpdatedDateTimeUtc: {privacyPolicyUpdateDateTimeUtc}",
                 $"StartDate: {_userDataRepository.GetStartDate().ToLocalTime().ToString("F")}",
                 $"DaysOfUse: {_userDataRepository.GetDaysOfUse()}",
-                $"Legacy-V1 ExposureCount: {_exposureDataRepository.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay).Count()}",
+                $"Legacy-V1 ExposureCount: {_exposureDataRepository.GetExposureInformationList(AppConstants.TermOfExposureRecordValidityInDays).Count()}",
                 $"DailySummaryCount: {dailySummaryCount}",
                 $"ExposureWindowCount: {exposureWindowCount}",
                 $"LastProcessTekTimestamp: {lastProcessTekTimestampsStr}",

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Repository/ExposureDataRepositoryTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Repository/ExposureDataRepositoryTests.cs
@@ -429,7 +429,7 @@ namespace Covid19Radar.UnitTests.Repository
             mockSecureStorageService.Setup(x => x.GetStringValue("ExposureInformation", default)).Returns("[{\"Timestamp\":\"2021-01-01T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-02T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-03T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-04T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4}]");
             mockDateTimeUtility.Setup(x => x.UtcNow).Returns(new DateTime(2021, 1, day, 0, 0, 0));
 
-            var result = unitUnderTest.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay);
+            var result = unitUnderTest.GetExposureInformationList(AppConstants.TermOfExposureRecordValidityInDays);
 
             Assert.Equal(expectedCount, result.Count);
             for (int idx = 0; idx < expectedCount; idx++)
@@ -446,7 +446,7 @@ namespace Covid19Radar.UnitTests.Repository
             mockSecureStorageService.Setup(x => x.GetStringValue("ExposureInformation", default)).Returns((string)(object)null);
             mockDateTimeUtility.Setup(x => x.UtcNow).Returns(new DateTime(2021, 1, 1, 0, 0, 0));
 
-            var result = unitUnderTest.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay);
+            var result = unitUnderTest.GetExposureInformationList(AppConstants.TermOfExposureRecordValidityInDays);
 
             Assert.NotNull(result);
             Assert.Empty(result);
@@ -462,7 +462,7 @@ namespace Covid19Radar.UnitTests.Repository
             mockSecureStorageService.Setup(x => x.GetStringValue("ExposureInformation", default)).Returns("[{\"Timestamp\":\"2021-01-01T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-02T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-03T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-04T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4}]");
             mockDateTimeUtility.Setup(x => x.UtcNow).Returns(new DateTime(2021, 1, day, hour, minute, 0).AddHours(-9));
 
-            var result = unitUnderTest.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay);
+            var result = unitUnderTest.GetExposureInformationList(AppConstants.TermOfExposureRecordValidityInDays);
 
             Assert.Equal(expectedCount, result.Count);
             for (int idx = 0; idx < expectedCount; idx++)
@@ -485,7 +485,7 @@ namespace Covid19Radar.UnitTests.Repository
             mockSecureStorageService.Setup(x => x.GetStringValue("ExposureInformation", default)).Returns("[{\"Timestamp\":\"2021-01-01T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-02T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-03T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4},{\"Timestamp\":\"2021-01-04T00:00:00\",\"Duration\":\"00:05:00.000\",\"AttenuationValue\":3,\"TotalRiskScore\":21,\"TransmissionRiskLevel\":4}]");
             mockDateTimeUtility.Setup(x => x.UtcNow).Returns(new DateTime(2021, 1, day, 0, 0, 0));
 
-            var result = unitUnderTest.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay).Count();
+            var result = unitUnderTest.GetExposureInformationList(AppConstants.TermOfExposureRecordValidityInDays).Count();
 
             Assert.Equal(expectedCount, result);
         }
@@ -498,7 +498,7 @@ namespace Covid19Radar.UnitTests.Repository
             mockSecureStorageService.Setup(x => x.GetStringValue("ExposureInformation", default)).Returns((string)(object)null);
             mockDateTimeUtility.Setup(x => x.UtcNow).Returns(new DateTime(2021, 1, 1, 0, 0, 0));
 
-            var result = unitUnderTest.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay).Count();
+            var result = unitUnderTest.GetExposureInformationList(AppConstants.TermOfExposureRecordValidityInDays).Count();
 
             Assert.Equal(0, result);
         }

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/ExposureDetectionServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/ExposureDetectionServiceTests.cs
@@ -194,7 +194,7 @@ namespace Covid19Radar.UnitTests.Services {
             // Test Data
             var now = new DateTime(2022, 04, 17, 12, 00, 00, DateTimeKind.Utc);
             var exposureDateTime = now
-                .AddDays(AppConstants.DaysOfExposureInformationToDisplay);
+                .AddDays(AppConstants.TermOfExposureRecordValidityInDays);
             var exposureConfiguration = new ExposureConfiguration();
             var enVersion = 2;
 
@@ -266,7 +266,7 @@ namespace Covid19Radar.UnitTests.Services {
             // Test Data
             var now = new DateTime(2022, 04, 17, 12, 00, 00, DateTimeKind.Utc);
             var exposureDateTime = now
-                .AddDays(AppConstants.DaysOfExposureInformationToDisplay);
+                .AddDays(AppConstants.TermOfExposureRecordValidityInDays);
             var exposureConfiguration = new ExposureConfiguration();
             var enVersion = 2;
 
@@ -338,7 +338,7 @@ namespace Covid19Radar.UnitTests.Services {
             // Test Data
             var now = new DateTime(2022, 04, 17, 12, 00, 00, DateTimeKind.Utc);
             var exposureDateTime = now
-                .AddDays(AppConstants.DaysOfExposureInformationToDisplay)
+                .AddDays(AppConstants.TermOfExposureRecordValidityInDays)
                 .AddDays(-1);
             var exposureConfiguration = new ExposureConfiguration();
             var enVersion = 2;

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/ExposureDetectionServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/ExposureDetectionServiceTests.cs
@@ -194,7 +194,7 @@ namespace Covid19Radar.UnitTests.Services {
             // Test Data
             var now = new DateTime(2022, 04, 17, 12, 00, 00, DateTimeKind.Utc);
             var exposureDateTime = now
-                .AddDays(-AppConstants.DaysOfExposureInformationToDisplay);
+                .AddDays(AppConstants.DaysOfExposureInformationToDisplay);
             var exposureConfiguration = new ExposureConfiguration();
             var enVersion = 2;
 
@@ -266,7 +266,7 @@ namespace Covid19Radar.UnitTests.Services {
             // Test Data
             var now = new DateTime(2022, 04, 17, 12, 00, 00, DateTimeKind.Utc);
             var exposureDateTime = now
-                .AddDays(-AppConstants.DaysOfExposureInformationToDisplay);
+                .AddDays(AppConstants.DaysOfExposureInformationToDisplay);
             var exposureConfiguration = new ExposureConfiguration();
             var enVersion = 2;
 
@@ -338,7 +338,7 @@ namespace Covid19Radar.UnitTests.Services {
             // Test Data
             var now = new DateTime(2022, 04, 17, 12, 00, 00, DateTimeKind.Utc);
             var exposureDateTime = now
-                .AddDays(-AppConstants.DaysOfExposureInformationToDisplay)
+                .AddDays(AppConstants.DaysOfExposureInformationToDisplay)
                 .AddDays(-1);
             var exposureConfiguration = new ExposureConfiguration();
             var enVersion = 2;

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/ExposureDetectionServiceTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/Services/ExposureDetectionServiceTests.cs
@@ -192,13 +192,16 @@ namespace Covid19Radar.UnitTests.Services {
         public async void ExposureDetected_HighRiskExposureDetected()
         {
             // Test Data
+            var now = new DateTime(2022, 04, 17, 12, 00, 00, DateTimeKind.Utc);
+            var exposureDateTime = now
+                .AddDays(-AppConstants.DaysOfExposureInformationToDisplay);
             var exposureConfiguration = new ExposureConfiguration();
             var enVersion = 2;
 
             var dailySummaries = new List<DailySummary>() {
                 new DailySummary()
                 {
-                    DateMillisSinceEpoch = 0,
+                    DateMillisSinceEpoch = exposureDateTime.ToUnixEpochMillis(),
                     DaySummary = new ExposureSummaryData(),
                     ConfirmedClinicalDiagnosisSummary = new ExposureSummaryData(),
                     ConfirmedTestSummary = new ExposureSummaryData(),
@@ -212,7 +215,7 @@ namespace Covid19Radar.UnitTests.Services {
                 new ExposureWindow()
                 {
                     CalibrationConfidence = CalibrationConfidence.High,
-                    DateMillisSinceEpoch = 0,
+                    DateMillisSinceEpoch = exposureDateTime.ToUnixEpochMillis(),
                     Infectiousness = Infectiousness.High,
                     ReportType = ReportType.Unknown,
                     ScanInstances = new List<ScanInstance>()
@@ -220,6 +223,8 @@ namespace Covid19Radar.UnitTests.Services {
             };
 
             // Mock Setup
+            dateTimeUtility.Setup(x => x.UtcNow)
+                .Returns(now);
             preferencesService
                 .Setup(x => x.GetBoolValue(It.Is<string>(x => x == "IsDiagnosisKeysDataMappingConfigurationUpdated"), false))
                 .Returns(true);
@@ -259,13 +264,16 @@ namespace Covid19Radar.UnitTests.Services {
         public async void ExposureDetected_HighRiskExposureNotDetected()
         {
             // Test Data
+            var now = new DateTime(2022, 04, 17, 12, 00, 00, DateTimeKind.Utc);
+            var exposureDateTime = now
+                .AddDays(-AppConstants.DaysOfExposureInformationToDisplay);
             var exposureConfiguration = new ExposureConfiguration();
             var enVersion = 2;
 
             var dailySummaries = new List<DailySummary>() {
                 new DailySummary()
                 {
-                    DateMillisSinceEpoch = 0,
+                    DateMillisSinceEpoch = exposureDateTime.ToUnixEpochMillis(),
                     DaySummary = new ExposureSummaryData(),
                     ConfirmedClinicalDiagnosisSummary = new ExposureSummaryData(),
                     ConfirmedTestSummary = new ExposureSummaryData(),
@@ -279,7 +287,7 @@ namespace Covid19Radar.UnitTests.Services {
                 new ExposureWindow()
                 {
                     CalibrationConfidence = CalibrationConfidence.High,
-                    DateMillisSinceEpoch = 0,
+                    DateMillisSinceEpoch = exposureDateTime.ToUnixEpochMillis(),
                     Infectiousness = Infectiousness.High,
                     ReportType = ReportType.Unknown,
                     ScanInstances = new List<ScanInstance>()
@@ -287,6 +295,81 @@ namespace Covid19Radar.UnitTests.Services {
             };
 
             // Mock Setup
+            dateTimeUtility.Setup(x => x.UtcNow)
+                .Returns(now);
+            preferencesService.
+                Setup(x => x.GetBoolValue(It.Is<string>(x => x == "IsDiagnosisKeysDataMappingConfigurationUpdated"), false))
+                .Returns(true);
+            secureStorageService
+                .Setup(x => x.GetStringValue(It.Is<string>(x => x == "DailySummaries"), It.IsAny<string>()))
+                .Returns("[]");
+            secureStorageService
+                .Setup(x => x.GetStringValue(It.Is<string>(x => x == "ExposureWindows"), It.IsAny<string>()))
+                .Returns("[]");
+            exposureDataCollectServer
+                .Setup(x => x.UploadExposureDataAsync(
+                    It.IsAny<ExposureConfiguration>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<List<DailySummary>>(),
+                    It.IsAny<List<ExposureWindow>>()));
+            deviceInfoUtility.Setup(x => x.Model).Returns("UnitTest");
+
+            exposureRiskCalculationConfigurationRepository
+                .Setup(x => x.GetExposureRiskCalculationConfigurationAsync(It.IsAny<bool>()))
+                .ReturnsAsync(new V1ExposureRiskCalculationConfiguration());
+
+            exposureRiskCalculationService
+                .Setup(x => x.CalcRiskLevel(It.IsAny<DailySummary>(), It.IsAny<List<ExposureWindow>>(), It.IsAny<V1ExposureRiskCalculationConfiguration>()))
+                .Returns(RiskLevel.Low);
+
+            // Test Case
+            var unitUnderTest = CreateService();
+            await unitUnderTest.ExposureDetectedAsync(exposureConfiguration, enVersion, dailySummaries, exposureWindows);
+
+
+            // Assert
+            localNotificationService.Verify(x => x.ShowExposureNotificationAsync(), Times.Never);
+        }
+
+        [Fact]
+        public async void ExposureDetected_HighRiskExposureNotDetected_ExpiredDate()
+        {
+            // Test Data
+            var now = new DateTime(2022, 04, 17, 12, 00, 00, DateTimeKind.Utc);
+            var exposureDateTime = now
+                .AddDays(-AppConstants.DaysOfExposureInformationToDisplay)
+                .AddDays(-1);
+            var exposureConfiguration = new ExposureConfiguration();
+            var enVersion = 2;
+
+            var dailySummaries = new List<DailySummary>() {
+                new DailySummary()
+                {
+                    DateMillisSinceEpoch = exposureDateTime.ToUnixEpochMillis(),
+                    DaySummary = new ExposureSummaryData(),
+                    ConfirmedClinicalDiagnosisSummary = new ExposureSummaryData(),
+                    ConfirmedTestSummary = new ExposureSummaryData(),
+                    RecursiveSummary = new ExposureSummaryData(),
+                    SelfReportedSummary = new ExposureSummaryData()
+                }
+            };
+
+            var exposureWindows = new List<ExposureWindow>()
+            {
+                new ExposureWindow()
+                {
+                    CalibrationConfidence = CalibrationConfidence.High,
+                    DateMillisSinceEpoch = exposureDateTime.ToUnixEpochMillis(),
+                    Infectiousness = Infectiousness.High,
+                    ReportType = ReportType.Unknown,
+                    ScanInstances = new List<ScanInstance>()
+                }
+            };
+
+            // Mock Setup
+            dateTimeUtility.Setup(x => x.UtcNow)
+                .Returns(now);
             preferencesService.
                 Setup(x => x.GetBoolValue(It.Is<string>(x => x == "IsDiagnosisKeysDataMappingConfigurationUpdated"), false))
                 .Returns(true);

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ContactedNotifyPageViewModelTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ContactedNotifyPageViewModelTests.cs
@@ -73,14 +73,14 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
         public void OnClickExposuresTest_Initialize()
         {
             mockExposureDataRepository
-                .Setup(x => x.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay))
+                .Setup(x => x.GetExposureInformationList(AppConstants.TermOfExposureRecordValidityInDays))
                 .Returns(new List<UserExposureInfo>()
                 {
                     new UserExposureInfo(),
                     new UserExposureInfo()
                 });
             mockExposureDataRepository
-                .Setup(x => x.GetDailySummariesAsync(AppConstants.DaysOfExposureInformationToDisplay))
+                .Setup(x => x.GetDailySummariesAsync(AppConstants.TermOfExposureRecordValidityInDays))
                 .Returns(Task.FromResult(new List<DailySummary>()
                 {
                     new DailySummary()
@@ -89,7 +89,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
                     }
                 }));
             mockExposureDataRepository
-                .Setup(x => x.GetExposureWindowsAsync(AppConstants.DaysOfExposureInformationToDisplay))
+                .Setup(x => x.GetExposureWindowsAsync(AppConstants.TermOfExposureRecordValidityInDays))
                 .Returns(Task.FromResult(new List<ExposureWindow>()
                 {
                     new ExposureWindow()
@@ -121,10 +121,10 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
         public void OnClickExposuresTest_Initialize_NoExposureInformation_HighRisk()
         {
             mockExposureDataRepository
-                .Setup(x => x.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay))
+                .Setup(x => x.GetExposureInformationList(AppConstants.TermOfExposureRecordValidityInDays))
                 .Returns(new List<UserExposureInfo>());
             mockExposureDataRepository
-                .Setup(x => x.GetDailySummariesAsync(AppConstants.DaysOfExposureInformationToDisplay))
+                .Setup(x => x.GetDailySummariesAsync(AppConstants.TermOfExposureRecordValidityInDays))
                 .Returns(Task.FromResult(new List<DailySummary>()
                 {
                     new DailySummary()
@@ -133,7 +133,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
                     }
                 }));
             mockExposureDataRepository
-                .Setup(x => x.GetExposureWindowsAsync(AppConstants.DaysOfExposureInformationToDisplay))
+                .Setup(x => x.GetExposureWindowsAsync(AppConstants.TermOfExposureRecordValidityInDays))
                 .Returns(Task.FromResult(new List<ExposureWindow>()
                 {
                     new ExposureWindow()
@@ -165,14 +165,14 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
         public void OnClickExposuresTest_Initialize_NoExposureInformation_NoHighRisk()
         {
             mockExposureDataRepository
-                .Setup(x => x.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay))
+                .Setup(x => x.GetExposureInformationList(AppConstants.TermOfExposureRecordValidityInDays))
                 .Returns(new List<UserExposureInfo>()
                 {
                     new UserExposureInfo(),
                     new UserExposureInfo()
                 });
             mockExposureDataRepository
-                .Setup(x => x.GetDailySummariesAsync(AppConstants.DaysOfExposureInformationToDisplay))
+                .Setup(x => x.GetDailySummariesAsync(AppConstants.TermOfExposureRecordValidityInDays))
                 .Returns(Task.FromResult(new List<DailySummary>()
                 {
                     new DailySummary()
@@ -181,7 +181,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
                     }
                 }));
             mockExposureDataRepository
-                .Setup(x => x.GetExposureWindowsAsync(AppConstants.DaysOfExposureInformationToDisplay))
+                .Setup(x => x.GetExposureWindowsAsync(AppConstants.TermOfExposureRecordValidityInDays))
                 .Returns(Task.FromResult(new List<ExposureWindow>()
                 {
                     new ExposureWindow()

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ExposureCheckPageViewModelTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ExposureCheckPageViewModelTests.cs
@@ -135,11 +135,11 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
                 .Returns((new DateTime()).AddDays(14));
 
             mockExposureDataRepository
-                .Setup(x => x.GetDailySummariesAsync(AppConstants.DaysOfExposureInformationToDisplay))
+                .Setup(x => x.GetDailySummariesAsync(AppConstants.TermOfExposureRecordValidityInDays))
                 .ReturnsAsync(dummyDailySummaries);
 
             mockExposureDataRepository
-                .Setup(x => x.GetExposureWindowsAsync(AppConstants.DaysOfExposureInformationToDisplay))
+                .Setup(x => x.GetExposureWindowsAsync(AppConstants.TermOfExposureRecordValidityInDays))
                 .ReturnsAsync(dummyExposureWindows);
 
             var riskConfiguration = new V1ExposureRiskCalculationConfiguration()
@@ -195,7 +195,7 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
         public async void NoRiskPage_Initialize_Display()
         {
             mockExposureDataRepository
-                .Setup(x => x.GetDailySummariesAsync(AppConstants.DaysOfExposureInformationToDisplay))
+                .Setup(x => x.GetDailySummariesAsync(AppConstants.TermOfExposureRecordValidityInDays))
                 .Returns(Task.FromResult(new List<DailySummary>()));
 
             var exposureCheckPageViewModel = CreateViewModel();

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ExposuresPageViewModelTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/ExposuresPageViewModelTests.cs
@@ -65,9 +65,9 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
             mockExposureRiskCalculationConfigurationRepository
                 .Setup(x => x.GetExposureRiskCalculationConfigurationAsync(It.IsAny<bool>()))
                 .ReturnsAsync(new V1ExposureRiskCalculationConfiguration());
-            mockExposureDataRepository.Setup(x => x.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay)).Returns(dummyList);
-            mockExposureDataRepository.Setup(x => x.GetDailySummariesAsync(AppConstants.DaysOfExposureInformationToDisplay)).Returns(Task.FromResult(dummyDailySummaryList));
-            mockExposureDataRepository.Setup(x => x.GetExposureWindowsAsync(AppConstants.DaysOfExposureInformationToDisplay)).Returns(Task.FromResult(dummyExposureWindowList));
+            mockExposureDataRepository.Setup(x => x.GetExposureInformationList(AppConstants.TermOfExposureRecordValidityInDays)).Returns(dummyList);
+            mockExposureDataRepository.Setup(x => x.GetDailySummariesAsync(AppConstants.TermOfExposureRecordValidityInDays)).Returns(Task.FromResult(dummyDailySummaryList));
+            mockExposureDataRepository.Setup(x => x.GetExposureWindowsAsync(AppConstants.TermOfExposureRecordValidityInDays)).Returns(Task.FromResult(dummyExposureWindowList));
 
             var vm = CreateViewModel();
             await vm.InitExposures();
@@ -92,9 +92,9 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
             mockExposureRiskCalculationConfigurationRepository
                 .Setup(x => x.GetExposureRiskCalculationConfigurationAsync(It.IsAny<bool>()))
                 .ReturnsAsync(new V1ExposureRiskCalculationConfiguration());
-            mockExposureDataRepository.Setup(x => x.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay)).Returns(testList);
-            mockExposureDataRepository.Setup(x => x.GetDailySummariesAsync(AppConstants.DaysOfExposureInformationToDisplay)).Returns(Task.FromResult(dummyDailySummaryList));
-            mockExposureDataRepository.Setup(x => x.GetExposureWindowsAsync(AppConstants.DaysOfExposureInformationToDisplay)).Returns(Task.FromResult(dummyExposureWindowList));
+            mockExposureDataRepository.Setup(x => x.GetExposureInformationList(AppConstants.TermOfExposureRecordValidityInDays)).Returns(testList);
+            mockExposureDataRepository.Setup(x => x.GetDailySummariesAsync(AppConstants.TermOfExposureRecordValidityInDays)).Returns(Task.FromResult(dummyDailySummaryList));
+            mockExposureDataRepository.Setup(x => x.GetExposureWindowsAsync(AppConstants.TermOfExposureRecordValidityInDays)).Returns(Task.FromResult(dummyExposureWindowList));
 
             var vm = CreateViewModel();
             await vm.InitExposures();
@@ -116,9 +116,9 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
             mockExposureRiskCalculationConfigurationRepository
                 .Setup(x => x.GetExposureRiskCalculationConfigurationAsync(It.IsAny<bool>()))
                 .ReturnsAsync(new V1ExposureRiskCalculationConfiguration());
-            mockExposureDataRepository.Setup(x => x.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay)).Returns(testList);
-            mockExposureDataRepository.Setup(x => x.GetDailySummariesAsync(AppConstants.DaysOfExposureInformationToDisplay)).Returns(Task.FromResult(dummyDailySummaryList));
-            mockExposureDataRepository.Setup(x => x.GetExposureWindowsAsync(AppConstants.DaysOfExposureInformationToDisplay)).Returns(Task.FromResult(dummyExposureWindowList));
+            mockExposureDataRepository.Setup(x => x.GetExposureInformationList(AppConstants.TermOfExposureRecordValidityInDays)).Returns(testList);
+            mockExposureDataRepository.Setup(x => x.GetDailySummariesAsync(AppConstants.TermOfExposureRecordValidityInDays)).Returns(Task.FromResult(dummyDailySummaryList));
+            mockExposureDataRepository.Setup(x => x.GetExposureWindowsAsync(AppConstants.TermOfExposureRecordValidityInDays)).Returns(Task.FromResult(dummyExposureWindowList));
 
             var vm = CreateViewModel();
             await vm.InitExposures();
@@ -144,9 +144,9 @@ namespace Covid19Radar.UnitTests.ViewModels.HomePage
             mockExposureRiskCalculationConfigurationRepository
                 .Setup(x => x.GetExposureRiskCalculationConfigurationAsync(It.IsAny<bool>()))
                 .ReturnsAsync(new V1ExposureRiskCalculationConfiguration());
-            mockExposureDataRepository.Setup(x => x.GetExposureInformationList(AppConstants.DaysOfExposureInformationToDisplay)).Returns(testList);
-            mockExposureDataRepository.Setup(x => x.GetDailySummariesAsync(AppConstants.DaysOfExposureInformationToDisplay)).Returns(Task.FromResult(dummyDailySummaryList));
-            mockExposureDataRepository.Setup(x => x.GetExposureWindowsAsync(AppConstants.DaysOfExposureInformationToDisplay)).Returns(Task.FromResult(dummyExposureWindowList));
+            mockExposureDataRepository.Setup(x => x.GetExposureInformationList(AppConstants.TermOfExposureRecordValidityInDays)).Returns(testList);
+            mockExposureDataRepository.Setup(x => x.GetDailySummariesAsync(AppConstants.TermOfExposureRecordValidityInDays)).Returns(Task.FromResult(dummyDailySummaryList));
+            mockExposureDataRepository.Setup(x => x.GetExposureWindowsAsync(AppConstants.TermOfExposureRecordValidityInDays)).Returns(Task.FromResult(dummyExposureWindowList));
 
             var vm = CreateViewModel();
             await vm.InitExposures();


### PR DESCRIPTION
## Issue 番号 / Issue ID

- #974

## 目的 / Purpose

- 接触が14日より前であれば通知を出さないようにする

## 変更内容 / Changes

- `AppConstants.DaysOfExposureInformationToDisplay`の値でフィルターを追加

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 確認事項 / What to check

- [ ] 実際に接触を発生させて14日待つテストはつらいので、境界値テストはユニットテストでカバー。実機テストは通常の接触が問題なく通知されるかのテストに限定してはどうでしょう

## その他 / Other information

- 

---

Internal IDs:

<!--
  関係者のみ: 内部向けの ID があれば紐付けてください。
  For parties only: Please link to internal IDs, if any.
-->

- 
