### PR TITLE
Change to enable error judgment of iOS device check that was temporar…

### DIFF
--- a/src/Covid19Radar.Api/Services/DeviceValidationAppleService.cs
+++ b/src/Covid19Radar.Api/Services/DeviceValidationAppleService.cs
@@ -100,12 +100,8 @@ namespace Covid19Radar.Api.Services
                 //    default:
                 //        break;
                 //}
-                if (response.StatusCode != System.Net.HttpStatusCode.OK)
-                {
-                    return false;
-                }
 
-                return true;
+                return (response.StatusCode == System.Net.HttpStatusCode.OK);
             }
             catch (Exception ex)
             {

--- a/src/Covid19Radar.Api/Services/DeviceValidationAppleService.cs
+++ b/src/Covid19Radar.Api/Services/DeviceValidationAppleService.cs
@@ -102,8 +102,7 @@ namespace Covid19Radar.Api.Services
                 //}
                 if (response.StatusCode != System.Net.HttpStatusCode.OK)
                 {
-                    // FIXME: When call iOS Device check, return error sometimes, Until the cause is known, ignored device check
-                    return true;
+                    return false;
                 }
 
                 return true;


### PR DESCRIPTION
…ily disabled

## Issue 番号 / Issue ID

<!--
  Issue 番号なき PR は受け付けません。
  PRs without the issue IDs are never accepted.
-->

- Close #

## 目的 / Purpose
iOSのデバイスチェックのエラーを有効にする
<!--
  その変更を提案する意図をご説明ください。どの問題が解決したり、機能的な追加がなされたりしますか。
  Describe the intention of the changes being proposed. What problem does it solve or functionality does it add?
-->

- 

## 変更内容 / Changes
調査のため一時的に無効にしていたiOSデバイスチェック時のエラーを有効にする
<!--
  この PR の変更内容をご説明ください。
  Describe the changes to this Pull Request.
-->

- 

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

<!--
  当てはまるもの 1 つに「x」とマークしてください。
  Mark one with an "x".
-->

```
[ ] Yes
[×] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[×] Bugfix
[] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 確認事項 / What to check

- [ ] 

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->

- 

---

Internal IDs:BUG3382

<!--
  関係者のみ: 内部向けの ID があれば紐付けてください。
  For parties only: Please link to internal IDs, if any.
-->

- 
