### PR TITLE
Fixed the conditions for displaying notification off warning text

### DIFF
--- a/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
+++ b/Covid19Radar/Covid19Radar/ViewModels/HomePage/HomePageViewModel.cs
@@ -458,6 +458,7 @@ namespace Covid19Radar.ViewModels
                 IsVisibleENStatusActiveLayout = false;
                 IsVisibleENStatusUnconfirmedLayout = false;
                 IsVisibleENStatusStoppedLayout = true;
+                IsVisibleLocalNotificationOffWarningLayout = false;
             }
             else if (!canConfirmExposure)
             {
@@ -465,6 +466,7 @@ namespace Covid19Radar.ViewModels
                 IsVisibleENStatusActiveLayout = false;
                 IsVisibleENStatusUnconfirmedLayout = true;
                 IsVisibleENStatusStoppedLayout = false;
+                IsVisibleLocalNotificationOffWarningLayout = false;
 
                 var isMaxPerDayExposureDetectionAPILimitReached = _userDataRepository.IsMaxPerDayExposureDetectionAPILimitReached();
                 EnStatusUnconfirmedDescription1 = isMaxPerDayExposureDetectionAPILimitReached
@@ -478,6 +480,7 @@ namespace Covid19Radar.ViewModels
                 IsVisibleENStatusActiveLayout = true;
                 IsVisibleENStatusUnconfirmedLayout = false;
                 IsVisibleENStatusStoppedLayout = false;
+                IsVisibleLocalNotificationOffWarningLayout = await localNotificationService.IsWarnedLocalNotificationOffAsync();
 
                 var latestUtcDate = _userDataRepository.GetLastConfirmedDate();
                 if (latestUtcDate == null)
@@ -497,8 +500,6 @@ namespace Covid19Radar.ViewModels
                     }
                 }
             }
-
-            IsVisibleLocalNotificationOffWarningLayout = await localNotificationService.IsWarnedLocalNotificationOffAsync();
 
             loggerService.EndMethod();
         }

--- a/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/HomePageViewModelTests.cs
+++ b/Covid19Radar/Tests/Covid19Radar.UnitTests/ViewModels/HomePage/HomePageViewModelTests.cs
@@ -228,6 +228,7 @@ namespace Covid19Radar.UnitTests.ViewModels
             Assert.False(homePageViewModel.IsVisibleENStatusActiveLayout);
             Assert.True(homePageViewModel.IsVisibleENStatusUnconfirmedLayout);
             Assert.False(homePageViewModel.IsVisibleENStatusStoppedLayout);
+            Assert.False(homePageViewModel.IsVisibleLocalNotificationOffWarningLayout);
             Assert.Equal(AppResources.HomePageENStatusUnconfirmedDescription1, homePageViewModel.EnStatusUnconfirmedDescription1);
             Assert.Equal(AppResources.HomePageENStatusUnconfirmedDescription2, homePageViewModel.EnStatusUnconfirmedDescription2);
             Assert.True(homePageViewModel.IsVisibleUnconfirmedTroubleshootingButton);
@@ -254,6 +255,7 @@ namespace Covid19Radar.UnitTests.ViewModels
             Assert.False(homePageViewModel.IsVisibleENStatusActiveLayout);
             Assert.True(homePageViewModel.IsVisibleENStatusUnconfirmedLayout);
             Assert.False(homePageViewModel.IsVisibleENStatusStoppedLayout);
+            Assert.False(homePageViewModel.IsVisibleLocalNotificationOffWarningLayout);
             Assert.Equal(AppResources.HomePageExposureDetectionAPILimitReachedDescription1, homePageViewModel.EnStatusUnconfirmedDescription1);
             Assert.Equal(AppResources.HomePageExposureDetectionAPILimitReachedDescription2, homePageViewModel.EnStatusUnconfirmedDescription2);
             Assert.False(homePageViewModel.IsVisibleUnconfirmedTroubleshootingButton);
@@ -277,6 +279,7 @@ namespace Covid19Radar.UnitTests.ViewModels
             Assert.False(homePageViewModel.IsVisibleENStatusActiveLayout);
             Assert.False(homePageViewModel.IsVisibleENStatusUnconfirmedLayout);
             Assert.True(homePageViewModel.IsVisibleENStatusStoppedLayout);
+            Assert.False(homePageViewModel.IsVisibleLocalNotificationOffWarningLayout);
         }
 
         [Fact]
@@ -328,13 +331,16 @@ namespace Covid19Radar.UnitTests.ViewModels
         }
 
         [Fact]
-        public void UpdateView_LocalNotificationOffWarning_Hidden()
+        public void UpdateView_ENStatus_Active_LocalNotificationOffWarning_Hidden()
         {
             var homePageViewModel = CreateViewModel();
 
             mockExposureNotificationApiService
                 .Setup(x => x.GetStatusCodesAsync())
                 .Returns(Task.FromResult(new List<int>() { ExposureNotificationStatus.Code_Android.ACTIVATED } as IList<int>));
+            mockPreferenceService
+                .Setup(x => x.GetBoolValue("CanConfirmExposure", true))
+                .Returns(true);
             mockLocalNotificationService
                 .Setup(x => x.IsWarnedLocalNotificationOffAsync())
                 .ReturnsAsync(false);
@@ -345,13 +351,16 @@ namespace Covid19Radar.UnitTests.ViewModels
         }
 
         [Fact]
-        public void UpdateView_LocalNotificationOffWarning_Shown()
+        public void UpdateView_ENStatus_Active_LocalNotificationOffWarning_Shown()
         {
             var homePageViewModel = CreateViewModel();
 
             mockExposureNotificationApiService
                 .Setup(x => x.GetStatusCodesAsync())
                 .Returns(Task.FromResult(new List<int>() { ExposureNotificationStatus.Code_Android.ACTIVATED } as IList<int>));
+            mockPreferenceService
+                .Setup(x => x.GetBoolValue("CanConfirmExposure", true))
+                .Returns(true);
             mockLocalNotificationService
                 .Setup(x => x.IsWarnedLocalNotificationOffAsync())
                 .ReturnsAsync(true);


### PR DESCRIPTION
## Issue 番号 / Issue ID

<!--
  Issue 番号なき PR は受け付けません。
  PRs without the issue IDs are never accepted.
-->

- Close #

## 目的 / Purpose

<!--
  その変更を提案する意図をご説明ください。どの問題が解決したり、機能的な追加がなされたりしますか。
  Describe the intention of the changes being proposed. What problem does it solve or functionality does it add?
-->

- 端末の通知OFF時に表示される[通知設定を確認してください]ボタンが、動作状況表示[停止中][接触有無が確認できません][接触有無が確認できません(接触回数超過Ver)]のときにも表示されているため、利用者が通知設定から解消できるのかと考えてしまいそうなので、[動作中]時のみ表示されるように修正

## 変更内容 / Changes

<!--
  この PR の変更内容をご説明ください。
  Describe the changes to this Pull Request.
-->

- 端末の通知OFF時に発生する[通知設定を確認してください]ボタンが、[動作中]時のみ表示されるように修正

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

<!--
  当てはまるもの 1 つに「x」とマークしてください。
  Mark one with an "x".
-->

```
[ ] Yes
[x] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 確認事項 / What to check

- [ ] 

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->

- 

---

Internal IDs:

<!--
  関係者のみ: 内部向けの ID があれば紐付けてください。
  For parties only: Please link to internal IDs, if any.
-->

- BUG 7336
