### PR TITLE
Improve "How to get ProcessingNumber".

### DIFF
--- a/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
+++ b/Covid19Radar/Covid19Radar/Resources/AppResources.ja.resx
@@ -225,8 +225,8 @@
     <comment>検査により新型コロナウイルスの感染が確認された場合。</comment>
   </data>
   <data name="HelpPage3Description2" xml:space="preserve">
-    <value>保健所等公的機関から登録用の「処理番号」が発行されます。</value>
-    <comment>保健所等公的機関から登録用の「処理番号」が発行されます。</comment>
+    <value>医療機関や保健所に登録されているメールアドレスや携帯電話番号に処理番号が通知されます。</value>
+    <comment>医療機関や保健所に登録されているメールアドレスや携帯電話番号に処理番号が通知されます。</comment>
   </data>
   <data name="HelpPage3Description3" xml:space="preserve">
     <value>本アプリを用いて処理番号の登録を行います。</value>

--- a/Covid19Radar/Covid19Radar/Views/HelpPage/HelpPage3.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HelpPage/HelpPage3.xaml
@@ -40,11 +40,25 @@
             <StackLayout
                 Orientation="Horizontal"
                 Spacing="10">
-                <Label
-                    AutomationProperties.IsInAccessibleTree="True"
-                    Style="{StaticResource DefaultLabel}"
-                    Text="{x:Static resources:AppResources.HelpPage3Description2}"
-                    VerticalTextAlignment="Center" />
+                <StackLayout
+                    Orientation="Vertical"
+                    Spacing="10">
+                    <Label
+                        AutomationProperties.IsInAccessibleTree="True"
+                        Style="{StaticResource DefaultLabel}"
+                        Text="{x:Static resources:AppResources.HelpPage3Description2}"
+                        VerticalTextAlignment="Center" />
+                    <Label
+                        AutomationProperties.IsInAccessibleTree="True"
+                        Margin="0, 0, 0, 0"
+                        HorizontalOptions="Start"
+                        Style="{StaticResource LinkLabelStyleMedium}"
+                        Text="{x:Static resources:AppResources.NotifyOtherPageLabel}">
+                        <Label.GestureRecognizers>
+                        <TapGestureRecognizer Command="{prism:NavigateTo 'HowToReceiveProcessingNumberPage'}" />
+                        </Label.GestureRecognizers>
+                    </Label>
+                </StackLayout>
                 <ffimageloading:CachedImage
                     AutomationProperties.IsInAccessibleTree="False"
                     WidthRequest="100"

--- a/Covid19Radar/Covid19Radar/Views/HomePage/SubmitConsentPage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/SubmitConsentPage.xaml
@@ -65,10 +65,26 @@
                     Aspect="AspectFit"
                     VerticalOptions="Start"
                     Source="img_number_1.png" />
-                <Label
-                    AutomationProperties.IsInAccessibleTree="True"
-                    Style="{StaticResource DefaultLabel}"
-                    Text="{x:Static resources:AppResources.SubmitConsentPageDescription3}" />
+
+                <StackLayout
+                    Orientation="Vertical"
+                    Spacing="10">
+                    <Label
+                        AutomationProperties.IsInAccessibleTree="True"
+                        Style="{StaticResource DefaultLabel}"
+                        Text="{x:Static resources:AppResources.SubmitConsentPageDescription3}" />
+
+                    <Label
+                        AutomationProperties.IsInAccessibleTree="True"
+                        Margin="0, 0, 0, 0"
+                        HorizontalOptions="Start"
+                        Style="{StaticResource LinkLabelStyleMedium}"
+                        Text="{x:Static resources:AppResources.NotifyOtherPageLabel}">
+                        <Label.GestureRecognizers>
+                        <TapGestureRecognizer Command="{prism:NavigateTo 'HowToReceiveProcessingNumberPage'}" />
+                        </Label.GestureRecognizers>
+                    </Label>
+                </StackLayout>
             </StackLayout>
             <StackLayout
                 Orientation="Horizontal"


### PR DESCRIPTION
## Issue 番号 / Issue ID

- #1084

## 目的 / Purpose

- 処理番号の取得方法へのアクセスをわかりやすくする

## 変更内容 / Changes

- 「新型コロナウイルスに感染していると判定されたら」のテキストを調整＋「処理番号の取得方法」への経路を新設
- 「陽性登録への同意」に「処理番号の取得方法」への経路を新設

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 確認事項 / What to check
![Screen Shot 2022-07-24 at 11 22 44](https://user-images.githubusercontent.com/932136/180629570-f89a39d2-70ae-4803-ad8a-76446c37ddbb.png)
![Screen Shot 2022-07-24 at 11 15 24](https://user-images.githubusercontent.com/932136/180629572-d239e919-7ab5-4202-8d91-8cd4567631eb.png)


## その他 / Other information

- リンクのテキスト「処理番号の取得方法」ではなく「処理番号について」の方がいいかも

---

Internal IDs:

<!--
  関係者のみ: 内部向けの ID があれば紐付けてください。
  For parties only: Please link to internal IDs, if any.
-->

- 
