### PR TITLE
FYI: Fix issue that crash after upgrade to v2.1.0.

### DIFF
--- a/Covid19Radar/Covid19Radar.iOS/Covid19Radar.iOS.csproj
+++ b/Covid19Radar/Covid19Radar.iOS/Covid19Radar.iOS.csproj
@@ -271,6 +271,7 @@
     <Compile Include="Services\LocalPathService.cs" />
     <Compile Include="Services\EventLogSubmissionBackgroundService.cs" />
     <Compile Include="Services\DataMaintainanceBackgroundService.cs" />
+    <Compile Include="Services\Migration\BGTaskMigrator.cs" />
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Assets.xcassets\Contents.json">

--- a/Covid19Radar/Covid19Radar.iOS/Services/Migration/BGTaskMigrator.cs
+++ b/Covid19Radar/Covid19Radar.iOS/Services/Migration/BGTaskMigrator.cs
@@ -1,0 +1,43 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+using System.Threading.Tasks;
+using BackgroundTasks;
+using Covid19Radar.Services.Logs;
+using Xamarin.Essentials;
+
+namespace Covid19Radar.iOS.Services.Migration
+{
+    internal class BGTaskMigrator
+    {
+        // Array of old identifier.
+        private static readonly string[] OLD_IDENTIFIER_ARRAY = {
+            AppInfo.PackageName + ".delete-old-logs",
+        };
+
+        private readonly ILoggerService _loggerService;
+
+        public BGTaskMigrator(
+            ILoggerService loggerService
+            )
+        {
+            _loggerService = loggerService;
+        }
+
+
+        internal Task ExecuteAsync()
+        {
+            _loggerService.StartMethod();
+
+            foreach(var identifier in OLD_IDENTIFIER_ARRAY)
+            {
+                BGTaskScheduler.Shared.Cancel(identifier);
+                _loggerService.Info($"BGTask {identifier} has been canceled.");
+            }
+
+            _loggerService.EndMethod();
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Covid19Radar/Covid19Radar.iOS/Services/Migration/MigrationProcessService.cs
+++ b/Covid19Radar/Covid19Radar.iOS/Services/Migration/MigrationProcessService.cs
@@ -2,12 +2,32 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+using System.Threading.Tasks;
+using Covid19Radar.Services.Logs;
 using Covid19Radar.Services.Migration;
 
 namespace Covid19Radar.iOS.Services.Migration
 {
     public class MigrationProcessService : IMigrationProcessService
     {
-        // Currently, It is not needed that iOS platform specific migration process.
+        private readonly ILoggerService _loggerService;
+
+        public MigrationProcessService(
+            ILoggerService loggerService
+        )
+        {
+            _loggerService = loggerService;
+        }
+
+        public async Task SetupAsync()
+        {
+            _loggerService.StartMethod();
+
+            await new BGTaskMigrator(
+                _loggerService
+                ).ExecuteAsync();
+
+            _loggerService.EndMethod();
+        }
     }
 }


### PR DESCRIPTION
## Issue 番号 / Issue ID

- Close #1115

## 目的 / Purpose

- v2.1.0へのアップデートでアプリが強制終了する不具合を修正した

## 変更内容 / Changes

- iOSのマイグレーションに、使わなくなったBGTaskをキャンセルする行程を追加する

## 破壊的変更をもたらしますか / Does this introduce a breaking change?

```
[x] Yes
[ ] No
```

## Pull Request の種類 / Pull Request type

<!--
  この PR は、どのような類の変更をもたらしますか。当てはまるもの 1 つに「x」でチェックしてください。
  What kind of change does this Pull Request introduce? Please check the one that applies to this PR using "x".
-->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## 確認事項 / What to check

- [x] v2.0.1のインストールと初期セットアップを終えてから、Pull Requestを含むv2.1.0を起動して正常に起動するかを確認する。

`jp.go.mhlw.covid19radar.delete-old-logs` がキャンセルされ、正常に起動することを確認した。

```
"2022/08/20 10:51:32","Info","BGTask jp.go.mhlw.covid19radar.delete-old-logs has been canceled.","ExecuteAsync","/Users/keiji_ariyama/Projects/cocoa/Covid19Radar/Covid19Radar.iOS/Services/Migration/
```

## その他 / Other information

<!--
  そのほかに、必要かもしれない有用な情報がありましたらご記入ください。
  Add any other helpful information that may be needed here.
-->

- 

---

Internal IDs:

- Bug 8686
