### PR TITLE
Remove lead text from app license description.

### DIFF
--- a/COPYRIGHT_THIRD_PARTY_SOFTWARE_NOTICES.md
+++ b/COPYRIGHT_THIRD_PARTY_SOFTWARE_NOTICES.md
@@ -1,8 +1,6 @@
 # LICENSE Copyright / THIRD PARTY SOFTWARE NOTICES
 Do Not Translate or Localize.
 This file incorporates components from the projects listed below.
-COVID-19Radar community licenses these components to you under COVID-19Radar community's software licensing terms, except that components licensed under open source licenses requiring that such components remain under their original license are being made available to you by COVID-19Radar community under their original licensing terms.
-The original copyright notices and the licenses under which COVID-19Radar community received such components are set forth below for informational purposes.
 
 ---
 ## COVID-19Radar


### PR DESCRIPTION
## Issue 番号 / Issue ID

- Close #940

## 目的 / Purpose

- COPYRIGHT_THIRD_PARTY_SOFTWARE_NOTICES.md の冒頭テキストでCOVID-19Radarが主体として解説がされているが、このリポジトリはCOCOAの場所なので、COVID-19RadarがCOCOAを開発していると誤解される恐れがある。
- もとよりこのファイルはCOCOAの内部からも参照されることになるので、冒頭テキストを削除して、純粋にライセンス一覧の役割に限定する。

## 変更内容 / Changes

- 冒頭テキストを削除して、ライセンスを一覧する役割に限定する。

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## 確認事項 / What to check

- [ ] 

## その他 / Other information

- 元々の記述はMicrosoftのおそらくプロプライエタリなプロダクトで利用されていた文章の様子。オープンソースのCOCOAにはあまり馴染まなさそうとは思う。
    - https://dynamics.microsoft.com/en-us/legaldocs/ctpn-dynamics365-engagement-public/

---

Internal IDs:

<!--
  関係者のみ: 内部向けの ID があれば紐付けてください。
  For parties only: Please link to internal IDs, if any.
-->

- 
