### PR TITLE
Handling ApiException from Google Play Services.

### DIFF
--- a/Covid19Radar/Covid19Radar.Android/Services/ExposureNotificationApiService.cs
+++ b/Covid19Radar/Covid19Radar.Android/Services/ExposureNotificationApiService.cs
@@ -49,7 +49,10 @@ namespace Covid19Radar.Droid.Services
                 }
                 else
                 {
-                    throw apiException;
+                    throw new AndroidGooglePlayServicesApiException(
+                        apiException.StatusCode,
+                        apiException.Message
+                        );
                 }
             }
         }
@@ -58,7 +61,18 @@ namespace Covid19Radar.Droid.Services
 
         public override async Task<IList<ExposureNotificationStatus>> GetStatusesAsync()
         {
-            return await Client.GetStatusesAsync();
+            try
+            {
+                return await Client.GetStatusesAsync();
+            }
+            catch(ApiException apiException)
+            {
+                throw new AndroidGooglePlayServicesApiException(
+                    apiException.StatusCode,
+                    apiException.Message
+                    );
+            }
+
         }
 
         public override async Task<List<TemporaryExposureKey>> GetTemporaryExposureKeyHistoryAsync()
@@ -77,7 +91,10 @@ namespace Covid19Radar.Droid.Services
                 }
                 else
                 {
-                    throw apiException;
+                    throw new AndroidGooglePlayServicesApiException(
+                        apiException.StatusCode,
+                        apiException.Message
+                        );
                 }
             }
         }
@@ -121,7 +138,10 @@ namespace Covid19Radar.Droid.Services
                 }
                 else
                 {
-                    throw apiException;
+                    throw new AndroidGooglePlayServicesApiException(
+                        apiException.StatusCode,
+                        apiException.Message
+                        );
                 }
             }
         }
@@ -142,7 +162,10 @@ namespace Covid19Radar.Droid.Services
                 }
                 else
                 {
-                    throw apiException;
+                    throw new AndroidGooglePlayServicesApiException(
+                        apiException.StatusCode,
+                        apiException.Message
+                        );
                 }
             }
         }

--- a/Covid19Radar/Covid19Radar/Services/AbsExposureNotificationApiService.cs
+++ b/Covid19Radar/Covid19Radar/Services/AbsExposureNotificationApiService.cs
@@ -11,6 +11,19 @@ using Covid19Radar.Services.Logs;
 
 namespace Covid19Radar.Services
 {
+    public class AndroidGooglePlayServicesApiException : Exception
+    {
+        public readonly int StatusCode;
+
+        public AndroidGooglePlayServicesApiException(
+            int statusCode,
+            string message
+            ) : base(message)
+        {
+            StatusCode = statusCode;
+        }
+    }
+
     public abstract class AbsExposureNotificationApiService : AbsExposureNotificationClient
     {
         private readonly ILoggerService _loggerService;

--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
@@ -202,6 +202,11 @@ namespace Covid19Radar.ViewModels
                 loggerService.Exception("Failed to exposure notification start.", exception);
                 await UpdateView();
             }
+            catch (AndroidGooglePlayServicesApiException exception)
+            {
+                loggerService.Exception("Failed to exposure notification start.", exception);
+                await UpdateView();
+            }
             finally
             {
                 loggerService.EndMethod();
@@ -402,19 +407,27 @@ namespace Covid19Radar.ViewModels
             loggerService.StartMethod();
 
             var daysOfUse = _userDataRepository.GetDaysOfUse();
-
             PastDate = daysOfUse.ToString();
 
-            var statusCodes = await exposureNotificationApiService.GetStatusCodesAsync();
+            bool isStopped;
+            try
+            {
+                var statusCodes = await exposureNotificationApiService.GetStatusCodesAsync();
 
-            var isStopped =
-                statusCodes.Contains(ExposureNotificationStatus.Code_Android.INACTIVATED)
-                || statusCodes.Contains(ExposureNotificationStatus.Code_Android.FOCUS_LOST)
-                || statusCodes.Contains(ExposureNotificationStatus.Code_iOS.Disabled)
-                || statusCodes.Contains(ExposureNotificationStatus.Code_iOS.Unauthorized)
-                || statusCodes.Contains(ExposureNotificationStatus.Code_Android.BLUETOOTH_DISABLED)
-                || statusCodes.Contains(ExposureNotificationStatus.Code_iOS.BluetoothOff)
-                || statusCodes.Contains(ExposureNotificationStatus.Code_Android.LOCATION_DISABLED);
+                isStopped = statusCodes.Contains(ExposureNotificationStatus.Code_Android.INACTIVATED)
+                    || statusCodes.Contains(ExposureNotificationStatus.Code_Android.FOCUS_LOST)
+                    || statusCodes.Contains(ExposureNotificationStatus.Code_iOS.Disabled)
+                    || statusCodes.Contains(ExposureNotificationStatus.Code_iOS.Unauthorized)
+                    || statusCodes.Contains(ExposureNotificationStatus.Code_Android.BLUETOOTH_DISABLED)
+                    || statusCodes.Contains(ExposureNotificationStatus.Code_iOS.BluetoothOff)
+                    || statusCodes.Contains(ExposureNotificationStatus.Code_Android.LOCATION_DISABLED);
+            }
+            catch (AndroidGooglePlayServicesApiException exception)
+            {
+                loggerService.Exception("Failed to exposure notification GetStatusCodesAsync.", exception);
+                isStopped = true;
+            }
+
             var canConfirmExposure = _userDataRepository.IsCanConfirmExposure();
 
             if (isStopped)


### PR DESCRIPTION
## Issue 番号 / Issue ID

- Close #987 
- Close #816

## 目的 / Purpose

- ApiExceptionをハンドルする

## 変更内容 / Changes

- ApiExceptionのうち、ResolutionRequired以外を`AndroidGooglePlayServicesApiException`として共通プロジェクト側にthrowするようにした
- 本来であればAndroid固有のExceptionを作りたくないが、Google Play Servicesの例外であることは間違いなく、ENExceptionに入れるのは不適当と判断した

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[x] Yes
[ ] No
```

## Pull Request の種類 / Pull Request type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 確認事項 / What to check

- [ ] 

## その他 / Other information

- 当初、CappuccinoのレイヤーでApiExcepitonをENExcepitonに変換する仕組みを考えたが、Google Play Servicesで発生する例外＝ENで起きる例外ではないので、COCOAでカバーすることにした。

---

Internal IDs:

<!--
  関係者のみ: 内部向けの ID があれば紐付けてください。
  For parties only: Please link to internal IDs, if any.
-->

- 
