### PR TITLE
Fix the issue that restoring NuGet packages failed on mac-latest image.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,8 @@ jobs:
         xcode-version: 13 # set the latest available Xcode 13
     - name: Prepare settings.json
       run: mv -f ${{ github.workspace }}/Covid19Radar/Covid19Radar/settings_template.json ${{ github.workspace }}/Covid19Radar/Covid19Radar/settings.json
+    - name: Setup NuGet.Config
+      run: echo '<configuration><packageSources><add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" /></packageSources></configuration>' > ~/.config/NuGet/NuGet.Config
     - name: Deploy nuget packages - ${{ matrix.Configuration }}
       run: cp -Force ${{ github.workspace }}/TempNugetFeed/${{ matrix.Configuration }}/*.nupkg ${{ github.workspace }}/TempNugetFeed/ | true
     - name: Build iOS Project - ${{ matrix.Configuration }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,8 +53,6 @@ jobs:
       uses: actions/checkout@v2
     - name: Prepare settings.json
       run: mv -Force ${{ github.workspace }}/Covid19Radar/Covid19Radar/settings_template.json ${{ github.workspace }}/Covid19Radar/Covid19Radar/settings.json
-    - name: Show NuGet.Config
-      run: echo ~/.config/NuGet/NuGet.Config
     - name: Deploy nuget packages - ${{ matrix.Configuration }}
       run: cp -Force ${{ github.workspace }}/TempNugetFeed/${{ matrix.Configuration }}/*.nupkg ${{ github.workspace }}/TempNugetFeed/| true
     - name: Add msbuild to PATH

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,6 +55,8 @@ jobs:
       uses: actions/checkout@v2
     - name: Prepare settings.json
       run: mv -Force ${{ github.workspace }}/Covid19Radar/Covid19Radar/settings_template.json ${{ github.workspace }}/Covid19Radar/Covid19Radar/settings.json
+    - name: Show NuGet.Config
+      run: echo ~/.config/NuGet/NuGet.Config
     - name: Deploy nuget packages - ${{ matrix.Configuration }}
       run: cp -Force ${{ github.workspace }}/TempNugetFeed/${{ matrix.Configuration }}/*.nupkg ${{ github.workspace }}/TempNugetFeed/| true
     - name: Add msbuild to PATH

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,8 +38,6 @@ jobs:
         xcode-version: 13 # set the latest available Xcode 13
     - name: Prepare settings.json
       run: mv -f ${{ github.workspace }}/Covid19Radar/Covid19Radar/settings_template.json ${{ github.workspace }}/Covid19Radar/Covid19Radar/settings.json
-    - name: Setup NuGet.Config
-      run: echo '<configuration><packageSources><add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" /></packageSources></configuration>' > ~/.config/NuGet/NuGet.Config
     - name: Deploy nuget packages - ${{ matrix.Configuration }}
       run: cp -Force ${{ github.workspace }}/TempNugetFeed/${{ matrix.Configuration }}/*.nupkg ${{ github.workspace }}/TempNugetFeed/ | true
     - name: Build iOS Project - ${{ matrix.Configuration }}

--- a/.github/workflows/CIserver.yml
+++ b/.github/workflows/CIserver.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1
     - name: msbuild
-      run: msbuild ${{ github.workspace }}/Covid19Radar.Functions.sln /restore /t:Build /p:Configuration=${{ matrix.Configuration }}
+      run: msbuild ${{ github.workspace }}/Covid19Radar.Functions.sln /restore /t:Build /p:RestoreConfigFile=${{ github.workspace }}/Nuget.config /p:Configuration=${{ matrix.Configuration }}
     - name: Execute Unit Tests
       run: dotnet test ${{ github.workspace }}/Covid19Radar.Functions.sln /p:CollectCoverage=true /p:CoverletOutputFormat=opencover --no-build --logger trx --settings ${{ github.workspace }}/Covid19Radar.Functions.runsettings --configuration ${{ matrix.Configuration }} --collect:"XPlat Code Coverage"    
       env:

--- a/Nuget.config
+++ b/Nuget.config
@@ -2,6 +2,7 @@
 <configuration>
     <packageSources>
         <add key="MyNuget" value="./TempNugetFeed" />
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     </packageSources>
     <activePackageSource>
         <add key="All" value="(Aggregate source)" />


### PR DESCRIPTION
## Issue 番号 / Issue ID

- #1046

## 目的 / Purpose

- GitHub ActionsでiOSビルドが失敗する問題のワークアラウンド

## 変更内容 / Changes

- NuGet.Configをセットアップするステップを一時的に追加する

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: workaround
```

## 確認事項 / What to check

- [ ] 

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->

- 

---

Internal IDs:

<!--
  関係者のみ: 内部向けの ID があれば紐付けてください。
  For parties only: Please link to internal IDs, if any.
-->

- 
