### PR TITLE
Fix to focus on the date label after closing the dialog

### DIFF
--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
@@ -16,6 +16,7 @@ using Covid19Radar.Views;
 using Prism.Navigation;
 using Xamarin.Forms;
 using Xamarin.Essentials;
+using Xamarin.CommunityToolkit.Extensions;
 
 namespace Covid19Radar.ViewModels
 {
@@ -329,7 +330,7 @@ namespace Covid19Radar.ViewModels
             loggerService.EndMethod();
         });
 
-        public Command OnClickQuestionIcon => new Command(() =>
+        public Command OnClickQuestionIcon => new Command<Label>((dateLabel) =>
         {
             loggerService.StartMethod();
 
@@ -337,6 +338,14 @@ namespace Covid19Radar.ViewModels
                 AppResources.LatestConfirmationDateExplanationDialogText,
                 null,
                 AppResources.ButtonClose);
+
+            if (Device.RuntimePlatform == Device.iOS && dateLabel != null)
+            {
+                Device.BeginInvokeOnMainThread(() =>
+                {
+                    SemanticExtensions.SetSemanticFocus(dateLabel);
+                });
+            }
 
             loggerService.EndMethod();
         });

--- a/Covid19Radar/Covid19Radar/Views/HomePage/HomePage.xaml
+++ b/Covid19Radar/Covid19Radar/Views/HomePage/HomePage.xaml
@@ -76,7 +76,8 @@
                                 Source="question_icon.png"
                                 Padding="5"
                                 BackgroundColor="Transparent"
-                                Command="{Binding Path=OnClickQuestionIcon}">
+                                Command="{Binding Path=OnClickQuestionIcon}"
+                                CommandParameter="{x:Reference activeConfirmationDateLabel}">
                                 <ImageButton.IsVisible>
                                     <OnPlatform
                                     x:TypeArguments="x:Boolean"
@@ -90,7 +91,8 @@
                                 AutomationProperties.Name="{x:Static resources:AppResources.HomePageQuestionIconAccessibilityTextiOS}"
                                 Aspect="AspectFit"
                                 Source="question_icon.png"
-                                Command="{Binding Path=OnClickQuestionIcon}">
+                                Command="{Binding Path=OnClickQuestionIcon}"
+                                CommandParameter="{x:Reference activeConfirmationDateLabel}">
                                 <ImageButton.IsVisible>
                                     <OnPlatform
                                         x:TypeArguments="x:Boolean"


### PR DESCRIPTION
## Issue 番号 / Issue ID

<!--
  Issue 番号なき PR は受け付けません。
  PRs without the issue IDs are never accepted.
-->

- Close #

## 目的 / Purpose

<!--
  その変更を提案する意図をご説明ください。どの問題が解決したり、機能的な追加がなされたりしますか。
  Describe the intention of the changes being proposed. What problem does it solve or functionality does it add?
-->

- ホーム画面の？ボタン押下後に表示されるダイアログを閉じた時に、読み上げのフォーカスがずれてしまうため？ボタンの次の段落の日付にフォーカスが当たるように修正

## 変更内容 / Changes

<!--
  この PR の変更内容をご説明ください。
  Describe the changes to this Pull Request.
-->

- ダイアログを閉じた時に、フォーカスが日付に当たるように修正
- Androidはダイアログを閉じた後も？ボタンにフォーカスがあるため、iOSのみ対象

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

<!--
  当てはまるもの 1 つに「x」とマークしてください。
  Mark one with an "x".
-->

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 確認事項 / What to check

- [ ] 

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->

- 

---

Internal IDs:

<!--
  関係者のみ: 内部向けの ID があれば紐付けてください。
  For parties only: Please link to internal IDs, if any.
-->

- PBI　7499
