### PR TITLE
Set ListView animation to false and fixed InitExposures() not being called twice at screen transition

### DIFF
--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposuresPageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/ExposuresPageViewModel.cs
@@ -62,13 +62,6 @@ namespace Covid19Radar.ViewModels
                 );
         }
 
-        public override async void Initialize(INavigationParameters parameters)
-        {
-            base.Initialize(parameters);
-
-            await InitExposures();
-        }
-
         public async Task InitExposures()
         {
             var exposures = new ObservableCollection<ExposureSummary>();

--- a/Covid19Radar/Covid19Radar/Views/HomePage/ExposuresPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/ExposuresPage.xaml
@@ -20,6 +20,7 @@
         ItemsSource="{Binding Exposures}"
         HasUnevenRows="True"
         SeparatorVisibility="None"
+        ios:ListView.RowAnimationsEnabled="False"
         >
         <ListView.Header>
             <StackLayout


### PR DESCRIPTION
## Issue 番号 / Issue ID

<!--
  Issue 番号なき PR は受け付けません。
  PRs without the issue IDs are never accepted.
-->

- Close #

## 目的 / Purpose

<!--
  その変更を提案する意図をご説明ください。どの問題が解決したり、機能的な追加がなされたりしますか。
  Describe the intention of the changes being proposed. What problem does it solve or functionality does it add?
-->

- 接触一覧画面の動作を修正

## 変更内容 / Changes

<!--
  この PR の変更内容をご説明ください。
  Describe the changes to this Pull Request.
-->

- iOSで接触データを表示する ListView のアニメーションをオフに設定
- 接触一覧画面に遷移時、InitExposures() が2回呼ばれるのを修正

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

<!--
  当てはまるもの 1 つに「x」とマークしてください。
  Mark one with an "x".
-->

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 確認事項 / What to check

- [ ] 

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->

- 

---

Internal IDs:

<!--
  関係者のみ: 内部向けの ID があれば紐付けてください。
  For parties only: Please link to internal IDs, if any.
-->

- PBI 2265
